### PR TITLE
Update README.md to use Releases instead of master

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,8 @@ These libraries contain helper functions, generalized standards, and other tools
 
 ## Using a library
 
-To import the Merkle Proof library the following should be added to the project's `Forc.toml` file under `[dependencies]`:
+To import the Merkle Proof library the following should be added to the project's `Forc.toml` file under `[dependencies]` with the most recent release:
 
-<!-- TODO: This should not point to the master branch but instead to a release -->
 ```rust
 sway_libs = { git = "https://github.com/FuelLabs/sway-libs", version = "0.1.0" }
 ```

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ To import the Merkle Proof library the following should be added to the project'
 
 <!-- TODO: This should not point to the master branch but instead to a release -->
 ```rust
-sway_libs = { git = "https://github.com/FuelLabs/sway-libs", branch = "master" }
+sway_libs = { git = "https://github.com/FuelLabs/sway-libs", version = "0.1.0" }
 ```
 
 You may then import your desired library in your Sway Smart Contract as so:


### PR DESCRIPTION
## Type of change

<!--Delete points that do not apply-->

- Documentation

## Changes

The following changes have been made:

- Update README.md

## Related Issues

<!--Delete everything after the "#" symbol and replace it with a number. No spaces between hash and number-->

Closes #22 
