### PR TITLE
Unused variables and private functions used - Fix

### DIFF
--- a/sway_libs/src/merkle_proof/README.md
+++ b/sway_libs/src/merkle_proof/README.md
@@ -19,8 +19,6 @@ Once imported, using the Merkle Proof library is as simple as calling the desire
 - `process_proof(key: u64, merkle_leaf: b256, num_leaves: u64, proof: [b256; 2]) -> b256`
 - `verify_proof(key: u64, merkle_leaf: b256, merkle_root: b256, num_leaves: u64, proof: [b256; 2]) -> bool`
 
-> **Note** Fuels-rs does not currently does not support the Sway standard library's `vec` as a function argument. As a result, the current implementation uses an array. 
-
 ## Using the Merkle Proof Library in Fuels-rs
 
 To generate a Merkle Tree and corresponding proof for your Sway Smart Contract, use the [Fuel-Merkle](https://github.com/FuelLabs/fuel-merkle) crate. 

--- a/sway_libs/src/nft/nft.sw
+++ b/sway_libs/src/nft/nft.sw
@@ -110,7 +110,7 @@ pub fn mint(amount: u64, to: Identity) {
     // Mint as many tokens as the sender has asked for
     let mut index = tokens_minted;
     while index < total_mint {
-        NFTCore::mint(to, index);
+        let _ = NFTCore::mint(to, index);
         index += 1;
     }
 }

--- a/sway_libs/src/nft/nft.sw
+++ b/sway_libs/src/nft/nft.sw
@@ -175,5 +175,5 @@ pub fn tokens_minted() -> u64 {
 pub fn transfer(to: Identity, token_id: u64) {
     let nft = get::<Option<NFTCore>>(sha256((TOKENS, token_id)));
     require(nft.is_some(), InputError::TokenDoesNotExist);
-    nft.unwrap().transfer(to);
+    let _ = nft.unwrap().transfer(to);
 }

--- a/sway_libs/src/nft/nft.sw
+++ b/sway_libs/src/nft/nft.sw
@@ -110,7 +110,7 @@ pub fn mint(amount: u64, to: Identity) {
     // Mint as many tokens as the sender has asked for
     let mut index = tokens_minted;
     while index < total_mint {
-        NFTCore::mint(to, index);
+        let _ = NFTCore::mint(to, index);
         index += 1;
     }
 }
@@ -175,5 +175,5 @@ pub fn tokens_minted() -> u64 {
 pub fn transfer(to: Identity, token_id: u64) {
     let nft = get::<Option<NFTCore>>(sha256((TOKENS, token_id)));
     require(nft.is_some(), InputError::TokenDoesNotExist);
-    nft.unwrap().transfer(to);
+    let _ = nft.unwrap().transfer(to);
 }

--- a/sway_libs/src/nft/nft.sw
+++ b/sway_libs/src/nft/nft.sw
@@ -110,7 +110,7 @@ pub fn mint(amount: u64, to: Identity) {
     // Mint as many tokens as the sender has asked for
     let mut index = tokens_minted;
     while index < total_mint {
-        let _ = NFTCore::mint(to, index);
+        NFTCore::mint(to, index);
         index += 1;
     }
 }
@@ -175,5 +175,5 @@ pub fn tokens_minted() -> u64 {
 pub fn transfer(to: Identity, token_id: u64) {
     let nft = get::<Option<NFTCore>>(sha256((TOKENS, token_id)));
     require(nft.is_some(), InputError::TokenDoesNotExist);
-    let _ = nft.unwrap().transfer(to);
+    nft.unwrap().transfer(to);
 }

--- a/tests/src/test_projects/signed_i128/src/main.sw
+++ b/tests/src/test_projects/signed_i128/src/main.sw
@@ -42,7 +42,7 @@ fn main() -> bool {
         lower: u64::max(),
     };
 
-    res = I128::from(u128_10) / I128::from_uint(u128_lower_max_u64);
+    res = I128::from(u128_10) / I128 { underlying: u128_lower_max_u64 };
     assert(res == I128::neg_from(u128_10));
 
     let u128_5 = U128 {

--- a/tests/src/test_projects/signed_i16/src/main.sw
+++ b/tests/src/test_projects/signed_i16/src/main.sw
@@ -8,7 +8,7 @@ fn main() -> bool {
     assert(res == I16::from(2u16));
 
     res = I16::from(10u16) - I16::from(11u16);
-    assert(res == I16::from_uint(32767u16));
+    assert(res == I16 { underlying: 32767u16 });
 
     res = I16::from(10u16) * I16::neg_from(1u16);
     assert(res == I16::neg_from(10u16));

--- a/tests/src/test_projects/signed_i256/src/main.sw
+++ b/tests/src/test_projects/signed_i256/src/main.sw
@@ -55,7 +55,7 @@ fn main() -> bool {
         d: u64::max(),
     };
 
-    res = I256::from(u128_10) / I256::from_uint(u128_lower_max_u64);
+    res = I256::from(u128_10) / I256 { underlying: u128_lower_max_u64 };
     assert(res == I256::neg_from(u128_10));
 
     let u128_5 = U256 {

--- a/tests/src/test_projects/signed_i32/src/main.sw
+++ b/tests/src/test_projects/signed_i32/src/main.sw
@@ -3,24 +3,24 @@ script;
 use sway_libs::i32::I32;
 
 fn main() -> bool {
-    let one = I32::from_uint(1u32);
-    let mut res = one + I32::from_uint(1u32);
-    assert(res == I32::from_uint(2u32));
+    let one = I32 { underlying: 1u32 };
+    let mut res = one + I32 { underlying: 1u32 };
+    assert(res == I32 { underlying: 2u32 });
 
-    res = I32::from_uint(10u32) - I32::from_uint(11u32);
+    res = I32 { underlying: 10u32 } - I32 { underlying: 11u32 };
     assert(res == I32::from(2147483647u32));
 
-    res = I32::from_uint(10u32) * I32::neg_from(1u32);
+    res = I32 { underlying: 10u32 } * I32 { underlying: 1u32 };
     assert(res == I32::neg_from(10u32));
 
-    res = I32::from_uint(10u32) * I32::from_uint(10u32);
-    assert(res == I32::from_uint(100u32));
+    res = I32 { underlying: 10u32 } * I32 { underlying: 10u32 };
+    assert(res == I32 { underlying: 100u32 });
 
-    res = I32::from_uint(10u32) / I32::neg_from(1u32);
+    res = I32 { underlying: 10u32 } / I32::neg_from(1u32);
     assert(res == I32::neg_from(10u32));
 
-    res = I32::from_uint(10u32) / I32::from_uint(5u32);
-    assert(res == I32::from_uint(2u32));
+    res = I32 { underlying: 10u32 } / I32 { underlying: 5u32 };
+    assert(res == I32 { underlying: 2u32 });
 
     true
 }

--- a/tests/src/test_projects/signed_i64/src/main.sw
+++ b/tests/src/test_projects/signed_i64/src/main.sw
@@ -8,15 +8,14 @@ fn main() -> bool {
     assert(res == I64::from(2u64));
 
     res = I64::from(10u64) - I64::from(11u64);
-    assert(res == I64::from_uint(9223372036854775807u64));
-
+    assert(res == I64 { underlying: 9223372036854775807u64 });
     res = I64::from(10u64) * I64::neg_from(1);
     assert(res == I64::neg_from(10));
 
     res = I64::from(10u64) * I64::from(10u64);
     assert(res == I64::from(100u64));
 
-    res = I64::from(10u64) / I64::from_uint(9223372036854775807u64);
+    res = I64::from(10u64) / I64 { underlying: 9223372036854775807u64 };
     assert(res == I64::neg_from(10u64));
 
     res = I64::from(10u64) / I64::from(5u64);

--- a/tests/src/test_projects/signed_i8/src/main.sw
+++ b/tests/src/test_projects/signed_i8/src/main.sw
@@ -8,16 +8,16 @@ fn main() -> bool {
     assert(res == I8::from(2u8));
 
     res = I8::from(10u8) - I8::from(11u8);
-    assert(res == I8::from_uint(127u8));
+    assert(res == I8 { underlying: 127u8 });
 
-    res = I8::from(10u8) * I8::from_uint(127u8);
-    assert(res == I8::from_uint(118u8));
+    res = I8::from(10u8) * I8 { underlying: 127u8 };
+    assert(res == I8 { underlying: 118u8 });
 
     res = I8::from(10u8) * I8::from(10u8);
     assert(res == I8::from(100u8));
 
-    res = I8::from(10u8) / I8::from_uint(127u8);
-    assert(res == I8::from_uint(118u8));
+    res = I8::from(10u8) / I8 { underlying: 127u8 };
+    assert(res == I8 { underlying: 118u8 });
 
     res = I8::from(10u8) / I8::from(5u8);
     assert(res == I8::from(2u8));


### PR DESCRIPTION
These unused variables were giving me annoying warnings on unrelated files and the private functions used made it impossible to compile the test contracts


