### PR TITLE
Two's complement for `I128` and `I256`

### DIFF
--- a/libs/signed_integers/src/i128.sw
+++ b/libs/signed_integers/src/i128.sw
@@ -208,7 +208,9 @@ impl core::ops::Subtract for I128 {
 
 impl TwosComplement for I128 {
     fn twos_complement(self) -> Self {
-        if self.underlying == Self::indent() || self.underlying > Self::indent() {
+        if self.underlying == Self::indent()
+            || self.underlying > Self::indent()
+        {
             return self;
         }
         let u_one = U128 {

--- a/libs/signed_integers/src/i128.sw
+++ b/libs/signed_integers/src/i128.sw
@@ -206,16 +206,16 @@ impl core::ops::Subtract for I128 {
     }
 }
 
-// impl TwosComplement for I128 {
-//     fn twos_complement(self) -> Self {
-//         if self.underlying == Self::indent() || self.underlying > Self::indent() {
-//             return self;
-//         }
-//         let one = I128::from(U128 {
-//             upper: 0,
-//             lower: 1,
-//         });
-//         let res = I128::from(!self.underlying) - one;
-//         res
-//     }
-// }
+impl TwosComplement for I128 {
+    fn twos_complement(self) -> Self {
+        if self.underlying == Self::indent() || self.underlying > Self::indent() {
+            return self;
+        }
+        let u_one = U128 {
+            upper: 0,
+            lower: 1,
+        };
+        let res = I128::from_uint(!self.underlying + u_one);
+        res
+    }
+}

--- a/libs/signed_integers/src/i16.sw
+++ b/libs/signed_integers/src/i16.sw
@@ -195,7 +195,7 @@ impl TwosComplement for I16 {
         if self.underlying >= Self::indent() {
             return self;
         }
-        let res = Self::from_uint(!self.underlying + 1);
+        let res = Self::from_uint(!self.underlying + 1u16);
         res
     }
 }

--- a/libs/signed_integers/src/i256.sw
+++ b/libs/signed_integers/src/i256.sw
@@ -210,7 +210,9 @@ impl core::ops::Subtract for I256 {
 
 impl TwosComplement for I256 {
     fn twos_complement(self) -> Self {
-        if self.underlying == Self::indent() || self.underlying > Self::indent() {
+        if self.underlying == Self::indent()
+            || self.underlying > Self::indent()
+        {
             return self;
         }
         let u_one = U256 {

--- a/libs/signed_integers/src/i256.sw
+++ b/libs/signed_integers/src/i256.sw
@@ -208,18 +208,18 @@ impl core::ops::Subtract for I256 {
     }
 }
 
-// impl TwosComplement for I256 {
-//     fn twos_complement(self) -> Self {
-//         if self.underlying == Self::indent() || self.underlying > Self::indent() {
-//             return self;
-//         }
-//         let one = I256::from(U256 {
-//             a: 0,
-//             b: 0,
-//             c: 0,
-//             d: 1,
-//         });
-//         let res = I256::from(!self.underlying) - one;
-//         res
-//     }
-// }
+impl TwosComplement for I256 {
+    fn twos_complement(self) -> Self {
+        if self.underlying == Self::indent() || self.underlying > Self::indent() {
+            return self;
+        }
+        let u_one = U256 {
+            a: 0,
+            b: 0,
+            c: 0,
+            d: 1,
+        };
+        let res = I256::from_uint(!self.underlying + u_one);
+        res
+    }
+}

--- a/libs/signed_integers/src/i32.sw
+++ b/libs/signed_integers/src/i32.sw
@@ -194,7 +194,7 @@ impl TwosComplement for I32 {
         if self.underlying >= Self::indent() {
             return self;
         }
-        let res = Self::from_uint(!self.underlying + 1);
+        let res = Self::from_uint(!self.underlying + 1u32);
         res
     }
 }

--- a/libs/signed_integers/src/i8.sw
+++ b/libs/signed_integers/src/i8.sw
@@ -194,7 +194,7 @@ impl TwosComplement for I8 {
         if self.underlying >= Self::indent() {
             return self;
         }
-        let res = Self::from_uint(!self.underlying + 1);
+        let res = Self::from_uint(!self.underlying + 1u8);
         res
     }
 }

--- a/tests/src/signed_integers/signed_i128_twos_complement/.gitignore
+++ b/tests/src/signed_integers/signed_i128_twos_complement/.gitignore
@@ -1,0 +1,2 @@
+out
+target

--- a/tests/src/signed_integers/signed_i128_twos_complement/Forc.toml
+++ b/tests/src/signed_integers/signed_i128_twos_complement/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "i128_twos_complement_test"
+
+[dependencies]
+signed_integers = { path = "../../../../libs/signed_integers" }

--- a/tests/src/signed_integers/signed_i128_twos_complement/mod.rs
+++ b/tests/src/signed_integers/signed_i128_twos_complement/mod.rs
@@ -1,0 +1,1 @@
+mod tests;

--- a/tests/src/signed_integers/signed_i128_twos_complement/src/main.sw
+++ b/tests/src/signed_integers/signed_i128_twos_complement/src/main.sw
@@ -1,0 +1,31 @@
+script;
+
+use signed_integers::i128::I128;
+use std::u128::U128;
+
+fn main() -> bool {
+    let u_one = U128::from((0, 1));
+    let one = I128::from(u_one);
+    let mut res = one + I128::from(U128::from((0, 1)));
+    assert(res.twos_complement() == I128::from(U128::from((0, 2))));
+
+    res = I128::from(U128::from((0, 10)));
+    assert(res.twos_complement() == I128::from(U128::from((0, 10))));
+
+    res = I128::neg_from(U128::from((0, 5)));
+    assert(res.twos_complement().underlying - u_one + res.underlying == U128::max());
+
+    res = I128::neg_from(U128::from((0, 27)));
+    assert(res.twos_complement().underlying - u_one + res.underlying == U128::max());
+
+    res = I128::neg_from(U128::from((0, 110)));
+    assert(res.twos_complement().underlying - u_one + res.underlying == U128::max());
+
+    res = I128::neg_from(U128::from((0, 93)));
+    assert(res.twos_complement().underlying - u_one + res.underlying == U128::max());
+
+    res = I128::neg_from(U128::from((0, 78)));
+    assert(res.twos_complement().underlying - u_one + res.underlying == U128::max());
+
+    true
+}

--- a/tests/src/signed_integers/signed_i128_twos_complement/tests/mod.rs
+++ b/tests/src/signed_integers/signed_i128_twos_complement/tests/mod.rs
@@ -1,0 +1,22 @@
+use fuels::prelude::{abigen, launch_provider_and_get_wallet};
+
+abigen!(Script(
+    name = "Testi128TwosComplement",
+    abi = "src/signed_integers/signed_i128_twos_complement/out/debug/i128_twos_complement_test-abi.json"
+),);
+
+mod success {
+
+    use super::*;
+
+    #[tokio::test]
+    async fn runs_i128_twos_complement_test_script() {
+        let path_to_bin =
+            "src/signed_integers/signed_i128_twos_complement/out/debug/i128_twos_complement_test.bin";
+        let wallet = launch_provider_and_get_wallet().await;
+
+        let instance = Testi128TwosComplement::new(wallet, path_to_bin);
+
+        let _result = instance.main().call().await;
+    }
+}

--- a/tests/src/signed_integers/signed_i256_twos_complement/.gitignore
+++ b/tests/src/signed_integers/signed_i256_twos_complement/.gitignore
@@ -1,0 +1,2 @@
+out
+target

--- a/tests/src/signed_integers/signed_i256_twos_complement/Forc.toml
+++ b/tests/src/signed_integers/signed_i256_twos_complement/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "i256_twos_complement_test"
+
+[dependencies]
+signed_integers = { path = "../../../../libs/signed_integers" }

--- a/tests/src/signed_integers/signed_i256_twos_complement/mod.rs
+++ b/tests/src/signed_integers/signed_i256_twos_complement/mod.rs
@@ -1,0 +1,1 @@
+mod tests;

--- a/tests/src/signed_integers/signed_i256_twos_complement/src/main.sw
+++ b/tests/src/signed_integers/signed_i256_twos_complement/src/main.sw
@@ -1,0 +1,31 @@
+script;
+
+use signed_integers::i256::I256;
+use std::u256::U256;
+
+fn main() -> bool {
+    let u_one = U256::from((0, 0, 0, 1));
+    let one = I256::from(u_one);
+    let mut res = one + I256::from(U256::from((0, 0, 0, 1)));
+    assert(res.twos_complement() == I256::from(U256::from((0, 0, 0, 2))));
+
+    res = I256::from(U256::from((0, 0, 0, 10)));
+    assert(res.twos_complement() == I256::from(U256::from((0, 0, 0, 10))));
+
+    res = I256::neg_from(U256::from((0, 0, 0, 5)));
+    assert(res.twos_complement().underlying - u_one + res.underlying == U256::max());
+
+    res = I256::neg_from(U256::from((0, 0, 0, 27)));
+    assert(res.twos_complement().underlying - u_one + res.underlying == U256::max());
+
+    res = I256::neg_from(U256::from((0, 0, 0, 110)));
+    assert(res.twos_complement().underlying - u_one + res.underlying == U256::max());
+
+    res = I256::neg_from(U256::from((0, 0, 0, 93)));
+    assert(res.twos_complement().underlying - u_one + res.underlying == U256::max());
+
+    res = I256::neg_from(U256::from((0, 0, 0, 78)));
+    assert(res.twos_complement().underlying - u_one + res.underlying == U256::max());
+
+    true
+}

--- a/tests/src/signed_integers/signed_i256_twos_complement/tests/mod.rs
+++ b/tests/src/signed_integers/signed_i256_twos_complement/tests/mod.rs
@@ -1,0 +1,22 @@
+use fuels::prelude::{abigen, launch_provider_and_get_wallet};
+
+abigen!(Script(
+    name = "Testi256TwosComplement",
+    abi = "src/signed_integers/signed_i256_twos_complement/out/debug/i256_twos_complement_test-abi.json"
+),);
+
+mod success {
+
+    use super::*;
+
+    #[tokio::test]
+    async fn runs_i256_twos_complement_test_script() {
+        let path_to_bin =
+            "src/signed_integers/signed_i256_twos_complement/out/debug/i256_twos_complement_test.bin";
+        let wallet = launch_provider_and_get_wallet().await;
+
+        let instance = Testi256TwosComplement::new(wallet, path_to_bin);
+
+        let _result = instance.main().call().await;
+    }
+}


### PR DESCRIPTION
## Type of change

<!--Delete points that do not apply-->

- New feature

## Changes

Two's complement functions for `I128` and `I256`

Fixed warnings

## Notes

- Note 1

## Related Issues

<!--Delete everything after the "#" symbol and replace it with a number. No spaces between hash and number-->

Closes #\<issue number\>
