### PR TITLE
Add Storage Read and Writes for NFT

### DIFF
--- a/libs/nft/src/extensions/administrator/administrator.sw
+++ b/libs/nft/src/extensions/administrator/administrator.sw
@@ -16,6 +16,10 @@ abi Administrator {
 }
 
 /// Returns the administrator for the library.
+///
+/// # Number of Storage Accesses
+///
+/// * Reads: `1`
 #[storage(read)]
 pub fn admin() -> Option<Identity> {
     get::<Option<Identity>>(ADMIN).unwrap_or(Option::None)
@@ -26,6 +30,11 @@ pub fn admin() -> Option<Identity> {
 /// # Arguments
 ///
 /// * `admin` - The user which is to be set as the new admin.
+///
+/// # Number of Storage Accesses
+///
+/// * Reads: `1`
+/// * Writes: `1`
 ///
 /// # Reverts
 ///

--- a/libs/nft/src/extensions/burnable/burnable.sw
+++ b/libs/nft/src/extensions/burnable/burnable.sw
@@ -42,6 +42,11 @@ impl Burnable for NFTCore {
 ///
 /// * `token_id` - The id of the token to burn.
 ///
+/// # Number of Storage Accesses
+///
+/// * Reads: `1`
+/// * Writes: `2`
+///
 /// # Reverts
 ///
 /// * When the `token_id` specified does not map to an existing token.

--- a/libs/nft/src/extensions/supply/supply.sw
+++ b/libs/nft/src/extensions/supply/supply.sw
@@ -16,6 +16,10 @@ abi Supply {
 }
 
 /// Returns the maximum supply that has been set for the NFT library.
+///
+/// # Number of Storage Accesses
+///
+/// * Reads: `1`
 #[storage(read)]
 pub fn max_supply() -> Option<u64> {
     get::<Option<u64>>(MAX_SUPPLY).unwrap_or(Option::None)
@@ -26,6 +30,11 @@ pub fn max_supply() -> Option<u64> {
 /// # Arguments
 ///
 /// * `supply` - The maximum number fo tokens which may be minted
+///
+/// # Number of Storage Accesses
+///
+/// * Reads: `1`
+/// * Writes: `1`
 ///
 /// # Reverts
 ///

--- a/libs/nft/src/extensions/token_metadata/token_metadata.sw
+++ b/libs/nft/src/extensions/token_metadata/token_metadata.sw
@@ -7,36 +7,32 @@ use ::{errors::InputError, nft_core::NFTCore, nft_storage::{TOKEN_METADATA, TOKE
 use std::{hash::sha256, storage::{get, store}};
 
 pub trait TokenMetadata<T> {
-    /// Returns the metadata for this token
-    #[storage(read)]
     fn token_metadata(self) -> Option<T>;
-
-    /// Creates new metadata for this token.
-    ///
-    /// # Arguments
-    ///
-    /// * `token_metadata` - The new metadata to overwrite the existing metadata.
-    #[storage(write)]
     fn set_token_metadata(self, token_metadata: Option<T>);
 }
-
-impl<T> TokenMetadata<T> for NFTCore {
+impl<T> TokenMetadata<T>
+ for NFTCore {
     #[storage(read)]
     fn token_metadata(self) -> Option<T> {
         get::<Option<T>>(sha256((TOKEN_METADATA, self.token_id))).unwrap_or(Option::None)
     }
-
     #[storage(write)]
-    fn set_token_metadata(self, token_metadata: Option<T>) {
+    fn set_token_metadata(self, token_metadata: Option<T>)
+ {
         store(sha256((TOKEN_METADATA, self.token_id)), token_metadata);
     }
 }
-
 /// Returns the metadata for a specific token.
 ///
 /// # Arguments
 ///
+
 /// * `token_id` - The id of the token which the metadata should be returned
+///
+/// # Number of Storage Accesses
+///
+
+/// * Reads: `2`
 #[storage(read)]
 pub fn token_metadata<T>(token_id: u64) -> Option<T> {
     let nft = get::<Option<NFTCore>>(sha256((TOKENS, token_id))).unwrap_or(Option::None);
@@ -49,13 +45,18 @@ pub fn token_metadata<T>(token_id: u64) -> Option<T> {
         }
     }
 }
-
 /// Sets the metadata for the specified token.
 ///
 /// # Arguments
 ///
 /// * `token_metadata` - The metadata which should be set.
 /// * `token_id` - The token which the metadata should be set for.
+///
+/// # Number of Storage Accesses
+
+///
+/// * Reads: `1`
+/// * Writes: `1`
 ///
 /// # Reverts
 ///
@@ -64,6 +65,5 @@ pub fn token_metadata<T>(token_id: u64) -> Option<T> {
 pub fn set_token_metadata<T>(token_metadata: Option<T>, token_id: u64) {
     let nft = get::<Option<NFTCore>>(sha256((TOKENS, token_id))).unwrap_or(Option::None);
     require(nft.is_some(), InputError::TokenDoesNotExist);
-
     nft.unwrap().set_token_metadata(token_metadata);
 }

--- a/libs/nft/src/extensions/token_metadata/token_metadata.sw
+++ b/libs/nft/src/extensions/token_metadata/token_metadata.sw
@@ -7,31 +7,39 @@ use ::{errors::InputError, nft_core::NFTCore, nft_storage::{TOKEN_METADATA, TOKE
 use std::{hash::sha256, storage::{get, store}};
 
 pub trait TokenMetadata<T> {
+    /// Returns the metadata for this token
+    #[storage(read)]
     fn token_metadata(self) -> Option<T>;
+
+    /// Creates new metadata for this token.
+    ///
+    /// # Arguments
+    ///
+    /// * `token_metadata` - The new metadata to overwrite the existing metadata.
+    #[storage(write)]
     fn set_token_metadata(self, token_metadata: Option<T>);
 }
-impl<T> TokenMetadata<T>
- for NFTCore {
+
+impl<T> TokenMetadata<T> for NFTCore {
     #[storage(read)]
     fn token_metadata(self) -> Option<T> {
         get::<Option<T>>(sha256((TOKEN_METADATA, self.token_id))).unwrap_or(Option::None)
     }
+
     #[storage(write)]
-    fn set_token_metadata(self, token_metadata: Option<T>)
- {
+    fn set_token_metadata(self, token_metadata: Option<T>) {
         store(sha256((TOKEN_METADATA, self.token_id)), token_metadata);
     }
 }
+
 /// Returns the metadata for a specific token.
 ///
 /// # Arguments
 ///
-
 /// * `token_id` - The id of the token which the metadata should be returned
 ///
 /// # Number of Storage Accesses
 ///
-
 /// * Reads: `2`
 #[storage(read)]
 pub fn token_metadata<T>(token_id: u64) -> Option<T> {
@@ -45,6 +53,7 @@ pub fn token_metadata<T>(token_id: u64) -> Option<T> {
         }
     }
 }
+
 /// Sets the metadata for the specified token.
 ///
 /// # Arguments
@@ -53,7 +62,6 @@ pub fn token_metadata<T>(token_id: u64) -> Option<T> {
 /// * `token_id` - The token which the metadata should be set for.
 ///
 /// # Number of Storage Accesses
-
 ///
 /// * Reads: `1`
 /// * Writes: `1`
@@ -65,5 +73,6 @@ pub fn token_metadata<T>(token_id: u64) -> Option<T> {
 pub fn set_token_metadata<T>(token_metadata: Option<T>, token_id: u64) {
     let nft = get::<Option<NFTCore>>(sha256((TOKENS, token_id))).unwrap_or(Option::None);
     require(nft.is_some(), InputError::TokenDoesNotExist);
+
     nft.unwrap().set_token_metadata(token_metadata);
 }

--- a/libs/nft/src/lib.sw
+++ b/libs/nft/src/lib.sw
@@ -46,6 +46,11 @@ abi NFT {
 /// * `approved` - The user which will be allowed to transfer the token on the owner's behalf.
 /// * `token_id` - The unique identifier of the token which the owner is giving approval for.
 ///
+/// # Number of Storage Accesses
+///
+/// * Reads: `1`
+/// * Writes: `1`
+///
 /// # Reverts
 ///
 /// * When `token_id` does not map to an existing token.
@@ -61,6 +66,10 @@ pub fn approve(approved: Option<Identity>, token_id: u64) {
 /// # Arguments
 ///
 /// * `token_id` - The unique identifier of the token which the approved user should be returned.
+///
+/// # Number of Storage Accesses
+///
+/// * Reads: `1`
 #[storage(read)]
 pub fn approved(token_id: u64) -> Option<Identity> {
     let nft = get::<Option<NFTCore>>(sha256((TOKENS, token_id))).unwrap_or(Option::None);
@@ -80,6 +89,10 @@ pub fn approved(token_id: u64) -> Option<Identity> {
 /// # Arguments
 ///
 /// * `owner` - The user of which the balance should be returned.
+///
+/// # Number of Storage Accesses
+///
+/// * Reads: `1`
 #[storage(read)]
 pub fn balance_of(owner: Identity) -> u64 {
     get::<u64>(sha256((BALANCES, owner))).unwrap_or(0)
@@ -91,6 +104,10 @@ pub fn balance_of(owner: Identity) -> u64 {
 ///
 /// * `operator` - The user which may or may not transfer all tokens on the `owner`s behalf.
 /// * `owner` - The user which may or may not have given approval to transfer all tokens.
+///
+/// # Number of Storage Accesses
+///
+/// * Reads: `1`
 #[storage(read)]
 pub fn is_approved_for_all(operator: Identity, owner: Identity) -> bool {
     get::<bool>(sha256((OPERATOR_APPROVAL, owner, operator))).unwrap_or(false)
@@ -102,6 +119,11 @@ pub fn is_approved_for_all(operator: Identity, owner: Identity) -> bool {
 ///
 /// * `amount` - The number of tokens to be minted in this transaction.
 /// * `to` - The user which will own the minted tokens.
+///
+/// # Number of Storage Accesses
+///
+/// * Reads: `n + 1`
+/// * Writes: `3n`
 #[storage(read, write)]
 pub fn mint(amount: u64, to: Identity) {
     let tokens_minted = get::<u64>(TOKENS_MINTED).unwrap_or(0);
@@ -120,6 +142,10 @@ pub fn mint(amount: u64, to: Identity) {
 /// # Arguments
 ///
 /// * `token_id` - The unique identifier of the token.
+///
+/// # Number of Storage Accesses
+///
+/// * Reads: `1`
 #[storage(read)]
 pub fn owner_of(token_id: u64) -> Option<Identity> {
     let nft = get::<Option<NFTCore>>(sha256((TOKENS, token_id))).unwrap_or(Option::None);
@@ -143,6 +169,10 @@ pub fn owner_of(token_id: u64) -> Option<Identity> {
 ///
 /// * `approve` - Represents whether the user is giving or revoking operator status.
 /// * `operator` - The user which may or may not transfer all tokens on the sender's behalf.
+///
+/// # Number of Storage Accesses
+///
+/// * Writes: `1`
 #[storage(write)]
 pub fn set_approval_for_all(approve: bool, operator: Identity) {
     let sender = msg_sender().unwrap();
@@ -156,6 +186,10 @@ pub fn set_approval_for_all(approve: bool, operator: Identity) {
 }
 
 /// Returns the total number of tokens that have been minted.
+///
+/// # Number of Storage Accesses
+///
+/// * Reads: `1`
 #[storage(read)]
 pub fn tokens_minted() -> u64 {
     get::<u64>(TOKENS_MINTED).unwrap_or(0)
@@ -167,6 +201,11 @@ pub fn tokens_minted() -> u64 {
 ///
 /// * `to` - The user which the ownership of the token should be set to.
 /// * `token_id` - The unique identifier of the token which should be transfered.
+///
+/// # Number of Storage Accesses
+///
+/// * Reads: `4`
+/// * Writes: `3`
 ///
 /// # Reverts
 ///

--- a/libs/nft/src/nft_core.sw
+++ b/libs/nft/src/nft_core.sw
@@ -24,6 +24,10 @@ impl NFTCore {
     ///
     /// * `approved` - The user which will be allowed to transfer the token on the owner's behalf.
     ///
+    /// # Number of Storage Accesses
+    ///
+    /// * Writes: `1`
+    ///
     /// # Reverts
     ///
     /// * When the sender is not the token's owner.
@@ -54,6 +58,10 @@ impl NFTCore {
     /// # Arguments
     ///
     /// * `operator` - The user which may or may not transfer all tokens on the owner`s behalf.
+    ///
+    /// # Number of Storage Accesses
+    ///
+    /// * Reads: `1`
     #[storage(read)]
     pub fn is_approved_for_all(self, operator: Identity) -> bool {
         get::<bool>(sha256((OPERATOR_APPROVAL, self.owner, operator))).unwrap_or(false)
@@ -65,6 +73,11 @@ impl NFTCore {
     ///
     /// * `to` - The user which will own the minted token.
     /// * `token_id` - The id the new token will have.
+    ///
+    /// # Number of Storage Accesses
+    ///
+    /// * Reads: `1`
+    /// * Writes: `3`
     ///
     /// # Reverts
     ///
@@ -106,6 +119,10 @@ impl NFTCore {
     /// * `approve` - Represents whether the user is giving or revoking operator status.
     /// * `operator` - The user which may or may not transfer all tokens on this owner's behalf.
     ///
+    /// # Number of Storage Accesses
+    ///
+    /// * Writes: `1`
+    ///
     /// # Reverts
     ///
     /// * When the sender is not the owner of this token
@@ -133,6 +150,11 @@ impl NFTCore {
     /// # Arguments
     ///
     /// * `to` - The user which the ownership of this token should be set to.
+    ///
+    /// # Number of Storage Accesses
+    ///
+    /// * Reads: `3`
+    /// * Writes: `3`
     ///
     /// # Reverts
     ///


### PR DESCRIPTION
## Type of change

<!--Delete points that do not apply-->

- Documentation

## Changes

The following changes have been made:

- Added storage read and writes for all NFT core, lib, and extension functions


## Related Issues

<!--Delete everything after the "#" symbol and replace it with a number. No spaces between hash and number-->

Closes #120 
