### PR TITLE
Add generic to meta_data and set_meta_data

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ These libraries contain helper functions, generalized standards, and other tools
 ### Libraries
 
 - [Binary Merkle Proof](./sway_libs/src/merkle_proof/) is used to verify Binary Merkle Trees computed off-chain.
-- [Non-Fungible Token(NFT)](./sway_libs/src/nft/) is a token library which provides unqiue collectibles, identified and differentiated by token IDs.
+- [Non-Fungible Token (NFT)](./sway_libs/src/nft/) is a token library which provides unqiue collectibles, identified and differentiated by token IDs.
 - [String](./sway_libs/src/string/) is an interface to implement dynamic length strings that are UTF-8 encoded.
 
 ## Using a library

--- a/sway_libs/src/nft/README.md
+++ b/sway_libs/src/nft/README.md
@@ -71,6 +71,6 @@ These include:
 1. [Metadata](./extensions/meta_data/meta_data.sw)
 2. [Burning functionality](./extensions/burnable/burnable.sw)
 3. [Administrative capabilities](./extensions/administrator/administrator.sw)
-4. [Supply limits](./extensions/supply.sw)
+4. [Supply limits](./extensions/supply/supply.sw)
 
 For more information please see the [specification](./SPECIFICATION.md).

--- a/sway_libs/src/nft/extensions/meta_data/meta_data.sw
+++ b/sway_libs/src/nft/extensions/meta_data/meta_data.sw
@@ -38,7 +38,7 @@ impl<T> MetaData<T> for NFTCore {
 ///
 /// * `token_id` - The id of the token which the metadata should be returned
 #[storage(read)]
-pub fn meta_data(token_id: u64) -> Option<NFTMetaData> {
+pub fn meta_data<T>(token_id: u64) -> Option<T> {
     let nft = get::<Option<NFTCore>>(sha256((TOKENS, token_id)));
     match nft {
         Option::Some(nft) => {
@@ -61,7 +61,7 @@ pub fn meta_data(token_id: u64) -> Option<NFTMetaData> {
 ///
 /// * When the `token_id` does not map to an existing token
 #[storage(read, write)]
-pub fn set_meta_data(metadata: Option<NFTMetaData>, token_id: u64) {
+pub fn set_meta_data<T>(metadata: Option<T>, token_id: u64) {
     let nft = get::<Option<NFTCore>>(sha256((TOKENS, token_id)));
     require(nft.is_some(), InputError::TokenDoesNotExist);
 


### PR DESCRIPTION
## Type of change

<!--Delete points that do not apply-->

- Bug fix

## Changes

The following changes have been made:

-  Added generic to `meta_data` and `set_meta_data` functions. This was mistakenly not added when converting the extension to use a generic 
- Added a space in the README
- Fix broken link in README

## Related Issues

<!--Delete everything after the "#" symbol and replace it with a number. No spaces between hash and number-->

Closes #50 
