### PR TITLE
Bump to forc v0.39.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,8 @@ env:
   CARGO_TERM_COLOR: always
   REGISTRY: ghcr.io
   RUST_VERSION: 1.68.2
-  FORC_VERSION: 0.38.0
-  CORE_VERSION: 0.17.11
+  FORC_VERSION: 0.39.1
+  CORE_VERSION: 0.18.1
   PATH_TO_SCRIPTS: .github/scripts
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
     <a href="https://github.com/FuelLabs/sway-libs/actions/workflows/ci.yml" alt="CI">
         <img src="https://github.com/FuelLabs/sway-libs/actions/workflows/ci.yml/badge.svg" />
     </a>
-    <a href="https://crates.io/crates/forc/0.38.0" alt="forc">
-        <img src="https://img.shields.io/badge/forc-v0.38.0-orange" />
+    <a href="https://crates.io/crates/forc/0.39.1" alt="forc">
+        <img src="https://img.shields.io/badge/forc-v0.39.1-orange" />
     </a>
     <a href="./LICENSE" alt="forc">
         <img src="https://img.shields.io/github/license/FuelLabs/sway-libs" />
@@ -82,7 +82,7 @@ cargo test
 Any instructions related to using a specific library should be found within the README.md of that library.
 
 > **Note**
-> All projects currently use `forc v0.38.0`, `fuels-rs v0.41.0` and `fuel-core 0.17.11`.
+> All projects currently use `forc v0.39.1`, `fuels-rs v0.41.0` and `fuel-core 0.18.1`.
 
 ## Contributing
 

--- a/libs/strings/storage_string/README.md
+++ b/libs/strings/storage_string/README.md
@@ -45,14 +45,14 @@ let mut my_string = String::new();
 my_string.push(0u8);
 
 // Store the string
-storage.stored_string.store(my_string);
+storage.stored_string.write_slice(my_string);
 ```
 
 Retrieving a `String` from storage can be done with the `load` function.
 
 ```rust
 // Get a string from storage
-let my_string: String = storage.stored_string.load();
+let my_string: String = storage.stored_string.read_slice();
 ```
 
 For more information please see the [specification](./SPECIFICATION.md).

--- a/libs/strings/storage_string/SPECIFICATION.md
+++ b/libs/strings/storage_string/SPECIFICATION.md
@@ -12,11 +12,11 @@ The StorageString library can be used anytime a string's length is unknown at co
 
 ## Public Functions
 
-### `store()`
+### `write_slice()`
 
 Stores a `String` in storage. 
 
-### `load()`
+### `read_slice()`
 
 Retrieves a `String` from storage. 
 

--- a/libs/strings/storage_string/src/lib.sw
+++ b/libs/strings/storage_string/src/lib.sw
@@ -5,9 +5,9 @@ use std::{
     storage::{
         storable_slice::{
             clear_slice,
-            get_slice,
+            read_slice,
             StorableSlice,
-            store_slice,
+            write_slice,
         },
         storage_api::read,
     },
@@ -40,12 +40,12 @@ impl StorableSlice<String> for StorageKey<StorageString> {
     ///     string.push(7_u8);
     ///     string.push(9_u8);
     ///
-    ///     storage.stored_string.store(string);
+    ///     storage.stored_string.write_slice(string);
     /// }
     /// ```
     #[storage(read, write)]
-    fn store(self, string: String) {
-        store_slice(self.slot, string.as_raw_slice());
+    fn write_slice(self, string: String) {
+        write_slice(self.slot, string.as_raw_slice());
     }
 
     /// Constructs a `String` type from storage.
@@ -67,15 +67,15 @@ impl StorableSlice<String> for StorageKey<StorageString> {
     ///     string.push(7_u8);
     ///     string.push(9_u8);
     ///
-    ///     assert(storage.stored_string.load(key).is_none());
-    ///     storage.stored_string.store(string);
-    ///     let retrieved_string = storage.stored_string.load(key).unwrap();
+    ///     assert(storage.stored_string.read_slice(key).is_none());
+    ///     storage.stored_string.write_slice(string);
+    ///     let retrieved_string = storage.stored_string.read_slice(key).unwrap();
     ///     assert(string == retrieved_string);
     /// }
     /// ```
     #[storage(read)]
-    fn load(self) -> Option<String> {
-        match get_slice(self.slot) {
+    fn read_slice(self) -> Option<String> {
+        match read_slice(self.slot) {
             Option::Some(slice) => {
                 Option::Some(String::from_raw_slice(slice))
             },
@@ -102,12 +102,12 @@ impl StorableSlice<String> for StorageKey<StorageString> {
     ///     string.push(5_u8);
     ///     string.push(7_u8);
     ///     string.push(9_u8);
-    ///     storage.stored_string.store(string);
+    ///     storage.stored_string.write_slice(string);
     ///
-    ///     assert(storage.stored_string.load(key).is_some());
+    ///     assert(storage.stored_string.read_slice(key).is_some());
     ///     let cleared = storage.stored_string.clear();
     ///     assert(cleared);
-    ///     let retrieved_string = storage.stored_string.load(key);
+    ///     let retrieved_string = storage.stored_string.read_slice(key);
     ///     assert(retrieved_string.is_none());
     /// }
     /// ```
@@ -136,7 +136,7 @@ impl StorableSlice<String> for StorageKey<StorageString> {
     ///     string.push(9_u8);
     ///
     ///     assert(storage.stored_string.len() == 0)
-    ///     storage.stored_string.store(string);
+    ///     storage.stored_string.write_slice(string);
     ///     assert(storage.stored_string.len() == 3);
     /// }
     /// ```

--- a/libs/strings/string/src/lib.sw
+++ b/libs/strings/string/src/lib.sw
@@ -168,6 +168,8 @@ impl AsRawSlice for String {
 // }
 
 
+
+
 impl String {
     /// Moves all elements of the `other` String into `self`, leaving `other` empty.
     ///

--- a/libs/strings/string/src/lib.sw
+++ b/libs/strings/string/src/lib.sw
@@ -152,25 +152,6 @@ impl AsRawSlice for String {
     }
 }
 
-// Uncomment when https://github.com/FuelLabs/sway/issues/3637 is resolved.
-// impl From<raw_slice> for String {
-//     fn from(slice: raw_slice) -> String {
-//         let mut bytes = Bytes::with_capacity(slice.number_of_bytes());
-//         bytes.buf.ptr = slice.ptr();
-//         Self {
-//             bytes
-//         }
-//     }
-
-//     fn into(self) -> raw_slice {
-//         asm(ptr: (self.bytes.buf.ptr(), self.bytes.len)) { ptr: raw_slice }
-//     }
-// }
-
-
-
-
-
 impl String {
     /// Moves all elements of the `other` String into `self`, leaving `other` empty.
     ///
@@ -191,3 +172,18 @@ impl String {
         (Self::from(bytes1), Self::from(bytes2))
     }
 }
+
+// Uncomment when https://github.com/FuelLabs/sway/issues/3637 is resolved.
+// impl From<raw_slice> for String {
+//     fn from(slice: raw_slice) -> String {
+//         let mut bytes = Bytes::with_capacity(slice.number_of_bytes());
+//         bytes.buf.ptr = slice.ptr();
+//         Self {
+//             bytes
+//         }
+//     }
+
+//     fn into(self) -> raw_slice {
+//         asm(ptr: (self.bytes.buf.ptr(), self.bytes.len)) { ptr: raw_slice }
+//     }
+// }

--- a/libs/strings/string/src/lib.sw
+++ b/libs/strings/string/src/lib.sw
@@ -167,6 +167,7 @@ impl AsRawSlice for String {
 //     }
 // }
 
+
 impl String {
     /// Moves all elements of the `other` String into `self`, leaving `other` empty.
     ///

--- a/libs/strings/string/src/lib.sw
+++ b/libs/strings/string/src/lib.sw
@@ -170,6 +170,7 @@ impl AsRawSlice for String {
 
 
 
+
 impl String {
     /// Moves all elements of the `other` String into `self`, leaving `other` empty.
     ///

--- a/tests/src/storage_string/src/main.sw
+++ b/tests/src/storage_string/src/main.sw
@@ -27,7 +27,7 @@ impl MyContract for Contract {
 
     #[storage(read)]
     fn get_string() -> Bytes {
-        match storage.stored_string.load() {
+        match storage.stored_string.read_slice() {
             Option::Some(string) => {
                 string.bytes
             },
@@ -37,7 +37,7 @@ impl MyContract for Contract {
 
     #[storage(write)]
     fn store_string(string: String) {
-        storage.stored_string.store(string);
+        storage.stored_string.write_slice(string);
     }
 
     #[storage(read)]


### PR DESCRIPTION
## Type of change

<!--Delete points that do not apply-->

- Improvement (refactoring, restructuring repository, cleaning tech debt, ...)

## Changes

The following changes have been made:

- Bumped to forc v0.39.1
- Bumped to fuel-core v0.18.1
- Updated `StorageString` function definitions

## Notes

- This is a breaking change as the function definitions of `StorageString` have changed from `store()` -> `write_slice()` and `load()` -> `read_slice()` to match the rest of the storage library naming conventions. 

## Related Issues

<!--Delete everything after the "#" symbol and replace it with a number. No spaces between hash and number-->

Closes #161 