### PR TITLE
Update README for new versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
     <a href="https://github.com/FuelLabs/sway-libs/actions/workflows/ci.yml" alt="CI">
         <img src="https://github.com/FuelLabs/sway-libs/actions/workflows/ci.yml/badge.svg" />
     </a>
-    <a href="https://crates.io/crates/forc/0.30.1" alt="forc">
-        <img src="https://img.shields.io/badge/forc-v0.30.1-orange" />
+    <a href="https://crates.io/crates/forc/0.32.2" alt="forc">
+        <img src="https://img.shields.io/badge/forc-v0.32.2-orange" />
     </a>
     <a href="./LICENSE" alt="forc">
         <img src="https://img.shields.io/github/license/FuelLabs/sway-libs" />
@@ -58,7 +58,7 @@ sway_libs::binary_merkle_proof::verify_proof;
 ```
 
 > **Note**
-> All projects currently use `forc v0.30.1`, `fuels-rs v0.28.0` and `fuel-core 0.13.2`.
+> All projects currently use `forc v0.32.2`, `fuels-rs v0.33.0` and `fuel-core 0.15.1`.
 
 ## Contributing
 


### PR DESCRIPTION
## Type of change

<!--Delete points that do not apply-->

- Documentation

## Changes

The following changes have been made:

- Updated README to display forc v0.32.2, fuel-core 0.15.1 and fuels 0.33.0
