### PR TITLE
Update README to use tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ These libraries contain helper functions, generalized standards, and other tools
 To import the Merkle Proof library the following should be added to the project's `Forc.toml` file under `[dependencies]` with the most recent release:
 
 ```rust
-sway_libs = { git = "https://github.com/FuelLabs/sway-libs", version = "0.1.0" }
+sway_libs = { git = "https://github.com/FuelLabs/sway-libs", tag = "v0.1.0" }
 ```
 
 You may then import your desired library in your Sway Smart Contract as so:


### PR DESCRIPTION
## Type of change

<!--Delete points that do not apply-->

- Documentation

## Changes

The following changes have been made:

-  Update the README.md to use tag instead of version

## Related Issues

<!--Delete everything after the "#" symbol and replace it with a number. No spaces between hash and number-->

Closes #28 
