### PR TITLE
Update Merkle Proof library to use new `fuel-merkle` repo

### DIFF
--- a/libs/merkle_proof/README.md
+++ b/libs/merkle_proof/README.md
@@ -24,14 +24,14 @@ Once imported, using the Merkle Proof library is as simple as calling the desire
 
 ## Using the Merkle Proof Library in Fuels-rs
 
-To generate a Merkle Tree and corresponding proof for your Sway Smart Contract, use the [Fuel-Merkle](https://github.com/FuelLabs/fuel-merkle) crate. 
+To generate a Merkle Tree and corresponding proof for your Sway Smart Contract, use the [Fuel-Merkle](https://github.com/FuelLabs/fuel-vm/tree/master/fuel-merkle) crate. 
 
 ### Importing Into Your Project
 
 The import the Fuel-Merkle crate, the following should be added to the project's `Cargo.toml` file under `[dependencies]`:
 
 ```
-fuel-merkle = { version = "0.3" }
+fuel-merkle = { version = "0.33.0" }
 ```
 
 ### Importing Into Your Rust File
@@ -39,7 +39,10 @@ fuel-merkle = { version = "0.3" }
 The following should be added to your Rust file to use the Fuel-Merkle crate.
 
 ```rust
-use fuel_merkle::binary::in_memory::MerkleTree;
+use fuel_merkle::{
+    binary::in_memory::MerkleTree,
+    common::Bytes32,
+};
 ```
 
 ### Using Fuel-Merkle

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]
-fuel-merkle = { version = "0.4.1" }
+fuel-merkle = { version = "0.33.0" }
 fuels = { version = "0.42.0", features = ["fuel-core-lib"] }
 sha2 = { version = "0.10" }
 tokio = { version = "1.12", features = ["rt", "macros"] }

--- a/tests/src/merkle_proof/tests/functions/node_digest.rs
+++ b/tests/src/merkle_proof/tests/functions/node_digest.rs
@@ -1,8 +1,9 @@
 use crate::merkle_proof::tests::utils::{
     abi_calls::node_digest,
     test_helpers::{build_tree, merkle_proof_instance},
+    LEAF, NODE,
 };
-use fuel_merkle::common::{Bytes32, LEAF, NODE};
+use fuel_merkle::common::Bytes32;
 use fuels::types::Bits256;
 use sha2::{Digest, Sha256};
 

--- a/tests/src/merkle_proof/tests/utils/mod.rs
+++ b/tests/src/merkle_proof/tests/utils/mod.rs
@@ -1,6 +1,6 @@
 use fuel_merkle::{
     binary::in_memory::MerkleTree,
-    common::{empty_sum_sha256, Bytes32, LEAF, NODE},
+    common::{empty_sum_sha256, Bytes32},
 };
 use fuels::{
     prelude::{
@@ -15,6 +15,9 @@ abigen!(Contract(
     name = "TestMerkleProofLib",
     abi = "src/merkle_proof/out/debug/merkle_proof_test-abi.json"
 ));
+
+pub const NODE: u8 = 0x01;
+pub const LEAF: u8 = 0x00;
 
 pub mod abi_calls {
 


### PR DESCRIPTION
## Type of change

<!--Delete points that do not apply-->

- Improvement (refactoring, restructuring repository, cleaning tech debt, ...)

## Changes

The following changes have been made:

- Update tests to use new fuel-merkle repo
- Updated documentation to point to new repo 

## Notes

- `LEAF` and `NODE` are now private, so the constants have been explicitly added to the `utils.rs` file

## Related Issues

<!--Delete everything after the "#" symbol and replace it with a number. No spaces between hash and number-->

Closes #166 
