### PR TITLE
Add fungible token abi

### DIFF
--- a/libs/frc20_abi/.gitignore
+++ b/libs/frc20_abi/.gitignore
@@ -1,0 +1,2 @@
+out
+target

--- a/libs/frc20_abi/Forc.toml
+++ b/libs/frc20_abi/Forc.toml
@@ -1,0 +1,5 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "lib.sw"
+license = "Apache-2.0"
+name = "frc20_abi"

--- a/libs/frc20_abi/src/lib.sw
+++ b/libs/frc20_abi/src/lib.sw
@@ -3,10 +3,8 @@ library frc20_abi;
 use std::u256::U256;
 
 abi FRC20 {
-    #[storage(read)]
     /// Get the total supply of the token.
-    /// MUST track all mint and burn operations.
-    /// /// /// MAY store the amount as another type (i.e: 'u64') internally.
+    #[storage(read)]
     fn total_supply() -> U256;
 
     /// Get the name of the token

--- a/libs/frc20_abi/src/lib.sw
+++ b/libs/frc20_abi/src/lib.sw
@@ -1,0 +1,22 @@
+library frc20_abi;
+
+use std::u256::U256;
+
+abi Token {
+    #[storage(read)]
+    /// Get the total supply of the token.
+    /// MUST track all mint and burn operations.
+    /// MAY store the amount as another type (i.e: 'u64') internally.
+    fn total_supply() -> U256;
+
+    /// Get the name of the token
+    /// Example (with trailing padding): "MY_TOKEN                                                        "
+    fn name() -> str[64];
+
+    /// Get the symbol of the token
+    /// Example (with trailing padding): "TKN                             "
+    fn symbol() -> str[32];
+
+    /// Get the decimals of the token
+    fn decimals() -> u8;
+}

--- a/libs/frc20_abi/src/lib.sw
+++ b/libs/frc20_abi/src/lib.sw
@@ -2,11 +2,11 @@ library frc20_abi;
 
 use std::u256::U256;
 
-abi Token {
+abi FRC20 {
     #[storage(read)]
     /// Get the total supply of the token.
     /// MUST track all mint and burn operations.
-    /// MAY store the amount as another type (i.e: 'u64') internally.
+    /// /// /// MAY store the amount as another type (i.e: 'u64') internally.
     fn total_supply() -> U256;
 
     /// Get the name of the token


### PR DESCRIPTION
## Type of change

<!--Delete points that do not apply-->

- New feature

## Changes

The following changes have been made:

- Added the base abi for a fungible token on Fuel

## Notes

- authors: this manifest field could have additional entries for significant contributors?
- name: SRC20 was also suggested. I went with FRC20 initially as it seems to be common to use the network name rather than the Language name  (i.e: ERC20 uses the "E" from Ethereum, cosmos has the ICS-20 standard, etc.)

