### PR TITLE
Bump Merkle Proof to use depth of 8

### DIFF
--- a/sway_libs/src/merkle_proof/binary_merkle_proof.sw
+++ b/sway_libs/src/merkle_proof/binary_merkle_proof.sw
@@ -98,10 +98,10 @@ pub fn process_proof(
     key: u64,
     merkle_leaf: b256,
     num_leaves: u64,
-    proof: [b256; 2],
+    proof: [b256; 8],
 ) -> b256 {
     // let proof_length = proof.len();
-    let proof_length = 2;
+    let proof_length = 8;
     require((num_leaves > 1 && proof_length == path_length_from_key(key, num_leaves)) || (num_leaves <= 1 && proof_length == 0), ProofError::InvalidProofLength);
     require(key < num_leaves, ProofError::InvalidKey);
 
@@ -185,7 +185,7 @@ pub fn verify_proof(
     merkle_leaf: b256,
     merkle_root: b256,
     num_leaves: u64,
-    proof: [b256; 2],
+    proof: [b256; 8],
 ) -> bool {
     process_proof(key, merkle_leaf, num_leaves, proof) == merkle_root
 }

--- a/tests/src/test_projects/merkle_proof/src/main.sw
+++ b/tests/src/test_projects/merkle_proof/src/main.sw
@@ -9,14 +9,14 @@ abi MerkleProofTest {
         key: u64,
         merkle_leaf: b256,
         num_leaves: u64,
-        proof: [b256; 2],
+        proof: [b256; 8],
     ) -> b256;
     fn verify_proof(
         key: u64,
         merkle_leaf: b256,
         merkle_root: b256,
         num_leaves: u64,
-        proof: [b256; 2],
+        proof: [b256; 8],
     ) -> bool;
 }
 
@@ -33,7 +33,7 @@ impl MerkleProofTest for Contract {
         key: u64,
         merkle_leaf: b256,
         num_leaves: u64,
-        proof: [b256; 2],
+        proof: [b256; 8],
     ) -> b256 {
         process_proof(key, merkle_leaf, num_leaves, proof)
     }
@@ -43,7 +43,7 @@ impl MerkleProofTest for Contract {
         merkle_leaf: b256,
         merkle_root: b256,
         num_leaves: u64,
-        proof: [b256; 2],
+        proof: [b256; 8],
     ) -> bool {
         verify_proof(key, merkle_leaf, merkle_root, num_leaves, proof)
     }

--- a/tests/src/test_projects/merkle_proof/tests/functions/process_proof.rs
+++ b/tests/src/test_projects/merkle_proof/tests/functions/process_proof.rs
@@ -2,7 +2,7 @@
 // TODO: Using the fuel-merkle repository will currently fail all tests due to https://github.com/FuelLabs/sway/issues/2594
 use crate::merkle_proof::tests::utils::{
     abi_calls::process_proof,
-    test_helpers::{build_tree, merkle_proof_instance},
+    test_helpers::{build_tree, leaves_with_depth, merkle_proof_instance},
 };
 use fuel_merkle::common::{Bytes32, LEAF};
 use sha2::{Digest, Sha256};
@@ -63,15 +63,26 @@ mod success {
         let instance = merkle_proof_instance().await;
 
         // Data as bytes
-        let leaves = ["A".as_bytes(), "B".as_bytes(), "C".as_bytes()];
+        let leaves = leaves_with_depth(8).await;
+        assert_eq!(leaves.len(), 511);
         let key = 0;
         let num_leaves = 3;
 
-        //            ABC
-        //           /   \
-        //          AB    C
-        //         /  \
-        //        A    B
+        // 8                ABC
+        //                /   \
+        // 7              AB    C
+        //              /   \
+        // 6            A    B
+        //                                           /
+        // 5                         ABCDEFGHIJKLMNOP
+        //                        /                     \
+        // 4              ABCDEFGH                       IJKLMNOP
+        //              /         \                    /          \
+        // 3       ABCD            EFGH            IJKL            MNOP
+        //        /    \          /    \         /      \        /      \
+        // 2    AB      CD      EF      GH      IJ      KL      MN      OP
+        //     /  \    /  \    /  \    /  \    /  \    /  \    /  \    /  \    /  \    /  \    /  \    /  \    /  \    /  \    /  \    /  \
+        // 1  A    B  C    D  E    F  G    H  I    J  K    L  M    N  O    P  A    B  C    D  E    F  G    H  I    J  K    L  M    N  O    P
 
         // Leaf A hash
         let mut merkle_leaf_a = Sha256::new();

--- a/tests/src/test_projects/merkle_proof/tests/functions/process_proof.rs
+++ b/tests/src/test_projects/merkle_proof/tests/functions/process_proof.rs
@@ -64,7 +64,8 @@ mod success {
         let depth = 8;
         let leaves = leaves_with_depth(depth).await;
         let key = 0;
-        let (leaf_hash, proof, root_hash) = build_tree_manual(leaves.clone(), depth.try_into().unwrap(), key).await;
+        let (leaf_hash, proof, root_hash) =
+            build_tree_manual(leaves.clone(), depth.try_into().unwrap(), key).await;
 
         // This passes due to use of u64 for node concatenation
         assert_eq!(

--- a/tests/src/test_projects/merkle_proof/tests/utils/mod.rs
+++ b/tests/src/test_projects/merkle_proof/tests/utils/mod.rs
@@ -68,7 +68,6 @@ pub mod test_helpers {
     use super::*;
 
     #[derive(Clone)]
-    #[derive(PartialEq)]
     struct Node {
         hash: Bytes32,
         left: Option<usize>,

--- a/tests/src/test_projects/merkle_proof/tests/utils/mod.rs
+++ b/tests/src/test_projects/merkle_proof/tests/utils/mod.rs
@@ -1,6 +1,6 @@
 use fuel_merkle::{
     binary::in_memory::MerkleTree,
-    common::{Bytes32, ProofSet},
+    common::{Bytes32, LEAF, ProofSet},
 };
 use fuels::prelude::*;
 
@@ -82,6 +82,19 @@ pub mod test_helpers {
         proof.1.remove(0);
 
         (tree, merkle_root, merkle_leaf, proof.1)
+    }
+
+    pub async fn leaves_with_depth(depth: u32) -> Vec<[u8; 1]> {
+        // Max elements in tree: (2 ^ (k + 1)) - 1
+        let num_elements_in_tree = (2_i32.pow(depth + 1)) - 1;
+        let mut return_vec: Vec<[u8; 1]> = Vec::new();
+
+        for n in 0..num_elements_in_tree {
+            let n_u8: u8 = (n % i32::from(u8::MAX)).try_into().unwrap();
+            return_vec.push([n_u8]);
+        }
+
+        return_vec
     }
 
     pub async fn merkle_proof_instance() -> TestMerkleProofLib {

--- a/tests/src/test_projects/merkle_proof/tests/utils/mod.rs
+++ b/tests/src/test_projects/merkle_proof/tests/utils/mod.rs
@@ -1,6 +1,6 @@
 use fuel_merkle::{
     binary::in_memory::MerkleTree,
-    common::{Bytes32, LEAF, empty_sum_sha256, ProofSet},
+    common::{empty_sum_sha256, Bytes32, ProofSet, LEAF},
 };
 use fuels::prelude::*;
 use sha2::{Digest, Sha256};
@@ -113,9 +113,9 @@ pub mod test_helpers {
     }
 
     pub async fn build_tree_manual(
-        leaves: Vec<[u8; 1]>, 
+        leaves: Vec<[u8; 1]>,
         height: usize,
-        key: usize
+        key: usize,
     ) -> (Bytes32, ProofSet, Bytes32) {
         let num_leaves = leaves.len();
         let mut nodes: Vec<Node> = Vec::new();
@@ -151,10 +151,8 @@ pub mod test_helpers {
                 hasher.update(&nodes[itterator].hash);
                 hasher.update(&nodes[itterator + 1].hash);
                 let hash: Bytes32 = hasher.finalize().try_into().unwrap();
-                
-                let new_node = Node::new(hash)
-                    .left(itterator)
-                    .right(itterator + 1);
+
+                let new_node = Node::new(hash).left(itterator).right(itterator + 1);
                 nodes.push(new_node);
                 itterator += 2;
             }
@@ -166,12 +164,12 @@ pub mod test_helpers {
         for i in 0..height {
             let node = nodes[index].clone();
 
-            if node.left == None && node.right == None {             
+            if node.left == None && node.right == None {
                 break;
             }
 
-            let number_subtree_elements = ((2usize.pow(((height - i) + 1).try_into().unwrap()))) / 2;
-        
+            let number_subtree_elements = (2usize.pow(((height - i) + 1).try_into().unwrap())) / 2;
+
             if key <= number_subtree_elements {
                 // Go left
                 index = node.left.unwrap();
@@ -182,7 +180,7 @@ pub mod test_helpers {
                 index = node.right.unwrap();
                 let proof_node = node.left.unwrap();
                 proof.push(nodes[proof_node].hash);
-                
+
                 key = key - number_subtree_elements;
             }
         }


### PR DESCRIPTION
## Type of change

<!--Delete points that do not apply-->

- Improvement (refactoring, restructuring repository, cleaning tech debt, ...)

## Changes

The following changes have been made:

- Use a fixed array of length 8 for binary Merkle proof
- Function to automatically return leaves for a perfect binary tree
- Function to generate a Merkle proof for a perfect binary tree

## Related Issues

<!--Delete everything after the "#" symbol and replace it with a number. No spaces between hash and number-->

Closes #26 
