### PR TITLE
Bump Repo to use forc v0.40.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,8 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   REGISTRY: ghcr.io
-  RUST_VERSION: 1.68.2
-  FORC_VERSION: 0.39.1
+  RUST_VERSION: 1.69.0
+  FORC_VERSION: 0.40.1
   CORE_VERSION: 0.18.1
   PATH_TO_SCRIPTS: .github/scripts
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
     <a href="https://github.com/FuelLabs/sway-libs/actions/workflows/ci.yml" alt="CI">
         <img src="https://github.com/FuelLabs/sway-libs/actions/workflows/ci.yml/badge.svg" />
     </a>
-    <a href="https://crates.io/crates/forc/0.39.1" alt="forc">
-        <img src="https://img.shields.io/badge/forc-v0.39.1-orange" />
+    <a href="https://crates.io/crates/forc/0.40.1" alt="forc">
+        <img src="https://img.shields.io/badge/forc-v0.40.1-orange" />
     </a>
     <a href="./LICENSE" alt="forc">
         <img src="https://img.shields.io/github/license/FuelLabs/sway-libs" />
@@ -82,7 +82,7 @@ cargo test
 Any instructions related to using a specific library should be found within the README.md of that library.
 
 > **Note**
-> All projects currently use `forc v0.39.1`, `fuels-rs v0.41.0` and `fuel-core 0.18.1`.
+> All projects currently use `forc v0.40.1`, `fuels-rs v0.42.0` and `fuel-core 0.18.1`.
 
 ## Contributing
 

--- a/libs/fixed_point/src/lib.sw
+++ b/libs/fixed_point/src/lib.sw
@@ -1,9 +1,9 @@
 library;
 
-mod ufp32;
-mod ufp64;
-mod ufp128;
+pub mod ufp32;
+pub mod ufp64;
+pub mod ufp128;
 
-mod ifp64;
-mod ifp128;
-mod ifp256;
+pub mod ifp64;
+pub mod ifp128;
+pub mod ifp256;

--- a/libs/merkle_proof/src/lib.sw
+++ b/libs/merkle_proof/src/lib.sw
@@ -1,3 +1,3 @@
 library;
 
-mod binary_merkle_proof;
+pub mod binary_merkle_proof;

--- a/libs/nft/src/extensions.sw
+++ b/libs/nft/src/extensions.sw
@@ -1,6 +1,6 @@
 library;
 
-mod administrator;
-mod burnable;
-mod supply;
-mod token_metadata;
+pub mod administrator;
+pub mod burnable;
+pub mod supply;
+pub mod token_metadata;

--- a/libs/nft/src/extensions/administrator.sw
+++ b/libs/nft/src/extensions/administrator.sw
@@ -1,7 +1,7 @@
 library;
 
-mod administrator_errors;
-mod administrator_events;
+pub mod administrator_errors;
+pub mod administrator_events;
 
 use administrator_errors::AdminError;
 use administrator_events::AdminEvent;

--- a/libs/nft/src/extensions/burnable.sw
+++ b/libs/nft/src/extensions/burnable.sw
@@ -1,6 +1,6 @@
 library;
 
-mod burnable_events;
+pub mod burnable_events;
 
 use burnable_events::BurnEvent;
 use ::nft_core::{errors::{AccessError, InputError}, nft_storage::{BALANCES, TOKENS}, NFTCore};

--- a/libs/nft/src/extensions/supply.sw
+++ b/libs/nft/src/extensions/supply.sw
@@ -1,7 +1,7 @@
 library;
 
-mod supply_errors;
-mod supply_events;
+pub mod supply_errors;
+pub mod supply_events;
 
 use ::nft_core::nft_storage::MAX_SUPPLY;
 use std::storage::storage_api::{read, write};

--- a/libs/nft/src/extensions/token_metadata.sw
+++ b/libs/nft/src/extensions/token_metadata.sw
@@ -1,6 +1,6 @@
 library;
 
-mod token_metadata_structures;
+pub mod token_metadata_structures;
 
 use token_metadata_structures::NFTMetadata;
 use ::nft_core::{errors::InputError, nft_storage::{TOKEN_METADATA, TOKENS}, NFTCore};

--- a/libs/nft/src/lib.sw
+++ b/libs/nft/src/lib.sw
@@ -1,8 +1,8 @@
 library;
 
 // TODO: Move these into alphabetical order once https://github.com/FuelLabs/sway/issues/409 is resolved
-mod nft_core;
-mod extensions;
+pub mod nft_core;
+pub mod extensions;
 
 use nft_core::{
     errors::InputError,

--- a/libs/nft/src/nft_core.sw
+++ b/libs/nft/src/nft_core.sw
@@ -1,8 +1,8 @@
 library;
 
-mod errors;
-mod events;
-mod nft_storage;
+pub mod errors;
+pub mod events;
+pub mod nft_storage;
 
 use errors::{AccessError, InputError};
 use events::{ApprovalEvent, MintEvent, OperatorEvent, TransferEvent};

--- a/libs/ownership/src/ownable.sw
+++ b/libs/ownership/src/ownable.sw
@@ -1,8 +1,8 @@
 library;
 
-mod data_structures;
-mod errors;
-mod events;
+pub mod data_structures;
+pub mod errors;
+pub mod events;
 
 use data_structures::State;
 use errors::AccessError;

--- a/libs/signed_integers/src/lib.sw
+++ b/libs/signed_integers/src/lib.sw
@@ -1,11 +1,11 @@
 library;
 
-mod common;
-mod errors;
+pub mod common;
+pub mod errors;
 
-mod i8;
-mod i16;
-mod i32;
-mod i64;
-mod i128;
-mod i256;
+pub mod i8;
+pub mod i16;
+pub mod i32;
+pub mod i64;
+pub mod i128;
+pub mod i256;

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 
 [dependencies]
 fuel-merkle = { version = "0.4.1" }
-fuels = { version = "0.41.0", features = ["fuel-core-lib"] }
+fuels = { version = "0.42.0", features = ["fuel-core-lib"] }
 sha2 = { version = "0.10" }
 tokio = { version = "1.12", features = ["rt", "macros"] }
 

--- a/tests/src/reentrancy/mod.rs
+++ b/tests/src/reentrancy/mod.rs
@@ -3,7 +3,7 @@ use fuels::{
         abigen, launch_provider_and_get_wallet, Contract, LoadConfiguration, StorageConfiguration,
         TxParameters, WalletUnlocked,
     },
-    tx::ContractId,
+    types::ContractId,
 };
 
 abigen!(


### PR DESCRIPTION
## Type of change

<!--Delete points that do not apply-->

- Improvement (refactoring, restructuring repository, cleaning tech debt, ...)

## Changes

The following changes have been made:

- Bump to use Rust v1.69.0
- Bump to use force v0.40.1
- Bump to use fuels-rs v0.42.0

## Related Issues

<!--Delete everything after the "#" symbol and replace it with a number. No spaces between hash and number-->

Closes #164 
