### PR TITLE
Remove SDK vec comment from README

### DIFF
--- a/sway_libs/src/merkle_proof/README.md
+++ b/sway_libs/src/merkle_proof/README.md
@@ -19,8 +19,6 @@ Once imported, using the Merkle Proof library is as simple as calling the desire
 - `process_proof(key: u64, merkle_leaf: b256, num_leaves: u64, proof: [b256; 2]) -> b256`
 - `verify_proof(key: u64, merkle_leaf: b256, merkle_root: b256, num_leaves: u64, proof: [b256; 2]) -> bool`
 
-> **Note** Fuels-rs does not currently does not support the Sway standard library's `vec` as a function argument. As a result, the current implementation uses an array. 
-
 ## Using the Merkle Proof Library in Fuels-rs
 
 To generate a Merkle Tree and corresponding proof for your Sway Smart Contract, use the [Fuel-Merkle](https://github.com/FuelLabs/fuel-merkle) crate. 


### PR DESCRIPTION
## Type of change

<!--Delete points that do not apply-->

- Improvement (refactoring, restructuring repository, cleaning tech debt, ...)

## Changes

The following changes have been made:

- Remove comment of SDK not supporting Vec
