### PR TITLE
add missing keyword 'use' in library import example

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ use sway_libs::<library_name>::<library_function>;
 For example, to import the Merkle Proof library use the following statement:
 
 ```rust
-sway_libs::binary_merkle_proof::verify_proof;
+use sway_libs::binary_merkle_proof::verify_proof;
 ```
 
 ## Running Tests


### PR DESCRIPTION
## Type of change

- Readme.md

## Changes

The following changes have been made:

- Added missing `use` keyword in the library import example code snippet in line 58.
