### PR TITLE
assign return values to unused variables

### DIFF
--- a/sway_libs/src/nft/nft.sw
+++ b/sway_libs/src/nft/nft.sw
@@ -110,7 +110,7 @@ pub fn mint(amount: u64, to: Identity) {
     // Mint as many tokens as the sender has asked for
     let mut index = tokens_minted;
     while index < total_mint {
-        NFTCore::mint(to, index);
+        let _nft_core = NFTCore::mint(to, index);
         index += 1;
     }
 }
@@ -175,5 +175,5 @@ pub fn tokens_minted() -> u64 {
 pub fn transfer(to: Identity, token_id: u64) {
     let nft = get::<Option<NFTCore>>(sha256((TOKENS, token_id)));
     require(nft.is_some(), InputError::TokenDoesNotExist);
-    nft.unwrap().transfer(to);
+    let _nft_core = nft.unwrap().transfer(to);
 }


### PR DESCRIPTION
## Type of change

Apps in the `sway-applications` repo have warnings generated from return values not being assigned to anything at every build, as such:

```
warning
   --> /Users/tokamak/.forc/git/checkouts/sway_libs-44f4f3dc50c5fb6/f5539c14f16469e9103eb6c7c09e34d333c8ec5c/sway_libs/src/nft/nft.sw:113:9
    |
111 |
112 |     while index < total_mint {
113 |         NFTCore::mint(to, index);
    |         ------------------------ This returns a value of type NFTCore, which is not assigned to anything and is ignored.
114 |         index += 1;
115 |     }
    |
____

warning
   --> /Users/tokamak/.forc/git/checkouts/sway_libs-44f4f3dc50c5fb6/f5539c14f16469e9103eb6c7c09e34d333c8ec5c/sway_libs/src/nft/nft.sw:178:5
    |
176 |
177 |     require(nft.is_some(), InputError::TokenDoesNotExist);
178 |     nft.unwrap().transfer(to);
    |     ------------------------- This returns a value of type NFTCore, which is not assigned to anything and is ignored.
179 | }
    |
____
```

Omitting those would be nice.