### PR TITLE
Reimplement `append()` for `String` type

### DIFF
--- a/libs/string/src/lib.sw
+++ b/libs/string/src/lib.sw
@@ -138,15 +138,15 @@ impl From<Bytes> for String {
 }
 
 impl String {
-    // Uncomment when https://github.com/FuelLabs/sway/issues/4158 is resolved
     /// Moves all elements of the `other` String into `self`, leaving `other` empty.
     ///
     /// # Arguments
     ///
     /// * `other` - The String to join to self.
-    // pub fn append(ref mut self, mut other: self) {
-    //     self.bytes.append(other.into())
-    // }
+    pub fn append(ref mut self, mut other: self) {
+        self.bytes.append(other.into())
+    }
+
     /// Divides one Bytes into two at an index.
     ///
     /// # Arguments

--- a/tests/src/string/src/main.sw
+++ b/tests/src/string/src/main.sw
@@ -37,7 +37,7 @@ abi StringTest {
 
 impl StringTest for Contract {
     fn test_append() {
-        // Uncomment when https://github.com/FuelLabs/sway/issues/4158 is resolved.
+        // Uncomment when https://github.com/FuelLabs/sway/issues/4408 is resolved.
         // let mut string1 = String::new();
         // let mut string2 = String::new();
         // string1.push(NUMBER0);


### PR DESCRIPTION
## Type of change

<!--Delete points that do not apply-->

- Improvement (refactoring, restructuring repository, cleaning tech debt, ...)

## Changes

The following changes have been made:

- Uncommented `append()` as https://github.com/FuelLabs/sway/issues/4158 has been resolved

## Notes

- Due to https://github.com/FuelLabs/sway/issues/4408 the tests are still commented out

## Related Issues

<!--Delete everything after the "#" symbol and replace it with a number. No spaces between hash and number-->

Closes #101 
