### PR TITLE
Bump libraries that use storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ These libraries contain helper functions, generalized standards, and other tools
 - [Reentrancy](./libs/reentrancy) is used to detect and prevent reentrancy attacks.
 - [Signed Integers](./libs/signed_integers/) is an interface to implement signed integers.
 - [String](./libs/strings/string/) is an interface to implement dynamic length strings that are UTF-8 encoded.
-- [StorageMapVec](./libs/storagemapvec/) is a temporary workaround for a StorageMap<K, StorageVec<V>> type.
 - [StorageString](./libs/strings/storage_string/) is used to store dynamic length strings that are UTF-8 encoded in storage.
 - [Fixed Point Number](./libs/fixed_point/) is an interface to implement fixed-point numbers.
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
     <a href="https://github.com/FuelLabs/sway-libs/actions/workflows/ci.yml" alt="CI">
         <img src="https://github.com/FuelLabs/sway-libs/actions/workflows/ci.yml/badge.svg" />
     </a>
-    <a href="https://crates.io/crates/forc/0.37.0" alt="forc">
-        <img src="https://img.shields.io/badge/forc-v0.37.0-orange" />
+    <a href="https://crates.io/crates/forc/0.38.0" alt="forc">
+        <img src="https://img.shields.io/badge/forc-v0.38.0-orange" />
     </a>
     <a href="./LICENSE" alt="forc">
         <img src="https://img.shields.io/github/license/FuelLabs/sway-libs" />
@@ -87,7 +87,7 @@ cargo test
 Any instructions related to using a specific library should be found within the README.md of that library.
 
 > **Note**
-> All projects currently use `forc v0.37.0`, `fuels-rs v0.41.0` and `fuel-core 0.17.8`.
+> All projects currently use `forc v0.38.0`, `fuels-rs v0.41.0` and `fuel-core 0.17.8`.
 
 ## Contributing
 

--- a/libs/nft/src/extensions/administrator.sw
+++ b/libs/nft/src/extensions/administrator.sw
@@ -6,7 +6,7 @@ mod administrator_events;
 use administrator_errors::AdminError;
 use administrator_events::AdminEvent;
 use ::nft_core::nft_storage::ADMIN;
-use std::{auth::msg_sender, storage::{get, store}};
+use std::{auth::msg_sender, storage::storage_api::{read, write}};
 
 abi Administrator {
     #[storage(read)]
@@ -22,7 +22,7 @@ abi Administrator {
 /// * Reads: `1`
 #[storage(read)]
 pub fn admin() -> Option<Identity> {
-    get::<Option<Identity>>(ADMIN).unwrap_or(Option::None)
+    read::<Option<Identity>>(ADMIN, 0).unwrap_or(Option::None)
 }
 
 /// Changes the library's administrator.
@@ -42,10 +42,10 @@ pub fn admin() -> Option<Identity> {
 /// * When the sender is not the `admin` in storage.
 #[storage(read, write)]
 pub fn set_admin(new_admin: Option<Identity>) {
-    let admin = get::<Option<Identity>>(ADMIN).unwrap_or(Option::None);
+    let admin = read::<Option<Identity>>(ADMIN, 0).unwrap_or(Option::None);
     require(admin.is_none() || (admin.is_some() && admin.unwrap() == msg_sender().unwrap()), AdminError::SenderNotAdmin);
 
-    store(ADMIN, new_admin);
+    write(ADMIN, 0, new_admin);
 
     log(AdminEvent {
         admin: new_admin,

--- a/libs/nft/src/extensions/supply.sw
+++ b/libs/nft/src/extensions/supply.sw
@@ -4,7 +4,7 @@ mod supply_errors;
 mod supply_events;
 
 use ::nft_core::nft_storage::MAX_SUPPLY;
-use std::storage::{get, store};
+use std::storage::storage_api::{read, write};
 use supply_errors::SupplyError;
 use supply_events::SupplyEvent;
 
@@ -22,7 +22,7 @@ abi Supply {
 /// * Reads: `1`
 #[storage(read)]
 pub fn max_supply() -> Option<u64> {
-    get::<Option<u64>>(MAX_SUPPLY).unwrap_or(Option::None)
+    read::<Option<u64>>(MAX_SUPPLY, 0).unwrap_or(Option::None)
 }
 
 /// Sets the maximum supply for the NFT library.
@@ -41,10 +41,10 @@ pub fn max_supply() -> Option<u64> {
 /// * When the supply has already been set
 #[storage(read, write)]
 pub fn set_max_supply(supply: Option<u64>) {
-    let current_supply = get::<Option<u64>>(MAX_SUPPLY).unwrap_or(Option::None);
+    let current_supply = read::<Option<u64>>(MAX_SUPPLY, 0).unwrap_or(Option::None);
     require(current_supply.is_none(), SupplyError::CannotReinitializeSupply);
 
-    store(MAX_SUPPLY, supply);
+    write(MAX_SUPPLY, 0, supply);
 
     log(SupplyEvent { supply });
 }

--- a/libs/nft/src/lib.sw
+++ b/libs/nft/src/lib.sw
@@ -15,7 +15,7 @@ use nft_core::{
     },
     NFTCore,
 };
-use std::{auth::msg_sender, hash::sha256, storage::{get, store}};
+use std::{auth::msg_sender, hash::sha256, storage::storage_api::{read, write}};
 
 abi NFT {
     #[storage(read, write)]
@@ -57,7 +57,7 @@ abi NFT {
 /// * When `token_id` does not map to an existing token.
 #[storage(read, write)]
 pub fn approve(approved: Option<Identity>, token_id: u64) {
-    let mut nft = get::<Option<NFTCore>>(sha256((TOKENS, token_id))).unwrap_or(Option::None);
+    let mut nft = read::<Option<NFTCore>>(sha256((TOKENS, token_id)), 0).unwrap_or(Option::None);
     require(nft.is_some(), InputError::TokenDoesNotExist);
     nft.unwrap().approve(approved);
 }
@@ -73,7 +73,7 @@ pub fn approve(approved: Option<Identity>, token_id: u64) {
 /// * Reads: `1`
 #[storage(read)]
 pub fn approved(token_id: u64) -> Option<Identity> {
-    let nft = get::<Option<NFTCore>>(sha256((TOKENS, token_id))).unwrap_or(Option::None);
+    let nft = read::<Option<NFTCore>>(sha256((TOKENS, token_id)), 0).unwrap_or(Option::None);
 
     match nft {
         Option::Some(nft) => {
@@ -96,7 +96,7 @@ pub fn approved(token_id: u64) -> Option<Identity> {
 /// * Reads: `1`
 #[storage(read)]
 pub fn balance_of(owner: Identity) -> u64 {
-    get::<u64>(sha256((BALANCES, owner))).unwrap_or(0)
+    read::<u64>(sha256((BALANCES, owner)), 0).unwrap_or(0)
 }
 
 /// Returns whether the `operator` user is approved to transfer all tokens on behalf of the `owner`.
@@ -111,7 +111,7 @@ pub fn balance_of(owner: Identity) -> u64 {
 /// * Reads: `1`
 #[storage(read)]
 pub fn is_approved_for_all(operator: Identity, owner: Identity) -> bool {
-    get::<bool>(sha256((OPERATOR_APPROVAL, owner, operator))).unwrap_or(false)
+    read::<bool>(sha256((OPERATOR_APPROVAL, owner, operator)), 0).unwrap_or(false)
 }
 
 /// Mints `amount` number of tokens to the specified user.
@@ -127,7 +127,7 @@ pub fn is_approved_for_all(operator: Identity, owner: Identity) -> bool {
 /// * Writes: `3n`
 #[storage(read, write)]
 pub fn mint(amount: u64, to: Identity) {
-    let tokens_minted = get::<u64>(TOKENS_MINTED).unwrap_or(0);
+    let tokens_minted = read::<u64>(TOKENS_MINTED, 0).unwrap_or(0);
     let total_mint = tokens_minted + amount;
 
     // Mint as many tokens as the sender has asked for
@@ -149,7 +149,7 @@ pub fn mint(amount: u64, to: Identity) {
 /// * Reads: `1`
 #[storage(read)]
 pub fn owner_of(token_id: u64) -> Option<Identity> {
-    let nft = get::<Option<NFTCore>>(sha256((TOKENS, token_id))).unwrap_or(Option::None);
+    let nft = read::<Option<NFTCore>>(sha256((TOKENS, token_id)), 0).unwrap_or(Option::None);
 
     match nft {
         Option::Some(nft) => {
@@ -177,7 +177,7 @@ pub fn owner_of(token_id: u64) -> Option<Identity> {
 #[storage(write)]
 pub fn set_approval_for_all(approve: bool, operator: Identity) {
     let sender = msg_sender().unwrap();
-    store(sha256((OPERATOR_APPROVAL, sender, operator)), approve);
+    write(sha256((OPERATOR_APPROVAL, sender, operator)), 0, approve);
 
     log(OperatorEvent {
         approved: approve,
@@ -193,7 +193,7 @@ pub fn set_approval_for_all(approve: bool, operator: Identity) {
 /// * Reads: `1`
 #[storage(read)]
 pub fn tokens_minted() -> u64 {
-    get::<u64>(TOKENS_MINTED).unwrap_or(0)
+    read::<u64>(TOKENS_MINTED, 0).unwrap_or(0)
 }
 
 /// Transfers ownership of the specified token to another user.
@@ -213,7 +213,7 @@ pub fn tokens_minted() -> u64 {
 /// * When the `token_id` does not map to an existing token.
 #[storage(read, write)]
 pub fn transfer(to: Identity, token_id: u64) {
-    let nft = get::<Option<NFTCore>>(sha256((TOKENS, token_id))).unwrap_or(Option::None);
+    let nft = read::<Option<NFTCore>>(sha256((TOKENS, token_id)), 0).unwrap_or(Option::None);
     require(nft.is_some(), InputError::TokenDoesNotExist);
     let _ = nft.unwrap().transfer(to);
 }

--- a/libs/nft/src/nft_core.sw
+++ b/libs/nft/src/nft_core.sw
@@ -93,7 +93,7 @@ impl NFTCore {
         };
 
         write(sha256((TOKENS, token_id)), 0, Option::Some(nft));
-        write(TOKENS_MINTED, 0, read::<u64>(TOKENS_MINTED, 0).unwrap_or(0) + 1,);
+        write(TOKENS_MINTED, 0, read::<u64>(TOKENS_MINTED, 0).unwrap_or(0) + 1);
         write(sha256((BALANCES, to)), 0, read::<u64>(sha256((BALANCES, to)), 0).unwrap_or(0) + 1);
 
         log(MintEvent {

--- a/libs/ownership/src/ownable.sw
+++ b/libs/ownership/src/ownable.sw
@@ -10,14 +10,14 @@ use events::{OwnershipRenounced, OwnershipSet, OwnershipTransferred};
 use std::{auth::msg_sender, hash::sha256, storage::storage_api::{read, write}};
 
 pub struct Ownership {
-    owner: State
+    owner: State,
 }
 
 impl Ownership {
     /// Returns the `Ownership` struct in the `Uninitalized` state.
     pub fn uninitialized() -> Self {
         Self {
-            owner: State::Uninitialized
+            owner: State::Uninitialized,
         }
     }
 
@@ -28,14 +28,14 @@ impl Ownership {
     /// * `identity` - The `Identity` which ownership is set to.
     pub fn initialized(identity: Identity) -> Self {
         Self {
-            owner: State::Initialized(identity)
+            owner: State::Initialized(identity),
         }
     }
 
     /// Returns the `Ownership` struct in the `Revoked` state.
     pub fn revoked() -> Self {
         Self {
-            owner: State::Revoked
+            owner: State::Revoked,
         }
     }
 }
@@ -55,7 +55,7 @@ impl StorageKey<Ownership> {
     /// storage {
     ///     owner: Ownership = Ownership::initalized(Identity::Address(Address::from(ZERO_B256))),
     /// }
-    /// 
+    ///
     /// fn foo() {
     ///     let stored_owner = storage.owner.owner();
     /// }
@@ -81,7 +81,7 @@ impl StorageKey<Ownership> {
     ///
     /// ```sway
     /// use ownable::Ownership;
-    /// 
+    ///
     /// storage {
     ///     owner: Ownership = Ownership::initalized(Identity::Address(Address::from(ZERO_B256))),
     /// }
@@ -113,7 +113,7 @@ impl StorageKey<Ownership> {
     ///
     /// ```sway
     /// use ownable::Ownership;
-    /// 
+    ///
     /// storage {
     ///     owner: Ownership = Ownership::initalized(Identity::Address(Address::from(ZERO_B256))),
     /// }
@@ -154,7 +154,7 @@ impl StorageKey<Ownership> {
     /// storage {
     ///     owner: Ownership = Ownership::uninitialized(),
     /// }
-    /// 
+    ///
     /// fn foo(owner: Identity) {
     ///     assert(storage.owner.owner() == State::Uninitialized);
     ///     storage.owner.set_ownership(owner);
@@ -185,7 +185,7 @@ impl StorageKey<Ownership> {
     ///
     /// ```sway
     /// use ownable::Ownership;
-    /// 
+    ///
     /// storage {
     ///     owner: Ownership = OwnershipOwnership::initalized(Identity::Address(Address::from(ZERO_B256))),
     /// }

--- a/libs/ownership/src/ownable.sw
+++ b/libs/ownership/src/ownable.sw
@@ -3,155 +3,180 @@ library;
 mod data_structures;
 mod errors;
 mod events;
-mod ownable_storage;
 
 use data_structures::State;
 use errors::AccessError;
 use events::{OwnershipRenounced, OwnershipSet, OwnershipTransferred};
-use ownable_storage::OWNER;
-use std::{auth::msg_sender, hash::sha256, storage::{get, store}};
+use std::{auth::msg_sender, hash::sha256, storage::storage_api::{read, write}};
 
-/// Ensures that the sender is the owner.
-///
-/// # Number of Storage Accesses
-///
-/// * Reads: `1`
-///
-/// # Reverts
-///
-/// * When the sender is not the owner.
-///
-/// # Examples
-///
-/// ```sway
-/// use ownable::only_owner;
-///
-/// fn foo() {
-///     only_owner();
-///     // Do stuff here
-/// }
-/// ```
-#[storage(read)]
-pub fn only_owner() {
-    let owner = get::<State>(OWNER).unwrap_or(State::Uninitialized);
-    require(State::Initialized(msg_sender().unwrap()) == owner, AccessError::NotOwner);
+pub struct Ownership {}
+
+impl StorageKey<Ownership> {
+    /// Returns the owner.
+    ///
+    /// # Number of Storage Accesses
+    ///
+    /// * Reads: `1`
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use ownable::Ownership;
+    ///
+    /// storage {
+    ///     owner: Ownership = Ownership {},
+    /// }
+    /// 
+    /// fn foo() {
+    ///     let stored_owner = storage.owner.owner();
+    /// }
+    /// ```
+    #[storage(read)]
+    pub fn owner(self) -> State {
+        read::<State>(self.slot, 0).unwrap_or(State::Uninitialized)
+    }
 }
 
-/// Returns the owner.
-///
-/// # Number of Storage Accesses
-///
-/// * Reads: `1`
-///
-/// # Examples
-///
-/// ```sway
-/// use ownable::owner;
-///
-/// fn foo() {
-///     let stored_owner = owner();
-/// }
-/// ```
-#[storage(read)]
-pub fn owner() -> State {
-    get::<State>(OWNER).unwrap_or(State::Uninitialized)
+impl StorageKey<Ownership> {
+    /// Ensures that the sender is the owner.
+    ///
+    /// # Number of Storage Accesses
+    ///
+    /// * Reads: `1`
+    ///
+    /// # Reverts
+    ///
+    /// * When the sender is not the owner.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use ownable::Ownership;
+    /// 
+    /// storage {
+    ///     owner: Ownership = Ownership {},
+    /// }
+    ///
+    /// fn foo() {
+    ///     storage.owner.only_owner();
+    ///     // Do stuff here
+    /// }
+    /// ```
+    #[storage(read)]
+    pub fn only_owner(self) {
+        require(self.owner() == State::Initialized(msg_sender().unwrap()), AccessError::NotOwner);
+    }
 }
 
-/// Revokes ownership of the current owner and disallows any new owners.
-///
-/// # Number of Storage Accesses
-///
-/// * Reads: `1`
-/// * Writes: `1`
-///
-/// # Reverts
-///
-/// * When the sender is not the owner.
-///
-/// # Examples
-///
-/// ```sway
-/// use ownable::{owner, renounce_ownership, set_ownership};
-///
-/// fn foo(owner: Identity) {
-///     set_ownership(owner);
-///     assert(owner() == State::Initialized(owner));
-///     renounce_ownership();
-///     assert(owner() == State::Revoked);
-/// }
-/// ```
-#[storage(read, write)]
-pub fn renounce_ownership() {
-    only_owner();
+impl StorageKey<Ownership> {
+    /// Revokes ownership of the current owner and disallows any new owners.
+    ///
+    /// # Number of Storage Accesses
+    ///
+    /// * Reads: `1`
+    /// * Writes: `1`
+    ///
+    /// # Reverts
+    ///
+    /// * When the sender is not the owner.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use ownable::Ownership;
+    /// 
+    /// storage {
+    ///     owner: Ownership = Ownership {},
+    /// }
+    ///
+    /// fn foo(owner: Identity) {
+    ///     storage.owner.set_ownership(owner);
+    ///     assert(storage.owner.owner() == State::Initialized(owner));
+    ///     storage.owner.renounce_ownership();
+    ///     assert(storage.owner.owner() == State::Revoked);
+    /// }
+    /// ```
+    #[storage(read, write)]
+    pub fn renounce_ownership(self) {
+        self.only_owner();
 
-    store(OWNER, State::Revoked);
+        write(self.slot, 0, State::Revoked);
 
-    log(OwnershipRenounced {
-        previous_owner: msg_sender().unwrap(),
-    });
-}
+        log(OwnershipRenounced {
+            previous_owner: msg_sender().unwrap(),
+        });
+    }
 
-/// Sets the passed identity as the initial owner.
-///
-/// # Number of Storage Acesses
-///
-/// * Reads: `1`
-/// * Write: `1`
-///
-/// # Reverts
-///
-/// * When ownership has been set before.
-///
-/// # Examples
-///
-/// ```sway
-/// use ownable::set_ownership;
-///
-/// fn foo(owner: Identity) {
-///     assert(owner() == State::Uninitialized);
-///     set_ownership(owner);
-///     assert(owner() == State::Initialized(owner));
-/// }
-/// ```
-#[storage(read, write)]
-pub fn set_ownership(new_owner: Identity) {
-    require(get::<State>(OWNER).unwrap_or(State::Uninitialized) == State::Uninitialized, AccessError::CannotReinitialized);
+    /// Sets the passed identity as the initial owner.
+    ///
+    /// # Number of Storage Acesses
+    ///
+    /// * Reads: `1`
+    /// * Write: `1`
+    ///
+    /// # Reverts
+    ///
+    /// * When ownership has been set before.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use ownable::Ownership;
+    ///
+    /// storage {
+    ///     owner: Ownership = Ownership {},
+    /// }
+    /// 
+    /// fn foo(owner: Identity) {
+    ///     assert(storage.owner.owner() == State::Uninitialized);
+    ///     storage.owner.set_ownership(owner);
+    ///     assert(storage.owner.owner() == State::Initialized(owner));
+    /// }
+    /// ```
+    #[storage(read, write)]
+    pub fn set_ownership(self, new_owner: Identity) {
+        require(self.owner() == State::Uninitialized, AccessError::CannotReinitialized);
 
-    store(OWNER, State::Initialized(new_owner));
+        write(self.slot, 0, State::Initialized(new_owner));
 
-    log(OwnershipSet { new_owner });
-}
+        log(OwnershipSet { new_owner });
+    }
 
-/// Transfers ownership to the passed identity.
-///
-/// # Number of Storage Acesses
-///
-/// * Reads: `1`
-/// * Write: `1`
-///
-/// # Reverts
-///
-/// * When the sender is not the owner.
-///
-/// # Examples
-///
-/// ```sway
-/// use ownable::{set_ownership, transfer_ownership};
-///
-/// fn foo(owner: Identity, second_owner: Identity) {
-///     set_ownership(owner);
-///     assert(owner() == State::Initialized(owner));
-///     transfer_ownership(second_owner);
-///     assert(owner() == State::Initialized(second_owner));
-/// }
-/// ```
-#[storage(read, write)]
-pub fn transfer_ownership(new_owner: Identity) {
-    only_owner();
-    store(OWNER, State::Initialized(new_owner));
+    /// Transfers ownership to the passed identity.
+    ///
+    /// # Number of Storage Acesses
+    ///
+    /// * Reads: `1`
+    /// * Write: `1`
+    ///
+    /// # Reverts
+    ///
+    /// * When the sender is not the owner.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use ownable::Ownership;
+    /// 
+    /// storage {
+    ///     owner: Ownership = Ownership {},
+    /// }
+    ///
+    /// fn foo(owner: Identity, second_owner: Identity) {
+    ///     storage.owner.set_ownership(owner);
+    ///     assert(storage.owner.owner() == State::Initialized(owner));
+    ///     storage.owner.transfer_ownership(second_owner);
+    ///     assert(storage.owner.owner() == State::Initialized(second_owner));
+    /// }
+    /// ```
+    #[storage(read, write)]
+    pub fn transfer_ownership(self, new_owner: Identity) {
+        self.only_owner();
+        write(self.slot, 0, State::Initialized(new_owner));
 
-    log(OwnershipTransferred {
-        new_owner,
-        previous_owner: msg_sender().unwrap(),
-    });
+        log(OwnershipTransferred {
+            new_owner,
+            previous_owner: msg_sender().unwrap(),
+        });
+    }
 }

--- a/libs/ownership/src/ownable_storage.sw
+++ b/libs/ownership/src/ownable_storage.sw
@@ -1,5 +1,0 @@
-library;
-
-// TODO: These are temporary storage keys for manual storage management. These should be removed once
-// https://github.com/FuelLabs/sway/issues/2585 is resolved.
-pub const OWNER: b256 = 0x1100000000000000000000000000000000000000000000000000000000000000;

--- a/libs/storagemapvec/README.md
+++ b/libs/storagemapvec/README.md
@@ -1,3 +1,5 @@
+> **Note** This library has been deprecated. Use of nested storage types is now legal in Sway.
+
 <p align="center">
     <picture>
         <source media="(prefers-color-scheme: dark)" srcset=".docs/storagemapvec-logo-dark-theme.png">

--- a/libs/storagemapvec/SPECIFICATION.md
+++ b/libs/storagemapvec/SPECIFICATION.md
@@ -1,3 +1,5 @@
+> **Note** This library has been deprecated. Use of nested storage types is now legal in Sway.
+
 # Overview
 
 This document provides an overview of the StorageMapVec library.

--- a/libs/storagemapvec/src/lib.sw
+++ b/libs/storagemapvec/src/lib.sw
@@ -1,6 +1,5 @@
 library;
 /// ** This library has been deprecated. Use of nested storage types is now legal in Sway. **
-
 use std::{hash::sha256, storage::storage_api::{read, write}};
 
 /// A persistant mapping of K -> Vec<V>

--- a/libs/storagemapvec/src/lib.sw
+++ b/libs/storagemapvec/src/lib.sw
@@ -1,11 +1,12 @@
 library;
+/// ** This library has been deprecated. Use of nested storage types is now legal in Sway. **
 
-use std::{hash::sha256, storage::{get, store}};
+use std::{hash::sha256, storage::storage_api::{read, write}};
 
 /// A persistant mapping of K -> Vec<V>
 pub struct StorageMapVec<K, V> {}
 
-impl<K, V> StorageMapVec<K, V> {
+impl<K, V> StorageKey<StorageMapVec<K, V>> {
     /// Appends the value to the end of the vector
     ///
     /// ### Arguments
@@ -36,16 +37,16 @@ impl<K, V> StorageMapVec<K, V> {
     /// ```
     #[storage(read, write)]
     pub fn push(self, key: K, value: V) {
-        // The length of the vec is stored in the sha256((key, __get_storage_key())) slot
-        let len_key = sha256((key, __get_storage_key()));
-        let len = get::<u64>(len_key).unwrap_or(0);
+        // The length of the vec is stored in the sha256((key, self.slot)) slot
+        let len_key = sha256((key, self.slot));
+        let len = read::<u64>(len_key, 0).unwrap_or(0);
 
         // Storing the value at the current length index (if this is the first item, starts off at 0)
-        let key = sha256((key, len, __get_storage_key()));
-        store::<V>(key, value);
+        let key = sha256((key, len, self.slot));
+        write::<V>(key, 0, value);
 
         // Incrementing the length
-        store(len_key, len + 1);
+        write(len_key, 0, len + 1);
     }
 
     /// Removes the last element of the vector and returns it, None if empty
@@ -79,19 +80,19 @@ impl<K, V> StorageMapVec<K, V> {
     /// ```
     #[storage(read, write)]
     pub fn pop(self, key: K) -> Option<V> {
-        // The length of the vec is stored in the sha256((key, __get_storage_key())) slot
-        let len_key = sha256((key, __get_storage_key()));
-        let len = get::<u64>(len_key).unwrap_or(0);
+        // The length of the vec is stored in the sha256((key, self.slot)) slot
+        let len_key = sha256((key, self.slot));
+        let len = read::<u64>(len_key, 0).unwrap_or(0);
         // if the length is 0, there is no item to pop from the vec
         if len == 0 {
             return Option::None;
         }
 
         // reduces len by 1, effectively removing the last item in the vec
-        store(len_key, len - 1);
+        write(len_key, 0, len - 1);
 
-        let key = sha256((key, len - 1, __get_storage_key()));
-        get::<V>(key)
+        let key = sha256((key, len - 1, self.slot));
+        read::<V>(key, 0)
     }
 
     /// Gets the value in the given index, None if index is out of bounds
@@ -125,16 +126,16 @@ impl<K, V> StorageMapVec<K, V> {
     /// ```
     #[storage(read)]
     pub fn get(self, key: K, index: u64) -> Option<V> {
-        // The length of the vec is stored in the sha256((key, __get_storage_key())) slot
-        let len_key = sha256((key, __get_storage_key()));
-        let len = get::<u64>(len_key).unwrap_or(0);
+        // The length of the vec is stored in the sha256((key, self.slot)) slot
+        let len_key = sha256((key, self.slot));
+        let len = read::<u64>(len_key, 0).unwrap_or(0);
         // if the index is larger or equal to len, there is no item to return
         if len <= index {
             return Option::None;
         }
 
-        let key = sha256((key, index, __get_storage_key()));
-        get::<V>(key)
+        let key = sha256((key, index, self.slot));
+        read::<V>(key, 0)
     }
 
     /// Returns the length of the vector
@@ -166,9 +167,9 @@ impl<K, V> StorageMapVec<K, V> {
     /// ```
     #[storage(read)]
     pub fn len(self, key: K) -> u64 {
-        // The length of the vec is stored in the sha256((key, __get_storage_key())) slot
-        let len_key = sha256((key, __get_storage_key()));
-        get::<u64>(len_key).unwrap_or(0)
+        // The length of the vec is stored in the sha256((key, self.slot)) slot
+        let len_key = sha256((key, self.slot));
+        read::<u64>(len_key, 0).unwrap_or(0)
     }
 
     /// Checks whether the len is 0 or not
@@ -204,9 +205,9 @@ impl<K, V> StorageMapVec<K, V> {
     /// ```
     #[storage(read)]
     pub fn is_empty(self, key: K) -> bool {
-        // The length of the vec is stored in the sha256((key, __get_storage_key())) slot
-        let len_key = sha256((key, __get_storage_key()));
-        let len = get::<u64>(len_key).unwrap_or(0);
+        // The length of the vec is stored in the sha256((key, self.slot)) slot
+        let len_key = sha256((key, self.slot));
+        let len = read::<u64>(len_key, 0).unwrap_or(0);
         len == 0
     }
 
@@ -239,9 +240,9 @@ impl<K, V> StorageMapVec<K, V> {
     /// ```
     #[storage(write)]
     pub fn clear(self, key: K) {
-        // The length of the vec is stored in the sha256((key, __get_storage_key())) slot
-        let len_key = sha256((key, __get_storage_key()));
-        store(len_key, 0);
+        // The length of the vec is stored in the sha256((key, self.slot)) slot
+        let len_key = sha256((key, self.slot));
+        write(len_key, 0, 0);
     }
 
     /// Returns a Vec of all the items in the StorageVec
@@ -275,14 +276,14 @@ impl<K, V> StorageMapVec<K, V> {
     /// ```
     #[storage(read)]
     pub fn to_vec(self, key: K) -> Vec<V> {
-        // The length of the vec is stored in the sha256((key, __get_storage_key())) slot
-        let len_key = sha256((key, __get_storage_key()));
-        let len = get::<u64>(len_key).unwrap_or(0);
+        // The length of the vec is stored in the sha256((key, self.slot)) slot
+        let len_key = sha256((key, self.slot));
+        let len = read::<u64>(len_key, 0).unwrap_or(0);
         let mut i = 0;
         let mut vec = Vec::new();
         while len > i {
-            let len_key = sha256((key, i, __get_storage_key()));
-            let item = get::<V>(len_key).unwrap();
+            let len_key = sha256((key, i, self.slot));
+            let item = read::<V>(len_key, 0).unwrap();
             vec.push(item);
             i += 1;
         }
@@ -323,16 +324,16 @@ impl<K, V> StorageMapVec<K, V> {
     /// ```
     #[storage(read, write)]
     pub fn swap(self, key: K, index_a: u64, index_b: u64) {
-        let len_key = sha256((key, __get_storage_key()));
-        let len = get::<u64>(len_key).unwrap_or(0);
+        let len_key = sha256((key, self.slot));
+        let len = read::<u64>(len_key, 0).unwrap_or(0);
         assert(len > index_a);
         assert(len > index_b);
-        let item_a_key = sha256((key, index_a, __get_storage_key()));
-        let item_b_key = sha256((key, index_b, __get_storage_key()));
-        let item_a = get::<V>(item_a_key).unwrap();
-        let item_b = get::<V>(item_b_key).unwrap();
-        store(item_a_key, item_b);
-        store(item_b_key, item_a);
+        let item_a_key = sha256((key, index_a, self.slot));
+        let item_b_key = sha256((key, index_b, self.slot));
+        let item_a = read::<V>(item_a_key, 0).unwrap();
+        let item_b = read::<V>(item_b_key, 0).unwrap();
+        write(item_a_key, 0, item_b);
+        write(item_b_key, 0, item_a);
     }
 
     /// Swaps the position of the given item with the last item in the vector and then pops the last item
@@ -367,15 +368,15 @@ impl<K, V> StorageMapVec<K, V> {
     /// ```
     #[storage(read, write)]
     pub fn swap_remove(self, key: K, index: u64) -> V {
-        let len_key = sha256((key, __get_storage_key()));
-        let len = get::<u64>(len_key).unwrap_or(0);
+        let len_key = sha256((key, self.slot));
+        let len = read::<u64>(len_key, 0).unwrap_or(0);
         assert(len > index);
-        let item_key = sha256((key, index, __get_storage_key()));
-        let item = get::<V>(item_key).unwrap();
-        let last_item_key = sha256((key, len - 1, __get_storage_key()));
-        let last_item = get::<V>(last_item_key).unwrap();
-        store(item_key, last_item);
-        store(len_key, len - 1);
+        let item_key = sha256((key, index, self.slot));
+        let item = read::<V>(item_key, 0).unwrap();
+        let last_item_key = sha256((key, len - 1, self.slot));
+        let last_item = read::<V>(last_item_key, 0).unwrap();
+        write(item_key, 0, last_item);
+        write(len_key, 0, len - 1);
         item
     }
 
@@ -414,17 +415,17 @@ impl<K, V> StorageMapVec<K, V> {
     #[storage(read, write)]
     pub fn remove(self, key: K, index: u64) -> V {
         // get the key to the length of the vector
-        let len_key = sha256((key, __get_storage_key()));
+        let len_key = sha256((key, self.slot));
         // get the length of the vector
-        let len = get::<u64>(len_key).unwrap_or(0);
+        let len = read::<u64>(len_key, 0).unwrap_or(0);
 
         // assert that the index is less than the length of the vector to prevent out of bounds errors
         assert(len > index);
 
         // get the key to the item at the given index
-        let removed_item_key = sha256((key, index, __get_storage_key()));
+        let removed_item_key = sha256((key, index, self.slot));
         // get the item at the given index
-        let removed_item = get::<V>(removed_item_key).unwrap();
+        let removed_item = read::<V>(removed_item_key, 0).unwrap();
 
         // create a counter to iterate through the vector, starting from the next item from the given index
         let mut count = index + 1;
@@ -433,15 +434,15 @@ impl<K, V> StorageMapVec<K, V> {
         // this will move all items after the given index to the left by one
         while count < len {
             // get the key to the item at the current counter
-            let item_key = sha256((key, count - 1, __get_storage_key()));
+            let item_key = sha256((key, count - 1, self.slot));
             // store the item at the current counter in the key to the item at the current counter - 1
-            store::<V>(item_key, get::<V>(sha256((key, count, __get_storage_key()))).unwrap());
+            write::<V>(item_key, 0, read::<V>(sha256((key, count, self.slot)), 0).unwrap());
             // increment the counter
             count += 1;
         }
 
         // store the length of the vector - 1 in the key to the length of the vector
-        store(len_key, len - 1);
+        write(len_key, 0, len - 1);
 
         // return the removed item
         removed_item

--- a/libs/strings/storage_string/src/lib.sw
+++ b/libs/strings/storage_string/src/lib.sw
@@ -1,6 +1,17 @@
 library;
 
-use std::{bytes::Bytes, storage::{storage_api::read, storable_slice::{clear_slice, get_slice, StorableSlice, store_slice}}};
+use std::{
+    bytes::Bytes,
+    storage::{
+        storable_slice::{
+            clear_slice,
+            get_slice,
+            StorableSlice,
+            store_slice,
+        },
+        storage_api::read,
+    },
+};
 use string::String;
 
 pub struct StorageString {}

--- a/libs/strings/storage_string/src/lib.sw
+++ b/libs/strings/storage_string/src/lib.sw
@@ -1,11 +1,11 @@
 library;
 
-use std::{bytes::Bytes, storage::{clear_slice, get, get_slice, StorableSlice, store_slice}};
+use std::{bytes::Bytes, storage::{storage_api::read, storable_slice::{clear_slice, get_slice, StorableSlice, store_slice}}};
 use string::String;
 
 pub struct StorageString {}
 
-impl StorableSlice<String> for StorageString {
+impl StorableSlice<String> for StorageKey<StorageString> {
     /// Takes a `String` type and saves the underlying data in storage.
     ///
     /// ### Arguments
@@ -32,10 +32,9 @@ impl StorableSlice<String> for StorageString {
     ///     storage.stored_string.store(string);
     /// }
     /// ```
-    #[storage(write)]
+    #[storage(read, write)]
     fn store(self, string: String) {
-        let key = __get_storage_key();
-        store_slice(key, string.as_raw_slice());
+        store_slice(self.slot, string.as_raw_slice());
     }
 
     /// Constructs a `String` type from storage.
@@ -65,8 +64,7 @@ impl StorableSlice<String> for StorageString {
     /// ```
     #[storage(read)]
     fn load(self) -> Option<String> {
-        let key = __get_storage_key();
-        match get_slice(key) {
+        match get_slice(self.slot) {
             Option::Some(slice) => {
                 // Uncomment when https://github.com/FuelLabs/sway/issues/4408 is resolved
                 // Option::Some(String::from_raw_slice(slice))
@@ -108,8 +106,7 @@ impl StorableSlice<String> for StorageString {
     /// ```
     #[storage(read, write)]
     fn clear(self) -> bool {
-        let key = __get_storage_key();
-        clear_slice(key)
+        clear_slice(self.slot)
     }
 
     /// Returns the length of `String` in storage.
@@ -138,6 +135,6 @@ impl StorableSlice<String> for StorageString {
     /// ```
     #[storage(read)]
     fn len(self) -> u64 {
-        get::<u64>(__get_storage_key()).unwrap_or(0)
+        read::<u64>(self.slot, 0).unwrap_or(0)
     }
 }

--- a/libs/strings/string/src/lib.sw
+++ b/libs/strings/string/src/lib.sw
@@ -175,7 +175,7 @@ impl String {
     /// # Arguments
     ///
     /// * `other` - The String to join to self.
-    pub fn append(ref mut self, mut other: self) {
+    pub fn append(ref mut self, ref mut other: self) {
         self.bytes.append(other.into())
     }
 

--- a/libs/strings/string/src/lib.sw
+++ b/libs/strings/string/src/lib.sw
@@ -152,8 +152,6 @@ impl AsRawSlice for String {
     }
 }
 
-
-
 // Uncomment when https://github.com/FuelLabs/sway/issues/3637 is resolved.
 // impl From<raw_slice> for String {
 //     fn from(slice: raw_slice) -> String {

--- a/tests/src/ownership/src/main.sw
+++ b/tests/src/ownership/src/main.sw
@@ -4,7 +4,7 @@ use ownership::*;
 use ownership::data_structures::State;
 
 storage {
-    owner: Ownership = Ownership {},
+    owner: Ownership = Ownership::uninitialized(),
 }
 
 abi OwnableTest {

--- a/tests/src/ownership/src/main.sw
+++ b/tests/src/ownership/src/main.sw
@@ -1,13 +1,11 @@
 contract;
 
-use ownership::{
-    data_structures::State,
-    only_owner,
-    owner,
-    renounce_ownership,
-    set_ownership,
-    transfer_ownership,
-};
+use ownership::*;
+use ownership::data_structures::State;
+
+storage {
+    owner: Ownership = Ownership {},
+}
 
 abi OwnableTest {
     #[storage(read)]
@@ -25,26 +23,26 @@ abi OwnableTest {
 impl OwnableTest for Contract {
     #[storage(read)]
     fn only_owner() {
-        only_owner();
+        storage.owner.only_owner();
     }
 
     #[storage(read)]
     fn owner() -> State {
-        owner()
+        storage.owner.owner()
     }
 
     #[storage(read, write)]
     fn renounce_ownership() {
-        renounce_ownership();
+        storage.owner.renounce_ownership();
     }
 
     #[storage(read, write)]
     fn set_ownership(new_owner: Identity) {
-        set_ownership(new_owner);
+        storage.owner.set_ownership(new_owner);
     }
 
     #[storage(read, write)]
     fn transfer_ownership(new_owner: Identity) {
-        transfer_ownership(new_owner);
+        storage.owner.transfer_ownership(new_owner);
     }
 }

--- a/tests/src/ownership/tests/utils/mod.rs
+++ b/tests/src/ownership/tests/utils/mod.rs
@@ -1,7 +1,7 @@
 use fuels::{
     prelude::{
-        abigen, launch_custom_provider_and_get_wallets, Contract, LoadConfiguration, StorageConfiguration, TxParameters,
-        WalletUnlocked, WalletsConfig,
+        abigen, launch_custom_provider_and_get_wallets, Contract, LoadConfiguration,
+        StorageConfiguration, TxParameters, WalletUnlocked, WalletsConfig,
     },
     programs::call_response::FuelCallResponse,
     types::Identity,
@@ -86,7 +86,9 @@ pub mod test_helpers {
         let wallet2 = wallets.pop().unwrap();
         let wallet3 = wallets.pop().unwrap();
 
-        let storage_configuration = StorageConfiguration::load_from("src/ownership/out/debug/ownership_test-storage_slots.json");
+        let storage_configuration = StorageConfiguration::load_from(
+            "src/ownership/out/debug/ownership_test-storage_slots.json",
+        );
         let id = Contract::load_from(
             "src/ownership/out/debug/ownership_test.bin",
             LoadConfiguration::default().set_storage_configuration(storage_configuration.unwrap()),

--- a/tests/src/ownership/tests/utils/mod.rs
+++ b/tests/src/ownership/tests/utils/mod.rs
@@ -1,6 +1,6 @@
 use fuels::{
     prelude::{
-        abigen, launch_custom_provider_and_get_wallets, Contract, LoadConfiguration, TxParameters,
+        abigen, launch_custom_provider_and_get_wallets, Contract, LoadConfiguration, StorageConfiguration, TxParameters,
         WalletUnlocked, WalletsConfig,
     },
     programs::call_response::FuelCallResponse,
@@ -86,9 +86,10 @@ pub mod test_helpers {
         let wallet2 = wallets.pop().unwrap();
         let wallet3 = wallets.pop().unwrap();
 
+        let storage_configuration = StorageConfiguration::load_from("src/ownership/out/debug/ownership_test-storage_slots.json");
         let id = Contract::load_from(
             "src/ownership/out/debug/ownership_test.bin",
-            LoadConfiguration::default(),
+            LoadConfiguration::default().set_storage_configuration(storage_configuration.unwrap()),
         )
         .unwrap()
         .deploy(&wallet1, TxParameters::default())

--- a/tests/src/storage_string/src/main.sw
+++ b/tests/src/storage_string/src/main.sw
@@ -2,7 +2,7 @@ contract;
 
 use std::bytes::Bytes;
 use string::String;
-use storage_string::StorageString;
+use storage_string::*;
 
 storage {
     stored_string: StorageString = StorageString {},

--- a/tests/src/storagemapvec/src/main.sw
+++ b/tests/src/storagemapvec/src/main.sw
@@ -1,6 +1,6 @@
 contract;
 
-use storagemapvec::StorageMapVec;
+use storagemapvec::*;
 
 storage {
     mapvec: StorageMapVec<u64, u64> = StorageMapVec {},

--- a/tests/src/string/src/main.sw
+++ b/tests/src/string/src/main.sw
@@ -67,8 +67,6 @@ impl StringTest for Contract {
         assert(bytes.len() == string.len());
         assert(bytes.capacity() == string.capacity());
 
-
-
         // string.push(NUMBER0);
         // let bytes = string.as_vec();
         // assert(bytes.len() == string.len());
@@ -93,12 +91,6 @@ impl StringTest for Contract {
         let mut string = String::new();
 
         assert(string.capacity() == 0);
-
-
-
-
-
-
 
         // Uncomment when https://github.com/FuelLabs/sway/issues/4408 is resolved
         // string.push(NUMBER0);
@@ -138,12 +130,6 @@ impl StringTest for Contract {
         string.clear();
         assert(string.is_empty());
 
-
-
-
-
-
-
         // Uncomment when https://github.com/FuelLabs/sway/issues/4408 is resolved
         // string.push(NUMBER0);
         // assert(!string.is_empty());
@@ -176,7 +162,6 @@ impl StringTest for Contract {
     }
 
     fn test_from() {
-
 
         // Uncomment when https://github.com/FuelLabs/sway/issues/4408 is resolved
         // let mut bytes = Bytes::new();
@@ -217,7 +202,6 @@ impl StringTest for Contract {
 
     fn test_from_utf8() {
 
-
         // Uncomment when https://github.com/FuelLabs/sway/issues/4408 is resolved
         // let mut vec: Vec<u8> = Vec::new();
 
@@ -239,9 +223,6 @@ impl StringTest for Contract {
         let mut string = String::new();
 
         assert(string.len() == 0);
-
-
-
 
         // Uncomment when https://github.com/FuelLabs/sway/issues/4408 is resolved
         // string.insert(NUMBER0, 0);
@@ -267,8 +248,6 @@ impl StringTest for Contract {
         let bytes = string.into();
         assert(bytes.len() == string.len());
         assert(bytes.capacity() == string.capacity());
-
-
 
         // Uncomment when https://github.com/FuelLabs/sway/issues/4408 is resolved
         // string.push(NUMBER0);
@@ -297,8 +276,6 @@ impl StringTest for Contract {
         let raw_slice: raw_slice = string.as_raw_slice();
         assert(raw_slice.number_of_bytes() == string.len());
 
-
-
         // Uncomment when https://github.com/FuelLabs/sway/issues/4408 is resolved
         // string.push(NUMBER0);
         // let raw_slice = string.as_raw_slice();
@@ -319,12 +296,6 @@ impl StringTest for Contract {
         let mut string = String::new();
 
         assert(string.is_empty());
-
-
-
-
-
-
 
         // Uncomment when https://github.com/FuelLabs/sway/issues/4408 is resolved
         // string.push(NUMBER0);
@@ -353,14 +324,6 @@ impl StringTest for Contract {
         let mut string = String::new();
 
         assert(string.len() == 0);
-
-
-
-
-
-
-
-
 
         // Uncomment when https://github.com/FuelLabs/sway/issues/4408 is resolved
         // string.push(NUMBER0);
@@ -404,12 +367,6 @@ impl StringTest for Contract {
 
     fn test_nth() {
 
-
-
-
-
-
-
         // Uncomment when https://github.com/FuelLabs/sway/issues/4408 is resolved
         // let mut string = String::new();
 
@@ -449,11 +406,6 @@ impl StringTest for Contract {
 
     fn test_pop() {
 
-
-
-
-
-
         // Uncomment when https://github.com/FuelLabs/sway/issues/4408 is resolved
         // let mut string = String::new();
 
@@ -489,18 +441,6 @@ impl StringTest for Contract {
         assert(string.len() == 0);
         assert(string.is_empty());
         assert(string.capacity() == 0);
-
-
-
-
-
-
-
-
-
-
-
-
 
         // Uncomment when https://github.com/FuelLabs/sway/issues/4408 is resolved
         // string.push(NUMBER0);
@@ -561,9 +501,6 @@ impl StringTest for Contract {
 
     fn test_set() {
 
-
-
-
         // Uncomment when https://github.com/FuelLabs/sway/issues/4408 is resolved
         // let mut string = String::new();
 
@@ -587,9 +524,6 @@ impl StringTest for Contract {
 
     fn test_split_at() {
 
-
-
-
         // Uncomment when https://github.com/FuelLabs/sway/issues/4408 is resolved
         // let mut string1 = String::new();
 
@@ -610,9 +544,6 @@ impl StringTest for Contract {
 }
 
     fn test_swap() {
-
-
-
 
         // Uncomment when https://github.com/FuelLabs/sway/issues/4408 is resolved
         // let mut string = String::new();
@@ -641,13 +572,6 @@ impl StringTest for Contract {
 }
 
     fn test_remove() {
-
-
-
-
-
-
-
 
         // Uncomment when https://github.com/FuelLabs/sway/issues/4408 is resolved
         // let mut string = String::new();
@@ -694,14 +618,6 @@ impl StringTest for Contract {
 
         let mut string = String::with_capacity(0);
         assert(string.capacity() == 0);
-
-
-
-
-
-
-
-
 
         // Uncomment when https://github.com/FuelLabs/sway/issues/4408 is resolved
         // string.push(NUMBER0);


### PR DESCRIPTION
## Type of change

<!--Delete points that do not apply-->

- Improvement (refactoring, restructuring repository, cleaning tech debt, ...)

## Changes

The following changes have been made:

- Bumped StorageString library to use new `StorageKey`
- Bumped StorageMapVec library to use new `StorageKey`
- Bumped Ownership library to use new `StorageKey`
- Bumped NFT library to be **compatible** with forc v0.38.0.



## Notes

- **_Ownership can now be set upon contract deployment!!!!!!!_**  
     - This is huge, no need for calling `set_ownership()`. In a storage block, you can initialize ownership on deployment with `Ownership::initalized(Identity::Address(Address::from(my_b256_address))`.
- StorageMapVec is now deprecated. It will no longer be supported.
- NFT does not use `StorageKey`. This will require significant changes and will be done in another PR.
