### PR TITLE
Add Forc and Core versions to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,8 @@ env:
   CARGO_TERM_COLOR: always
   REGISTRY: ghcr.io
   RUST_VERSION: 1.63.0
+  FORC_VERSION: 0.24.1
+  CORE_VERSION: 0.10.1
   PATH_TO_SCRIPTS: .github/scripts
 
 jobs:
@@ -51,6 +53,9 @@ jobs:
 
         - name: Install Fuel toolchain
           uses: FuelLabs/action-fuel-toolchain@v0.1.0
+          with:
+            name: my-toolchain
+            components: forc@${{ env.FORC_VERSION }}, fuel-core@${{ env.CORE_VERSION }}
 
         - name: Check Sway formatting
           run: forc fmt --path sway_libs --check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
           run: rustup component add rustfmt
 
         - name: Install Fuel toolchain
-          uses: FuelLabs/action-fuel-toolchain@v0.1.0
+          uses: FuelLabs/action-fuel-toolchain@v0.2.0
           with:
             name: my-toolchain
             components: forc@${{ env.FORC_VERSION }}, fuel-core@${{ env.CORE_VERSION }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ env:
   CARGO_TERM_COLOR: always
   REGISTRY: ghcr.io
   RUST_VERSION: 1.63.0
-  FORC_VERSION: 0.24.1
+  FORC_VERSION: 0.24.4
   CORE_VERSION: 0.10.1
   PATH_TO_SCRIPTS: .github/scripts
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ For example, to import the Merkle Proof library use the following statement:
 sway_libs::binary_merkle_proof::verify_proof;
 ```
 
+> **Note**
+> All projects currently use `forc 0.24.1` and `fuel-core 0.10.1`.
+
 ## Contributing
 
 Check [CONTRIBUTING.md](./CONTRIBUTING.md) for more info!


### PR DESCRIPTION
## Type of change

<!--Delete points that do not apply-->

- Improvement (refactoring, restructuring repository, cleaning tech debt, ...)

## Changes

The following changes have been made:

- Add versions of Forc and Core to CI to avoid any breaking changes.

## Notes

- The String library will fail CI as the most recent version of Forc has a formatting change

## Related Issues

<!--Delete everything after the "#" symbol and replace it with a number. No spaces between hash and number-->

Closes #33 
