### PR TITLE
Begin move of standards to new repo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,48 +98,6 @@ jobs:
       - name: Run Unit Tests
         run: forc build --path libs && forc test --path libs
 
-  build-standards:
-      runs-on: ubuntu-latest
-      
-      steps:
-        - name: Checkout repository
-          uses: actions/checkout@v2
-
-        - name: Install Rust toolchain
-          uses: actions-rs/toolchain@v1
-          with:
-            profile: minimal
-            toolchain: ${{ env.RUST_VERSION }}
-            override: true
-
-        - name: Init cache
-          uses: Swatinem/rust-cache@v1
-
-        - name: Install a modern linker (mold)
-          uses: rui314/setup-mold@v1
-
-        - name: Force Rust to use mold globally for compilation
-          run: |
-            touch ~/.cargo/config.toml
-            echo "[target.x86_64-unknown-linux-gnu]" > ~/.cargo/config.toml
-            echo 'linker = "clang"' >> ~/.cargo/config.toml
-            echo 'rustflags = ["-C", "link-arg=-fuse-ld=/usr/local/bin/mold"]' >> ~/.cargo/config.toml
-
-        - name: Install rustfmt
-          run: rustup component add rustfmt
-
-        - name: Install Fuel toolchain
-          uses: FuelLabs/action-fuel-toolchain@v0.6.0
-          with:
-            name: my-toolchain
-            components: forc@${{ env.FORC_VERSION }}, fuel-core@${{ env.CORE_VERSION }}
-
-        - name: Check Sway formatting
-          run: forc fmt --path standards --check
-
-        - name: Build All Standards
-          run: forc build --path standards
-
   contributing-book:
     runs-on: ubuntu-latest
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 
 The purpose of this repository is to contain libraries which users can import and use that are not part of the standard library. 
 
-These libraries contain helper functions, generalized standards, and other tools valuable to blockchain development.
+These libraries contain helper functions and other tools valuable to blockchain development.
 
 > **Note**
 > Sway is a language under heavy development therefore the libraries may not be the most ergonomic. Over time they should receive updates / improvements in order to demonstrate how Sway can be used in real use cases.
@@ -39,11 +39,6 @@ These libraries contain helper functions, generalized standards, and other tools
 - [String](./libs/strings/string/) is an interface to implement dynamic length strings that are UTF-8 encoded.
 - [StorageString](./libs/strings/storage_string/) is used to store dynamic length strings that are UTF-8 encoded in storage.
 - [Fixed Point Number](./libs/fixed_point/) is an interface to implement fixed-point numbers.
-
-### Standards
-
-- [Token Standard](./standards/frc20/) is used to add metadata to native assets on Fuel.
-- [Non-Fungible Token(NFT) Standard](./standards/frc721/) is a standard ABI used to implement NFTs on Fuel.
 
 ## Using a library
 

--- a/standards/frc20/src/lib.sw
+++ b/standards/frc20/src/lib.sw
@@ -1,4 +1,5 @@
 library;
+/// **Note** This standard has moved to a new repository. Please visit the [Sway-Standards](https://github.com/FuelLabs/sway-standards) repository for the most up to date standards. 
 
 use std::u256::U256;
 

--- a/standards/frc721/README.md
+++ b/standards/frc721/README.md
@@ -1,3 +1,5 @@
+> **Note** This standard has moved to a new repository. Please visit the [Sway-Standards](https://github.com/FuelLabs/sway-standards) repository for the most up to date standards. 
+
 <p align="center">
     <picture>
         <source media="(prefers-color-scheme: dark)" srcset=".docs/frc-721-logo-dark-theme.png">

--- a/standards/frc721/src/extensions/frc721_metadata.sw
+++ b/standards/frc721/src/extensions/frc721_metadata.sw
@@ -1,4 +1,5 @@
 library;
+/// **Note** This standard has moved to a new repository. Please visit the [Sway-Standards](https://github.com/FuelLabs/sway-standards) repository for the most up to date standards. 
 
 /// Any contract that implements FRC721_metadata SHALL also implement FRC721.
 abi FRC721_metadata {

--- a/standards/frc721/src/frc_721.sw
+++ b/standards/frc721/src/frc_721.sw
@@ -1,4 +1,5 @@
 library;
+/// **Note** This standard has moved to a new repository. Please visit the [Sway-Standards](https://github.com/FuelLabs/sway-standards) repository for the most up to date standards. 
 
 /// This event MUST be logged when the approved Identity for an NFT is changed or modified.
 /// Option::None indicates there is no approved Identity.


### PR DESCRIPTION
## Type of change

<!--Delete points that do not apply-->

- Improvement (refactoring, restructuring repository, cleaning tech debt, ...)

## Changes

The following changes have been made:

- Removed standards from README
- Added comment on standards being moved  to README
- Added comment on standards being moved to files

## Notes

- These files will be removed **entirely** in the next release.

## Related Issues

<!--Delete everything after the "#" symbol and replace it with a number. No spaces between hash and number-->

Closes #151 
