### PR TITLE
Reimplement code for `StorageString`

### DIFF
--- a/libs/strings/storage_string/src/lib.sw
+++ b/libs/strings/storage_string/src/lib.sw
@@ -77,11 +77,7 @@ impl StorableSlice<String> for StorageKey<StorageString> {
     fn load(self) -> Option<String> {
         match get_slice(self.slot) {
             Option::Some(slice) => {
-                // Uncomment when https://github.com/FuelLabs/sway/issues/4408 is resolved
-                // Option::Some(String::from_raw_slice(slice))
-                Option::Some(String {
-                    bytes: Bytes::from_raw_slice(slice),
-                })
+                Option::Some(String::from_raw_slice(slice))
             },
             Option::None => Option::None,
         }


### PR DESCRIPTION
## Type of change

<!--Delete points that do not apply-->

- Improvement (refactoring, restructuring repository, cleaning tech debt, ...)

## Changes

The following changes have been made:

- Super simple change, using `String` instead of `Bytes` has been unblocked.

## Related Issues

<!--Delete everything after the "#" symbol and replace it with a number. No spaces between hash and number-->

Closes #155 
