### PR TITLE
Make `approve` function public

### DIFF
--- a/sway_libs/src/nft/nft_core.sw
+++ b/sway_libs/src/nft/nft_core.sw
@@ -28,7 +28,7 @@ impl NFTCore {
     ///
     /// * When the sender is not the token's owner.
     #[storage(write)]
-    fn approve(self, approved: Option<Identity>) {
+    pub fn approve(self, approved: Option<Identity>) {
         let mut nft = self;
         let sender = msg_sender().unwrap();
         require(nft.owner == sender, AccessError::SenderNotOwner);


### PR DESCRIPTION
## Type of change

<!--Delete points that do not apply-->

- Bug fix

## Changes

The following changes have been made:

- forc v0.31.0 and greater requires that functions in an implementation block have the `pub` keyword. This has been added to unblock an issue in the sway-applications repo.

## Related Issues

<!--Delete everything after the "#" symbol and replace it with a number. No spaces between hash and number-->

Closes #52 
