### PR TITLE
Add utility functions and tests to signed integers

### DIFF
--- a/sway_libs/src/signed_integers/i128.sw
+++ b/sway_libs/src/signed_integers/i128.sw
@@ -19,6 +19,12 @@ impl I128 {
             lower: 0,
         }
     }
+
+    pub fn zero() -> Self {
+        Self {
+            underlying: U128::from((0, 0)),
+        }
+    }
 }
 
 impl From<U128> for I128 {
@@ -51,6 +57,28 @@ impl core::ops::Ord for I128 {
 }
 
 impl I128 {
+    pub fn ge(self, other: Self) -> bool {
+        self > other || self == other
+    }
+
+    pub fn le(self, other: Self) -> bool {
+        self < other || self == other
+    }
+
+    pub fn from_u64(value: u64) -> I128 {
+        Self {
+            underlying: U128::from((0, value)),
+        }
+    }
+
+    pub fn as_u64(self) -> u64 {
+        if self.underlying < Self::indent() {
+            revert(0)
+        } else {
+            self.underlying.as_u64().unwrap()
+        }
+    }
+
     /// The size of this type in bits.
     pub fn bits() -> u32 {
         128
@@ -167,5 +195,13 @@ impl core::ops::Subtract for I128 {
             res = Self::from(Self::indent() - (other.underlying - self.underlying));
         }
         res
+    }
+}
+
+impl I128 {
+     pub fn flip(self) -> Self {
+        self * Self {
+            underlying: Self::indent() - self.underlying,
+        }
     }
 }

--- a/tests/src/test_projects/signed_i128/src/main.sw
+++ b/tests/src/test_projects/signed_i128/src/main.sw
@@ -58,5 +58,24 @@ fn main() -> bool {
     res = I128::from(u128_10) / I128::from(u128_5);
     assert(res == I128::from(u128_2));
 
+    //from_u64 test
+    assert(one == I128::from_u64(1));
+    //as_u64 test
+    assert(1 == one.as_u64());
+    //flip test
+    assert(one.flip() == I128::neg_from(u128_one));
+    //ge test
+    assert(one >= one);
+    assert(I128::from_u64(2) >= one);
+    assert(one >= one.flip());
+    assert(one.flip() >= I128::from_u64(2).flip());
+    //le test
+    assert(one <= one);
+    assert(one <= I128::from_u64(2));
+    assert(one.flip() <= one);
+    assert(I128::from_u64(2).flip() <= one.flip());
+    //zero test
+    assert(I128::zero() == I128::from_u64(0));
+    
     true
 }

--- a/tests/src/test_projects/signed_i128/tests/mod.rs
+++ b/tests/src/test_projects/signed_i128/tests/mod.rs
@@ -16,8 +16,8 @@ mod success {
 
         let instance = Testi128::new(wallet, path_to_bin);
 
-        let params = TxParameters::new(Some(1), Some(10000000), None);
-        let _result = instance.main().tx_params(params).call().await;
-        assert_eq!(_result.is_err(), false);
+        let params = TxParameters::new(Some(1), Some(10_000_000), None);
+        let result = instance.main().tx_params(params).call().await;
+        assert_eq!(result.is_err(), false);
     }
 }

--- a/tests/src/test_projects/signed_i128/tests/mod.rs
+++ b/tests/src/test_projects/signed_i128/tests/mod.rs
@@ -18,8 +18,6 @@ mod success {
 
         let params = TxParameters::new(Some(1), Some(10000000), None);
         let _result = instance.main().tx_params(params).call().await;
-        let logs = _result.as_ref().unwrap().get_logs().unwrap();
-        println!("{:#?}", logs);
         assert_eq!(_result.is_err(), false);
     }
 }

--- a/tests/src/test_projects/signed_i128/tests/mod.rs
+++ b/tests/src/test_projects/signed_i128/tests/mod.rs
@@ -16,6 +16,10 @@ mod success {
 
         let instance = Testi128::new(wallet, path_to_bin);
 
-        let _result = instance.main().call().await;
+        let params = TxParameters::new(Some(1), Some(10000000), None);
+        let _result = instance.main().tx_params(params).call().await;
+        let logs = _result.as_ref().unwrap().get_logs().unwrap();
+        println!("{:#?}", logs);
+        assert_eq!(_result.is_err(), false);
     }
 }

--- a/tests/src/test_projects/signed_i16/src/main.sw
+++ b/tests/src/test_projects/signed_i16/src/main.sw
@@ -22,5 +22,18 @@ fn main() -> bool {
     res = I16::from(10u16) / I16::from(5u16);
     assert(res == I16::from(2u16));
 
+    //flip test
+    assert(one.flip() == I16::neg_from(1));
+    //ge test
+    assert(one >= one);
+    assert(I16::from(2) >= one);
+    assert(one >= one.flip());
+    assert(one.flip() >= I16::from(2).flip());
+    //le test
+    assert(one <= one);
+    assert(one <= I16::from(2));
+    assert(one.flip() <= one);
+    assert(I16::from(2).flip() <= one.flip());
+
     true
 }

--- a/tests/src/test_projects/signed_i16/tests/mod.rs
+++ b/tests/src/test_projects/signed_i16/tests/mod.rs
@@ -16,8 +16,8 @@ mod success {
 
         let instance = Testi16::new(wallet, path_to_bin);
 
-        let params = TxParameters::new(Some(1), Some(10000000), None);
-        let _result = instance.main().tx_params(params).call().await;
-        assert_eq!(_result.is_err(), false);
+        let params = TxParameters::new(Some(1), Some(10_000_000), None);
+        let result = instance.main().tx_params(params).call().await;
+        assert_eq!(result.is_err(), false);
     }
 }

--- a/tests/src/test_projects/signed_i16/tests/mod.rs
+++ b/tests/src/test_projects/signed_i16/tests/mod.rs
@@ -16,6 +16,8 @@ mod success {
 
         let instance = Testi16::new(wallet, path_to_bin);
 
-        let _result = instance.main().call().await;
+        let params = TxParameters::new(Some(1), Some(10000000), None);
+        let _result = instance.main().tx_params(params).call().await;
+        assert_eq!(_result.is_err(), false);
     }
 }

--- a/tests/src/test_projects/signed_i256/src/main.sw
+++ b/tests/src/test_projects/signed_i256/src/main.sw
@@ -75,5 +75,24 @@ fn main() -> bool {
     res = I256::from(u128_10) / I256::from(u128_5);
     assert(res == I256::from(u128_2));
 
+    //from_u64 test
+    assert(one == I256::from_u64(1));
+    //as_u64 test
+    assert(1 == one.as_u64());
+    //flip test
+    assert(one.flip() == I256::neg_from(u128_one));
+    //ge test
+    assert(one >= one);
+    assert(I256::from_u64(2) >= one);
+    assert(one >= one.flip());
+    assert(one.flip() >= I256::from_u64(2).flip());
+    //le test
+    assert(one <= one);
+    assert(one <= I256::from_u64(2));
+    assert(one.flip() <= one);
+    assert(I256::from_u64(2).flip() <= one.flip());
+    //zero test
+    assert(I256::zero() == I256::from_u64(0));
+
     true
 }

--- a/tests/src/test_projects/signed_i256/tests/mod.rs
+++ b/tests/src/test_projects/signed_i256/tests/mod.rs
@@ -16,6 +16,8 @@ mod success {
 
         let instance = Testi256::new(wallet, path_to_bin);
 
-        let _result = instance.main().call().await;
+        let params = TxParameters::new(Some(1), Some(10000000), None);
+        let _result = instance.main().tx_params(params).call().await;
+        assert_eq!(_result.is_err(), false);
     }
 }

--- a/tests/src/test_projects/signed_i256/tests/mod.rs
+++ b/tests/src/test_projects/signed_i256/tests/mod.rs
@@ -16,8 +16,8 @@ mod success {
 
         let instance = Testi256::new(wallet, path_to_bin);
 
-        let params = TxParameters::new(Some(1), Some(10000000), None);
-        let _result = instance.main().tx_params(params).call().await;
-        assert_eq!(_result.is_err(), false);
+        let params = TxParameters::new(Some(1), Some(10_000_000), None);
+        let result = instance.main().tx_params(params).call().await;
+        assert_eq!(result.is_err(), false);
     }
 }

--- a/tests/src/test_projects/signed_i32/src/main.sw
+++ b/tests/src/test_projects/signed_i32/src/main.sw
@@ -22,5 +22,18 @@ fn main() -> bool {
     res = I32::from_uint(10u32) / I32::from_uint(5u32);
     assert(res == I32::from_uint(2u32));
 
+    //flip test
+    assert(one.flip() == I32::neg_from(1));
+    //ge test
+    assert(one >= one);
+    assert(I32::from(2) >= one);
+    assert(one >= one.flip());
+    assert(one.flip() >= I32::from(2).flip());
+    //le test
+    assert(one <= one);
+    assert(one <= I32::from(2));
+    assert(one.flip() <= one);
+    assert(I32::from(2).flip() <= one.flip());
+
     true
 }

--- a/tests/src/test_projects/signed_i32/tests/mod.rs
+++ b/tests/src/test_projects/signed_i32/tests/mod.rs
@@ -16,6 +16,8 @@ mod success {
 
         let instance = Testi32::new(wallet, path_to_bin);
 
-        let _result = instance.main().call().await;
+        let params = TxParameters::new(Some(1), Some(10000000), None);
+        let _result = instance.main().tx_params(params).call().await;
+        assert_eq!(_result.is_err(), false);
     }
 }

--- a/tests/src/test_projects/signed_i32/tests/mod.rs
+++ b/tests/src/test_projects/signed_i32/tests/mod.rs
@@ -16,8 +16,8 @@ mod success {
 
         let instance = Testi32::new(wallet, path_to_bin);
 
-        let params = TxParameters::new(Some(1), Some(10000000), None);
-        let _result = instance.main().tx_params(params).call().await;
-        assert_eq!(_result.is_err(), false);
+        let params = TxParameters::new(Some(1), Some(10_000_000), None);
+        let result = instance.main().tx_params(params).call().await;
+        assert_eq!(result.is_err(), false);
     }
 }

--- a/tests/src/test_projects/signed_i64/src/main.sw
+++ b/tests/src/test_projects/signed_i64/src/main.sw
@@ -22,5 +22,18 @@ fn main() -> bool {
     res = I64::from(10u64) / I64::from(5u64);
     assert(res == I64::from(2u64));
 
+    //flip test
+    assert(one.flip() == I64::neg_from(1));
+    //ge test
+    assert(one >= one);
+    assert(I64::from(2) >= one);
+    assert(one >= one.flip());
+    assert(one.flip() >= I64::from(2).flip());
+    //le test
+    assert(one <= one);
+    assert(one <= I64::from(2));
+    assert(one.flip() <= one);
+    assert(I64::from(2).flip() <= one.flip());
+
     true
 }

--- a/tests/src/test_projects/signed_i64/tests/mod.rs
+++ b/tests/src/test_projects/signed_i64/tests/mod.rs
@@ -16,6 +16,8 @@ mod success {
 
         let instance = Testi64::new(wallet, path_to_bin);
 
-        let _result = instance.main().call().await;
+        let params = TxParameters::new(Some(1), Some(10000000), None);
+        let _result = instance.main().tx_params(params).call().await;
+        assert_eq!(_result.is_err(), false);
     }
 }

--- a/tests/src/test_projects/signed_i64/tests/mod.rs
+++ b/tests/src/test_projects/signed_i64/tests/mod.rs
@@ -16,8 +16,8 @@ mod success {
 
         let instance = Testi64::new(wallet, path_to_bin);
 
-        let params = TxParameters::new(Some(1), Some(10000000), None);
-        let _result = instance.main().tx_params(params).call().await;
-        assert_eq!(_result.is_err(), false);
+        let params = TxParameters::new(Some(1), Some(10_000_000), None);
+        let result = instance.main().tx_params(params).call().await;
+        assert_eq!(result.is_err(), false);
     }
 }

--- a/tests/src/test_projects/signed_i8/src/main.sw
+++ b/tests/src/test_projects/signed_i8/src/main.sw
@@ -22,5 +22,18 @@ fn main() -> bool {
     res = I8::from(10u8) / I8::from(5u8);
     assert(res == I8::from(2u8));
 
+    //flip test
+    assert(one.flip() == I8::neg_from(1));
+    //ge test
+    assert(one >= one);
+    assert(I8::from(2) >= one);
+    assert(one >= one.flip());
+    assert(one.flip() >= I8::from(2).flip());
+    //le test
+    assert(one <= one);
+    assert(one <= I8::from(2));
+    assert(one.flip() <= one);
+    assert(I8::from(2).flip() <= one.flip());
+
     true
 }

--- a/tests/src/test_projects/signed_i8/tests/mod.rs
+++ b/tests/src/test_projects/signed_i8/tests/mod.rs
@@ -13,6 +13,8 @@ mod success {
 
         let instance = Testi8::new(wallet, path_to_bin);
 
-        let _result = instance.main().call().await;
+        let params = TxParameters::new(Some(1), Some(10000000), None);
+        let _result = instance.main().tx_params(params).call().await;
+        assert_eq!(_result.is_err(), false);
     }
 }

--- a/tests/src/test_projects/signed_i8/tests/mod.rs
+++ b/tests/src/test_projects/signed_i8/tests/mod.rs
@@ -13,8 +13,8 @@ mod success {
 
         let instance = Testi8::new(wallet, path_to_bin);
 
-        let params = TxParameters::new(Some(1), Some(10000000), None);
-        let _result = instance.main().tx_params(params).call().await;
-        assert_eq!(_result.is_err(), false);
+        let params = TxParameters::new(Some(1), Some(10_000_000), None);
+        let result = instance.main().tx_params(params).call().await;
+        assert_eq!(result.is_err(), false);
     }
 }


### PR DESCRIPTION
## Type of change

- Bug fix
- New feature


## Changes

The following changes have been made to I128 and I256:

- added functions 
> fn from_u64(value: u64) -> I128 
> fn as_u64(self) -> u64 
> fn flip(self) -> Self 
> fn ge(self, other: Self) -> bool 
> fn le(self, other: Self) -> bool 
> fn zero() -> I128 
- A tests
- Added check to test not to be failed

The following changes have been made to I8, I16, I32 and I64:

- added functions 
> fn flip(self) -> Self 
> fn ge(self, other: Self) -> bool 
> fn le(self, other: Self) -> bool 
- A tests
- Added check to test not to be failed

## Notes
But my tests are still failing because of the problem I have mentioned before in this topic
https://forum.fuel.network/t/cannot-use-from-uint-in-the-i128-from-sway-libs/1255

