### PR TITLE
remove tilde from method calls for compatibility with the latest sway compiler

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ env:
   CARGO_TERM_COLOR: always
   REGISTRY: ghcr.io
   RUST_VERSION: 1.63.0
-  FORC_VERSION: 0.25.2
+  FORC_VERSION: 0.29.0
   CORE_VERSION: 0.10.1
   PATH_TO_SCRIPTS: .github/scripts
 

--- a/sway_libs/src/string/README.md
+++ b/sway_libs/src/string/README.md
@@ -25,7 +25,7 @@ use sway_libs::string::String;
 Once imported, a `String` can be instantiated defining a new variable and calling the `new` function.
 
 ```rust
-let mut string = ~String::new();
+let mut string = String::new();
 ```
 
 ## Basic Functionality

--- a/sway_libs/src/string/string.sw
+++ b/sway_libs/src/string/string.sw
@@ -53,7 +53,7 @@ impl String {
     /// Constructs a new instance of the `String` type.
     pub fn new() -> Self {
         Self {
-            bytes: ~Vec::new(),
+            bytes: Vec::new(),
         }
     }
 
@@ -96,7 +96,7 @@ impl String {
     /// * `capacity` - The specified amount of memory on the heap to be allocated for the `String`.
     pub fn with_capacity(capacity: u64) -> Self {
         Self {
-            bytes: ~Vec::with_capacity(capacity),
+            bytes: Vec::with_capacity(capacity),
         }
     }
 }

--- a/tests/src/test_projects/string/src/main.sw
+++ b/tests/src/test_projects/string/src/main.sw
@@ -31,7 +31,7 @@ abi StringTest {
 
 impl StringTest for Contract {
     fn test_as_bytes() {
-        let mut string = ~String::new();
+        let mut string = String::new();
 
         let bytes: Vec<u8> = string.as_bytes();
         assert(bytes.len() == string.len());
@@ -58,7 +58,7 @@ impl StringTest for Contract {
     }
 
     fn test_capacity() {
-        let mut string = ~String::new();
+        let mut string = String::new();
 
         assert(string.capacity() == 0);
 
@@ -92,7 +92,7 @@ impl StringTest for Contract {
     }
 
     fn test_clear() {
-        let mut string = ~String::new();
+        let mut string = String::new();
 
         assert(string.is_empty());
 
@@ -130,7 +130,7 @@ impl StringTest for Contract {
     }
 
     fn test_from_utf8() {
-        let mut vec: Vec<u8> = ~Vec::new();
+        let mut vec: Vec<u8> = Vec::new();
 
         vec.push(NUMBER0);
         vec.push(NUMBER1);
@@ -138,7 +138,7 @@ impl StringTest for Contract {
         vec.push(NUMBER3);
         vec.push(NUMBER4);
 
-        let string_from_uft8 = ~String::from_utf8(vec);
+        let string_from_uft8 = String::from_utf8(vec);
         assert(vec.len() == string_from_uft8.len());
         assert(vec.capacity() == string_from_uft8.capacity());
         assert(vec.get(0).unwrap() == string_from_uft8.nth(0).unwrap());
@@ -147,7 +147,7 @@ impl StringTest for Contract {
     }
 
     fn test_insert() {
-        let mut string = ~String::new();
+        let mut string = String::new();
 
         assert(string.len() == 0);
 
@@ -169,7 +169,7 @@ impl StringTest for Contract {
     }
 
     fn test_is_empty() {
-        let mut string = ~String::new();
+        let mut string = String::new();
 
         assert(string.is_empty());
 
@@ -196,7 +196,7 @@ impl StringTest for Contract {
     }
 
     fn test_len() {
-        let mut string = ~String::new();
+        let mut string = String::new();
 
         assert(string.len() == 0);
 
@@ -235,7 +235,7 @@ impl StringTest for Contract {
     }
 
     fn test_new() {
-        let mut string = ~String::new();
+        let mut string = String::new();
 
         assert(string.len() == 0);
         assert(string.is_empty());
@@ -243,7 +243,7 @@ impl StringTest for Contract {
     }
 
     fn test_nth() {
-        let mut string = ~String::new();
+        let mut string = String::new();
 
         string.push(NUMBER0);
         assert(string.nth(0).unwrap() == NUMBER0);
@@ -280,7 +280,7 @@ impl StringTest for Contract {
     }
 
     fn test_pop() {
-        let mut string = ~String::new();
+        let mut string = String::new();
 
         string.push(NUMBER0);
         string.push(NUMBER1);
@@ -310,7 +310,7 @@ impl StringTest for Contract {
     }
 
     fn test_push() {
-        let mut string = ~String::new();
+        let mut string = String::new();
 
         assert(string.len() == 0);
         assert(string.is_empty());
@@ -374,7 +374,7 @@ impl StringTest for Contract {
     }
 
     fn test_remove() {
-        let mut string = ~String::new();
+        let mut string = String::new();
 
         string.push(NUMBER0);
         string.push(NUMBER1);
@@ -412,12 +412,12 @@ impl StringTest for Contract {
         let mut iterator = 0;
 
         while iterator < 16 {
-            let mut string = ~String::with_capacity(iterator);
+            let mut string = String::with_capacity(iterator);
             assert(string.capacity() == iterator);
             iterator += 1;
         }
 
-        let mut string = ~String::with_capacity(0);
+        let mut string = String::with_capacity(0);
         assert(string.capacity() == 0);
 
         string.push(NUMBER0);
@@ -432,7 +432,7 @@ impl StringTest for Contract {
         string.clear();
         assert(string.capacity() == 4);
 
-        let mut string = ~String::with_capacity(4);
+        let mut string = String::with_capacity(4);
 
         assert(string.capacity() == 4);
 


### PR DESCRIPTION
## Type of change


- Other (describe below)

## Changes

The following changes have been made:

- Remove `~` from all method applications to be compatible with the latest version of Sway.

## Notes

Once https://github.com/FuelLabs/sway/pull/3218 goes in and `0.29.0` is released, code that contains `~`, like `~Address::from()`, will no longer compile. As a show of good faith, respect for our consumers, and in apology for breaking your repo, I'm submitting this PR. ❤️ 