### PR TITLE
Bump repo to forc v0.25.2 and Fuels-rs v0.25.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ env:
   CARGO_TERM_COLOR: always
   REGISTRY: ghcr.io
   RUST_VERSION: 1.63.0
-  FORC_VERSION: 0.24.4
+  FORC_VERSION: 0.25.2
   CORE_VERSION: 0.10.1
   PATH_TO_SCRIPTS: .github/scripts
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ sway_libs::binary_merkle_proof::verify_proof;
 ```
 
 > **Note**
-> All projects currently use `forc 0.24.1` and `fuel-core 0.10.1`.
+> All projects currently use `forc v0.25.2`, `fuels-rs v0.25.1` and `fuel-core 0.10.1`.
 
 ## Contributing
 

--- a/sway_libs/src/string/string.sw
+++ b/sway_libs/src/string/string.sw
@@ -1,7 +1,5 @@
 library string;
 
-use std::{option::Option, vec::Vec};
-
 pub struct String {
     bytes: Vec<u8>,
 }
@@ -23,18 +21,18 @@ impl String {
     }
 
     /// Converts a vector of bytes to a `String`.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `bytes` - The vector of `u8` bytes which will be converted into a `String`.
     pub fn from_utf8(bytes: Vec<u8>) -> String {
         String { bytes }
     }
 
     /// Inserts a byte at the index within the `String`.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `byte` - The element which will be added to the `String`.
     /// * `index` - The position in the `String` where the byte will be inserted.
     pub fn insert(self, byte: u8, index: u64) {
@@ -60,9 +58,9 @@ impl String {
     }
 
     /// Returns the byte at the specified index.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `index` - The position of the byte that will be returned.
     pub fn nth(self, index: u64) -> Option<u8> {
         self.bytes.get(index)
@@ -74,27 +72,27 @@ impl String {
     }
 
     /// Appends a byte to the end of the `String`.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `byte` - The element to be appended to the end of the `String`.
     pub fn push(self, byte: u8) {
         self.bytes.push(byte);
     }
 
     /// Removes and returns the byte at the specified index.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `index` - The position of the byte that will be removed.
     pub fn remove(self, index: u64) -> u8 {
         self.bytes.remove(index)
     }
 
     /// Constructs a new instance of the `String` type with the specified capacity.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `capacity` - The specified amount of memory on the heap to be allocated for the `String`.
     pub fn with_capacity(capacity: u64) -> Self {
         Self {

--- a/tests/src/Cargo.toml
+++ b/tests/src/Cargo.toml
@@ -6,10 +6,10 @@ edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]
-forc = { version = "0.24.1" }
+forc = { version = "0.25" }
 fuel-core = { version = "0.10.1 "}
 fuel-merkle = { version = "0.3" }
-fuels = { version = "0.22" }
+fuels = { version = "0.25" }
 sha2 = { version = "0.10" }
 tokio = { version = "1.12", features = ["rt", "macros"] }
 

--- a/tests/src/Cargo.toml
+++ b/tests/src/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0"
 forc = { version = "0.25.2" }
 fuel-core = { version = "0.10.1 "}
 fuel-merkle = { version = "0.3" }
-fuels = { version = "0.25", features = ["fuel-core-lib"] }
+fuels = { version = "0.25.1", features = ["fuel-core-lib"] }
 sha2 = { version = "0.10" }
 tokio = { version = "1.12", features = ["rt", "macros"] }
 

--- a/tests/src/Cargo.toml
+++ b/tests/src/Cargo.toml
@@ -6,10 +6,10 @@ edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]
-forc = { version = "0.25" }
+forc = { version = "0.25.2" }
 fuel-core = { version = "0.10.1 "}
 fuel-merkle = { version = "0.3" }
-fuels = { version = "0.25" }
+fuels = { version = "0.25", features = ["fuel-core-lib"] }
 sha2 = { version = "0.10" }
 tokio = { version = "1.12", features = ["rt", "macros"] }
 

--- a/tests/src/test_projects/merkle_proof/src/main.sw
+++ b/tests/src/test_projects/merkle_proof/src/main.sw
@@ -5,19 +5,8 @@ use sway_libs::binary_merkle_proof::{leaf_digest, node_digest, process_proof, ve
 abi MerkleProofTest {
     fn leaf_digest(data: b256) -> b256;
     fn node_digest(left: b256, right: b256) -> b256;
-    fn process_proof(
-        key: u64,
-        merkle_leaf: b256,
-        num_leaves: u64,
-        proof: [b256; 8],
-    ) -> b256;
-    fn verify_proof(
-        key: u64,
-        merkle_leaf: b256,
-        merkle_root: b256,
-        num_leaves: u64,
-        proof: [b256; 8],
-    ) -> bool;
+    fn process_proof(key: u64, merkle_leaf: b256, num_leaves: u64, proof: Vec<b256>, ) -> b256;
+    fn verify_proof(key: u64, merkle_leaf: b256, merkle_root: b256, num_leaves: u64, proof: Vec<b256>, ) -> bool;
 }
 
 impl MerkleProofTest for Contract {
@@ -33,7 +22,7 @@ impl MerkleProofTest for Contract {
         key: u64,
         merkle_leaf: b256,
         num_leaves: u64,
-        proof: [b256; 8],
+        proof: Vec<b256>,
     ) -> b256 {
         process_proof(key, merkle_leaf, num_leaves, proof)
     }
@@ -43,7 +32,7 @@ impl MerkleProofTest for Contract {
         merkle_leaf: b256,
         merkle_root: b256,
         num_leaves: u64,
-        proof: [b256; 8],
+        proof: Vec<b256>,
     ) -> bool {
         verify_proof(key, merkle_leaf, merkle_root, num_leaves, proof)
     }

--- a/tests/src/test_projects/merkle_proof/tests/functions/leaf_digest.rs
+++ b/tests/src/test_projects/merkle_proof/tests/functions/leaf_digest.rs
@@ -2,6 +2,7 @@ use crate::merkle_proof::tests::utils::{
     abi_calls::leaf_digest,
     test_helpers::{build_tree, merkle_proof_instance},
 };
+use fuels::prelude::Bits256;
 
 mod success {
 
@@ -17,7 +18,7 @@ mod success {
         let (_tree, _root, leaf, _proof) = build_tree(leaves, key).await;
 
         assert_eq!(
-            leaf_digest(&instance, "A".as_bytes().try_into().unwrap()).await,
+            leaf_digest(&instance, Bits256("A".as_bytes().try_into().unwrap())).await,
             leaf
         );
     }

--- a/tests/src/test_projects/merkle_proof/tests/functions/node_digest.rs
+++ b/tests/src/test_projects/merkle_proof/tests/functions/node_digest.rs
@@ -3,6 +3,7 @@ use crate::merkle_proof::tests::utils::{
     test_helpers::{build_tree, merkle_proof_instance},
 };
 use fuel_merkle::common::{Bytes32, LEAF};
+use fuels::prelude::Bits256;
 use sha2::{Digest, Sha256};
 
 mod success {
@@ -75,13 +76,13 @@ mod success {
 
         // This passes due to use of u64 for node concatenation
         assert_eq!(
-            node_digest(&instance, leaf_a_hash, leaf_b_hash).await,
-            node_ab_hash
+            node_digest(&instance, Bits256(leaf_a_hash), Bits256(leaf_b_hash)).await,
+            Bits256(node_ab_hash)
         );
 
         assert_eq!(
-            node_digest(&instance, node_ab_hash, leaf_c_hash).await,
-            node_abc_hash
+            node_digest(&instance, Bits256(node_ab_hash), Bits256(leaf_c_hash)).await,
+            Bits256(node_abc_hash)
         );
     }
 }

--- a/tests/src/test_projects/merkle_proof/tests/utils/mod.rs
+++ b/tests/src/test_projects/merkle_proof/tests/utils/mod.rs
@@ -15,7 +15,13 @@ pub mod abi_calls {
     use super::*;
 
     pub async fn leaf_digest(contract: &TestMerkleProofLib, data: Bits256) -> Bits256 {
-        contract.methods().leaf_digest(data).call().await.unwrap().value
+        contract
+            .methods()
+            .leaf_digest(data)
+            .call()
+            .await
+            .unwrap()
+            .value
     }
 
     pub async fn node_digest(
@@ -118,7 +124,12 @@ pub mod test_helpers {
             final_proof.push(Bits256(itterator.clone()));
         }
 
-        (tree, Bits256(merkle_root), Bits256(merkle_leaf), final_proof)
+        (
+            tree,
+            Bits256(merkle_root),
+            Bits256(merkle_leaf),
+            final_proof,
+        )
     }
 
     pub async fn build_tree_manual(
@@ -196,7 +207,11 @@ pub mod test_helpers {
 
         proof.reverse();
 
-        (Bits256(leaf_hash), proof, Bits256(nodes.last().unwrap().hash))
+        (
+            Bits256(leaf_hash),
+            proof,
+            Bits256(nodes.last().unwrap().hash),
+        )
     }
 
     pub async fn leaves_with_depth(depth: u32) -> Vec<[u8; 1]> {
@@ -223,8 +238,7 @@ pub mod test_helpers {
         .await
         .unwrap();
 
-        let instance =
-            TestMerkleProofLib::new(contract_id.to_string(), wallet.clone());
+        let instance = TestMerkleProofLib::new(contract_id.to_string(), wallet.clone());
 
         instance
     }

--- a/tests/src/test_projects/merkle_proof/tests/utils/mod.rs
+++ b/tests/src/test_projects/merkle_proof/tests/utils/mod.rs
@@ -1,6 +1,6 @@
 use fuel_merkle::{
     binary::in_memory::MerkleTree,
-    common::{empty_sum_sha256, Bytes32, ProofSet, LEAF},
+    common::{empty_sum_sha256, Bytes32, LEAF},
 };
 use fuels::prelude::*;
 use sha2::{Digest, Sha256};
@@ -14,16 +14,17 @@ pub mod abi_calls {
 
     use super::*;
 
-    pub async fn leaf_digest(contract: &TestMerkleProofLib, data: [u8; 32]) -> [u8; 32] {
-        contract.leaf_digest(data).call().await.unwrap().value
+    pub async fn leaf_digest(contract: &TestMerkleProofLib, data: Bits256) -> Bits256 {
+        contract.methods().leaf_digest(data).call().await.unwrap().value
     }
 
     pub async fn node_digest(
         contract: &TestMerkleProofLib,
-        left: [u8; 32],
-        right: [u8; 32],
-    ) -> [u8; 32] {
+        left: Bits256,
+        right: Bits256,
+    ) -> Bits256 {
         contract
+            .methods()
             .node_digest(left, right)
             .call()
             .await
@@ -34,11 +35,12 @@ pub mod abi_calls {
     pub async fn process_proof(
         contract: &TestMerkleProofLib,
         key: u64,
-        leaf: [u8; 32],
+        leaf: Bits256,
         num_leaves: u64,
-        proof: Vec<[u8; 32]>,
-    ) -> [u8; 32] {
+        proof: Vec<Bits256>,
+    ) -> Bits256 {
         contract
+            .methods()
             .process_proof(key, leaf, num_leaves, proof)
             .call()
             .await
@@ -49,12 +51,13 @@ pub mod abi_calls {
     pub async fn verify_proof(
         contract: &TestMerkleProofLib,
         key: u64,
-        leaf: [u8; 32],
-        root: [u8; 32],
+        leaf: Bits256,
+        root: Bits256,
         num_leaves: u64,
-        proof: Vec<[u8; 32]>,
+        proof: Vec<Bits256>,
     ) -> bool {
         contract
+            .methods()
             .verify_proof(key, root, leaf, num_leaves, proof)
             .call()
             .await
@@ -97,7 +100,7 @@ pub mod test_helpers {
     pub async fn build_tree(
         leaves: Vec<&[u8]>,
         key: u64,
-    ) -> (MerkleTree, Bytes32, Bytes32, ProofSet) {
+    ) -> (MerkleTree, Bits256, Bits256, Vec<Bits256>) {
         let mut tree = MerkleTree::new();
 
         for datum in leaves.iter() {
@@ -109,18 +112,24 @@ pub mod test_helpers {
         let merkle_leaf = proof.1[0];
         proof.1.remove(0);
 
-        (tree, merkle_root, merkle_leaf, proof.1)
+        let mut final_proof: Vec<Bits256> = Vec::new();
+
+        for itterator in proof.1 {
+            final_proof.push(Bits256(itterator.clone()));
+        }
+
+        (tree, Bits256(merkle_root), Bits256(merkle_leaf), final_proof)
     }
 
     pub async fn build_tree_manual(
         leaves: Vec<[u8; 1]>,
         height: usize,
         key: usize,
-    ) -> (Bytes32, ProofSet, Bytes32) {
+    ) -> (Bits256, Vec<Bits256>, Bits256) {
         let num_leaves = leaves.len();
         let mut nodes: Vec<Node> = Vec::new();
         let mut leaf_hash: Bytes32 = *empty_sum_sha256();
-        let mut proof: ProofSet = Vec::new();
+        let mut proof: Vec<Bits256> = Vec::new();
 
         assert!(key <= num_leaves);
 
@@ -174,12 +183,12 @@ pub mod test_helpers {
                 // Go left
                 index = node.left.unwrap();
                 let proof_node = node.right.unwrap();
-                proof.push(nodes[proof_node].hash);
+                proof.push(Bits256(nodes[proof_node].hash));
             } else {
                 // Go right
                 index = node.right.unwrap();
                 let proof_node = node.left.unwrap();
-                proof.push(nodes[proof_node].hash);
+                proof.push(Bits256(nodes[proof_node].hash));
 
                 key = key - number_subtree_elements;
             }
@@ -187,7 +196,7 @@ pub mod test_helpers {
 
         proof.reverse();
 
-        (leaf_hash, proof, nodes.last().unwrap().hash)
+        (Bits256(leaf_hash), proof, Bits256(nodes.last().unwrap().hash))
     }
 
     pub async fn leaves_with_depth(depth: u32) -> Vec<[u8; 1]> {
@@ -215,7 +224,7 @@ pub mod test_helpers {
         .unwrap();
 
         let instance =
-            TestMerkleProofLibBuilder::new(contract_id.to_string(), wallet.clone()).build();
+            TestMerkleProofLib::new(contract_id.to_string(), wallet.clone());
 
         instance
     }

--- a/tests/src/test_projects/string/src/main.sw
+++ b/tests/src/test_projects/string/src/main.sw
@@ -1,12 +1,6 @@
 contract;
 
-use std::{
-    assert::assert, 
-    intrinsics::size_of, 
-    mem::{addr_of, read}, 
-    option::Option, 
-    vec::Vec
-};
+use std::{intrinsics::size_of, mem::{addr_of, read}};
 use sway_libs::string::String;
 
 const NUMBER0 = 0u8;
@@ -203,7 +197,7 @@ impl StringTest for Contract {
 
     fn test_len() {
         let mut string = ~String::new();
-        
+
         assert(string.len() == 0);
 
         string.push(NUMBER0);
@@ -311,7 +305,6 @@ impl StringTest for Contract {
 
         assert(string.len() == 0);
         assert(string.pop().is_none());
-
         string.push(NUMBER5);
         assert(string.pop().unwrap() == NUMBER5);
     }
@@ -423,7 +416,7 @@ impl StringTest for Contract {
             assert(string.capacity() == iterator);
             iterator += 1;
         }
-        
+
         let mut string = ~String::with_capacity(0);
         assert(string.capacity() == 0);
 
@@ -440,12 +433,11 @@ impl StringTest for Contract {
         assert(string.capacity() == 4);
 
         let mut string = ~String::with_capacity(4);
-        
+
         assert(string.capacity() == 4);
 
         string.push(NUMBER0);
         assert(string.capacity() == 4);
-
         string.push(NUMBER1);
         assert(string.capacity() == 4);
 

--- a/tests/src/test_projects/string/tests/functions/as_bytes.rs
+++ b/tests/src/test_projects/string/tests/functions/as_bytes.rs
@@ -1,7 +1,4 @@
-use crate::string::tests::utils::{
-    abi_calls::as_bytes,
-    test_helpers::setup,
-};
+use crate::string::tests::utils::{abi_calls::as_bytes, test_helpers::setup};
 
 mod success {
 

--- a/tests/src/test_projects/string/tests/functions/capacity.rs
+++ b/tests/src/test_projects/string/tests/functions/capacity.rs
@@ -1,7 +1,4 @@
-use crate::string::tests::utils::{
-    abi_calls::capacity,
-    test_helpers::setup,
-};
+use crate::string::tests::utils::{abi_calls::capacity, test_helpers::setup};
 
 mod success {
 

--- a/tests/src/test_projects/string/tests/functions/clear.rs
+++ b/tests/src/test_projects/string/tests/functions/clear.rs
@@ -1,7 +1,4 @@
-use crate::string::tests::utils::{
-    abi_calls::clear,
-    test_helpers::setup,
-};
+use crate::string::tests::utils::{abi_calls::clear, test_helpers::setup};
 
 mod success {
 

--- a/tests/src/test_projects/string/tests/functions/from_utf8.rs
+++ b/tests/src/test_projects/string/tests/functions/from_utf8.rs
@@ -1,7 +1,4 @@
-use crate::string::tests::utils::{
-    abi_calls::from_utf8,
-    test_helpers::setup,
-};
+use crate::string::tests::utils::{abi_calls::from_utf8, test_helpers::setup};
 
 mod success {
 

--- a/tests/src/test_projects/string/tests/functions/insert.rs
+++ b/tests/src/test_projects/string/tests/functions/insert.rs
@@ -1,7 +1,4 @@
-use crate::string::tests::utils::{
-    abi_calls::insert,
-    test_helpers::setup,
-};
+use crate::string::tests::utils::{abi_calls::insert, test_helpers::setup};
 
 mod success {
 

--- a/tests/src/test_projects/string/tests/functions/is_empty.rs
+++ b/tests/src/test_projects/string/tests/functions/is_empty.rs
@@ -1,7 +1,4 @@
-use crate::string::tests::utils::{
-    abi_calls::is_empty,
-    test_helpers::setup,
-};
+use crate::string::tests::utils::{abi_calls::is_empty, test_helpers::setup};
 
 mod success {
 

--- a/tests/src/test_projects/string/tests/functions/len.rs
+++ b/tests/src/test_projects/string/tests/functions/len.rs
@@ -1,7 +1,4 @@
-use crate::string::tests::utils::{
-    abi_calls::len,
-    test_helpers::setup,
-};
+use crate::string::tests::utils::{abi_calls::len, test_helpers::setup};
 
 mod success {
 

--- a/tests/src/test_projects/string/tests/functions/new.rs
+++ b/tests/src/test_projects/string/tests/functions/new.rs
@@ -1,7 +1,4 @@
-use crate::string::tests::utils::{
-    abi_calls::new,
-    test_helpers::setup,
-};
+use crate::string::tests::utils::{abi_calls::new, test_helpers::setup};
 
 mod success {
 

--- a/tests/src/test_projects/string/tests/functions/nth.rs
+++ b/tests/src/test_projects/string/tests/functions/nth.rs
@@ -1,7 +1,4 @@
-use crate::string::tests::utils::{
-    abi_calls::nth,
-    test_helpers::setup,
-};
+use crate::string::tests::utils::{abi_calls::nth, test_helpers::setup};
 
 mod success {
 

--- a/tests/src/test_projects/string/tests/functions/pop.rs
+++ b/tests/src/test_projects/string/tests/functions/pop.rs
@@ -1,7 +1,4 @@
-use crate::string::tests::utils::{
-    abi_calls::pop,
-    test_helpers::setup,
-};
+use crate::string::tests::utils::{abi_calls::pop, test_helpers::setup};
 
 mod success {
 

--- a/tests/src/test_projects/string/tests/functions/push.rs
+++ b/tests/src/test_projects/string/tests/functions/push.rs
@@ -1,7 +1,4 @@
-use crate::string::tests::utils::{
-    abi_calls::push,
-    test_helpers::setup,
-};
+use crate::string::tests::utils::{abi_calls::push, test_helpers::setup};
 
 mod success {
 

--- a/tests/src/test_projects/string/tests/functions/remove.rs
+++ b/tests/src/test_projects/string/tests/functions/remove.rs
@@ -1,7 +1,4 @@
-use crate::string::tests::utils::{
-    abi_calls::remove,
-    test_helpers::setup,
-};
+use crate::string::tests::utils::{abi_calls::remove, test_helpers::setup};
 
 mod success {
 

--- a/tests/src/test_projects/string/tests/functions/with_capacity.rs
+++ b/tests/src/test_projects/string/tests/functions/with_capacity.rs
@@ -1,7 +1,4 @@
-use crate::string::tests::utils::{
-    abi_calls::with_capacity,
-    test_helpers::setup,
-};
+use crate::string::tests::utils::{abi_calls::with_capacity, test_helpers::setup};
 
 mod success {
 

--- a/tests/src/test_projects/string/tests/utils/mod.rs
+++ b/tests/src/test_projects/string/tests/utils/mod.rs
@@ -59,7 +59,12 @@ pub mod abi_calls {
     }
 
     pub async fn with_capacity(contract: &StringTestLib) -> CallResponse<()> {
-        contract.methods().test_with_capacity().call().await.unwrap()
+        contract
+            .methods()
+            .test_with_capacity()
+            .call()
+            .await
+            .unwrap()
     }
 }
 

--- a/tests/src/test_projects/string/tests/utils/mod.rs
+++ b/tests/src/test_projects/string/tests/utils/mod.rs
@@ -11,55 +11,55 @@ pub mod abi_calls {
     use super::*;
 
     pub async fn as_bytes(contract: &StringTestLib) -> CallResponse<()> {
-        contract.test_as_bytes().call().await.unwrap()
+        contract.methods().test_as_bytes().call().await.unwrap()
     }
 
     pub async fn capacity(contract: &StringTestLib) -> CallResponse<()> {
-        contract.test_capacity().call().await.unwrap()
+        contract.methods().test_capacity().call().await.unwrap()
     }
 
     pub async fn clear(contract: &StringTestLib) -> CallResponse<()> {
-        contract.test_clear().call().await.unwrap()
+        contract.methods().test_clear().call().await.unwrap()
     }
 
     pub async fn from_utf8(contract: &StringTestLib) -> CallResponse<()> {
-        contract.test_from_utf8().call().await.unwrap()
+        contract.methods().test_from_utf8().call().await.unwrap()
     }
 
     pub async fn insert(contract: &StringTestLib) -> CallResponse<()> {
-        contract.test_insert().call().await.unwrap()
+        contract.methods().test_insert().call().await.unwrap()
     }
 
     pub async fn is_empty(contract: &StringTestLib) -> CallResponse<()> {
-        contract.test_is_empty().call().await.unwrap()
+        contract.methods().test_is_empty().call().await.unwrap()
     }
 
     pub async fn len(contract: &StringTestLib) -> CallResponse<()> {
-        contract.test_len().call().await.unwrap()
+        contract.methods().test_len().call().await.unwrap()
     }
 
     pub async fn new(contract: &StringTestLib) -> CallResponse<()> {
-        contract.test_new().call().await.unwrap()
+        contract.methods().test_new().call().await.unwrap()
     }
 
     pub async fn nth(contract: &StringTestLib) -> CallResponse<()> {
-        contract.test_nth().call().await.unwrap()
+        contract.methods().test_nth().call().await.unwrap()
     }
 
     pub async fn pop(contract: &StringTestLib) -> CallResponse<()> {
-        contract.test_pop().call().await.unwrap()
+        contract.methods().test_pop().call().await.unwrap()
     }
 
     pub async fn push(contract: &StringTestLib) -> CallResponse<()> {
-        contract.test_push().call().await.unwrap()
+        contract.methods().test_push().call().await.unwrap()
     }
 
     pub async fn remove(contract: &StringTestLib) -> CallResponse<()> {
-        contract.test_remove().call().await.unwrap()
+        contract.methods().test_remove().call().await.unwrap()
     }
 
     pub async fn with_capacity(contract: &StringTestLib) -> CallResponse<()> {
-        contract.test_with_capacity().call().await.unwrap()
+        contract.methods().test_with_capacity().call().await.unwrap()
     }
 }
 
@@ -89,7 +89,7 @@ pub mod test_helpers {
         .await
         .unwrap();
 
-        let instance = StringTestLibBuilder::new(id.to_string(), wallet).build();
+        let instance = StringTestLib::new(id.to_string(), wallet);
 
         instance
     }


### PR DESCRIPTION
## Type of change

<!--Delete points that do not apply-->

- Improvement (refactoring, restructuring repository, cleaning tech debt, ...)

## Changes

The following changes have been made:

- Update Merkle Proof to use `Vec` as input
- Update libraries for new prelude
- Update Merkle Proof tests to use Vec
- Bump Merkle Proof tests to v0.25.1
- Bump String tests to v0.25.1

## Related Issues

<!--Delete everything after the "#" symbol and replace it with a number. No spaces between hash and number-->

Closes #35 
