### PR TITLE
Refactor to use `From` trait for `String`

### DIFF
--- a/libs/strings/storage_string/src/lib.sw
+++ b/libs/strings/storage_string/src/lib.sw
@@ -77,7 +77,7 @@ impl StorableSlice<String> for StorageKey<StorageString> {
     fn read_slice(self) -> Option<String> {
         match read_slice(self.slot) {
             Option::Some(slice) => {
-                Option::Some(String::from_raw_slice(slice))
+                Option::Some(String::from(slice))
             },
             Option::None => Option::None,
         }

--- a/libs/strings/string/SPECIFICATION.md
+++ b/libs/strings/string/SPECIFICATION.md
@@ -16,10 +16,6 @@ The String library can be used anytime a string's length is unknown at compile t
 
 Joins two `String` instances into a single larger `String`. 
 
-### `as_vec()`
-
-Convert the `String` struct to a `Vec` of `u8` bytes. 
-
 ### `capacity()`
 
 Returns the total amount of memory on the heap allocated to the `String` which can be filled with bytes. 
@@ -32,11 +28,7 @@ Truncates the `String` to a length of 0 and will appear empty. This does not cle
 
 ### `from()`
 
-A new instance of a `String` will be created from the `Bytes` type.
-
-### `from_utf8()`
-
-A new instance of a `String` will be created from a vector of `u8`'s.
+A new instance of a `String` will be created from `Bytes`, `raw_slice`, or `Vec<u8>`.
 
 ### `insert()`
 
@@ -44,7 +36,7 @@ Inserts a new byte at the specified index in the `String`.
 
 ### `into()`
 
-Convert the `String` struct to the `Bytes` type. 
+Convert the `String` struct to a `Vec` of `u8` bytes, `raw_slice`, or `Bytes`. 
 
 ### `is_empty()`
 

--- a/libs/strings/string/src/lib.sw
+++ b/libs/strings/string/src/lib.sw
@@ -7,11 +7,6 @@ pub struct String {
 }
 
 impl String {
-    /// Returns a `Vec<u8>` of the bytes stored for the `String`.
-    pub fn as_vec(self) -> Vec<u8> {
-        self.bytes.into_vec_u8()
-    }
-
     /// Gets the amount of memory on the heap allocated to the `String`.
     pub fn capacity(self) -> u64 {
         self.bytes.capacity()
@@ -20,18 +15,6 @@ impl String {
     /// Truncates this `String` to a length of zero, removing all contents.
     pub fn clear(ref mut self) {
         self.bytes.clear()
-    }
-
-    /// Converts a vector of bytes to a `String`.
-    ///
-    /// # Arguments
-    ///
-    /// * `bytes` - The vector of `u8` bytes which will be converted into a `String`.
-    pub fn from_utf8(bytes: Vec<u8>) -> Self {
-        let mut bytes = bytes;
-        Self {
-            bytes: Bytes::from_vec_u8(bytes),
-        }
     }
 
     /// Inserts a byte at the index within the `String`.
@@ -124,13 +107,6 @@ impl String {
             bytes: Bytes::with_capacity(capacity),
         }
     }
-
-    // Should be removed when https://github.com/FuelLabs/sway/issues/3637 is resovled
-    pub fn from_raw_slice(slice: raw_slice) -> Self {
-        Self {
-            bytes: Bytes::from_raw_slice(slice),
-        }
-    }
 }
 
 impl From<Bytes> for String {
@@ -173,17 +149,33 @@ impl String {
     }
 }
 
-// Uncomment when https://github.com/FuelLabs/sway/issues/3637 is resolved.
-// impl From<raw_slice> for String {
-//     fn from(slice: raw_slice) -> String {
-//         let mut bytes = Bytes::with_capacity(slice.number_of_bytes());
-//         bytes.buf.ptr = slice.ptr();
-//         Self {
-//             bytes
-//         }
-//     }
+impl From<raw_slice> for String {
+    fn from(slice: raw_slice) -> String {
+        Self {
+            bytes: Bytes::from_raw_slice(slice),
+        }
+    }
 
-//     fn into(self) -> raw_slice {
-//         asm(ptr: (self.bytes.buf.ptr(), self.bytes.len)) { ptr: raw_slice }
-//     }
-// }
+    fn into(self) -> raw_slice {
+        asm(ptr: (self.bytes.buf.ptr(), self.bytes.len)) { ptr: raw_slice }
+    }
+}
+
+impl From<Vec<u8>> for String {
+    /// Converts a vector of bytes to a `String`.
+    ///
+    /// # Arguments
+    ///
+    /// * `bytes` - The vector of `u8` bytes which will be converted into a `String`.
+    fn from(vec: Vec<u8>) -> Self {
+        let mut vec = vec;
+        Self {
+            bytes: Bytes::from_vec_u8(vec),
+        }
+    }
+
+    /// Returns a `Vec<u8>` of the bytes stored for the `String`.
+    fn into(self) -> Vec<u8> {
+        self.bytes.into_vec_u8()
+    }
+}

--- a/libs/strings/string/src/lib.sw
+++ b/libs/strings/string/src/lib.sw
@@ -150,7 +150,7 @@ impl String {
 }
 
 impl From<raw_slice> for String {
-    fn from(slice: raw_slice) -> String {
+    fn from(slice: raw_slice) -> Self {
         Self {
             bytes: Bytes::from_raw_slice(slice),
         }
@@ -166,7 +166,7 @@ impl From<Vec<u8>> for String {
     ///
     /// # Arguments
     ///
-    /// * `bytes` - The vector of `u8` bytes which will be converted into a `String`.
+    /// * `vec` - The vector of `u8` bytes which will be converted into a `String`.
     fn from(vec: Vec<u8>) -> Self {
         let mut vec = vec;
         Self {

--- a/tests/src/string/src/main.sw
+++ b/tests/src/string/src/main.sw
@@ -15,15 +15,15 @@ const NUMBER8 = 8u8;
 
 abi StringTest {
     fn test_append();
-    fn test_as_vec();
     fn test_capacity();
     fn test_clear();
-    fn test_from();
+    fn test_from_bytes();
     fn test_from_raw_slice();
-    fn test_from_utf8();
+    fn test_from_vec();
     fn test_insert();
-    fn test_into();
+    fn test_into_bytes();
     fn test_into_raw_slice();
+    fn test_into_vec();
     fn test_is_empty();
     fn test_len();
     fn test_new();
@@ -62,26 +62,6 @@ impl StringTest for Contract {
         assert(string1.nth(3).unwrap() == NUMBER3);
         assert(string1.nth(4).unwrap() == NUMBER4);
         assert(string1.nth(5).unwrap() == NUMBER5);
-    }
-
-    fn test_as_vec() {
-        let mut string = String::new();
-
-        let bytes = string.as_vec();
-        assert(bytes.len() == string.len());
-        assert(bytes.capacity() == string.capacity());
-
-        string.push(NUMBER0);
-        let bytes = string.as_vec();
-        assert(bytes.len() == string.len());
-        assert(bytes.capacity() == string.capacity());
-        assert(bytes.get(0).unwrap() == string.nth(0).unwrap());
-
-        string.push(NUMBER1);
-        let mut bytes = string.as_vec();
-        assert(bytes.len() == string.len());
-        assert(bytes.capacity() == string.capacity());
-        assert(bytes.get(1).unwrap() == string.nth(1).unwrap());
     }
 
     fn test_capacity() {
@@ -156,7 +136,7 @@ impl StringTest for Contract {
         assert(string.is_empty());
     }
 
-    fn test_from() {
+    fn test_from_bytes() {
         let mut bytes = Bytes::new();
 
         bytes.push(NUMBER0);
@@ -183,14 +163,14 @@ impl StringTest for Contract {
         bytes.push(NUMBER4);
 
         let raw_slice = bytes.as_raw_slice();
-        let mut string_from_slice = String::from_raw_slice(raw_slice);
+        let mut string_from_slice = String::from(raw_slice);
         assert(bytes.len() == string_from_slice.len());
         assert(bytes.get(0).unwrap() == string_from_slice.nth(0).unwrap());
         assert(bytes.get(1).unwrap() == string_from_slice.nth(1).unwrap());
         assert(bytes.get(2).unwrap() == string_from_slice.nth(2).unwrap());
     }
 
-    fn test_from_utf8() {
+    fn test_from_vec() {
         let mut vec: Vec<u8> = Vec::new();
 
         vec.push(NUMBER0);
@@ -199,7 +179,7 @@ impl StringTest for Contract {
         vec.push(NUMBER3);
         vec.push(NUMBER4);
 
-        let mut string_from_uft8 = String::from_utf8(vec);
+        let mut string_from_uft8 = String::from(vec);
         assert(vec.len() == string_from_uft8.len());
         assert(vec.capacity() == string_from_uft8.capacity());
         assert(vec.get(0).unwrap() == string_from_uft8.nth(0).unwrap());
@@ -229,21 +209,21 @@ impl StringTest for Contract {
         assert(string.nth(string.len() - 2).unwrap() == NUMBER5);
     }
 
-    fn test_into() {
+    fn test_into_bytes() {
         let mut string = String::new();
 
-        let bytes = string.into();
+        let bytes: Bytes = string.into();
         assert(bytes.len() == string.len());
         assert(bytes.capacity() == string.capacity());
 
         string.push(NUMBER0);
-        let bytes = string.into();
+        let bytes: Bytes = string.into();
         assert(bytes.len() == string.len());
         assert(bytes.capacity() == string.capacity());
         assert(bytes.get(0).unwrap() == string.nth(0).unwrap());
 
         string.push(NUMBER1);
-        let mut bytes = string.into();
+        let mut bytes: Bytes = string.into();
         assert(bytes.len() == string.len());
         assert(bytes.capacity() == string.capacity());
         assert(bytes.get(1).unwrap() == string.nth(1).unwrap());
@@ -259,22 +239,49 @@ impl StringTest for Contract {
     fn test_into_raw_slice() {
         let mut string = String::new();
 
-        let raw_slice: raw_slice = string.as_raw_slice();
+        let raw_slice: raw_slice = string.into();
         assert(raw_slice.number_of_bytes() == string.len());
 
         string.push(NUMBER0);
-        let raw_slice = string.as_raw_slice();
+        let raw_slice: raw_slice = string.into();
         assert(raw_slice.number_of_bytes() == string.len());
         assert(raw_slice.ptr().read_byte() == string.nth(0).unwrap());
 
         string.push(NUMBER1);
-        let mut raw_slice = string.as_raw_slice();
+        let mut raw_slice: raw_slice = string.into();
         assert(raw_slice.number_of_bytes() == string.len());
         assert(raw_slice.ptr().add_uint_offset(1).read_byte() == string.nth(1).unwrap());
 
-        let mut raw_slice = string.as_raw_slice();
+        let mut raw_slice: raw_slice = string.as_raw_slice();
         assert(raw_slice.number_of_bytes() == string.len());
         assert(raw_slice.ptr().read_byte() == string.nth(0).unwrap());
+    }
+
+    fn test_into_vec() {
+        let mut string = String::new();
+
+        let vec: Vec<u8> = string.into();
+        assert(vec.len() == string.len());
+        assert(vec.capacity() == string.capacity());
+
+        string.push(NUMBER0);
+        let vec: Vec<u8> = string.into();
+        assert(vec.len() == string.len());
+        assert(vec.capacity() == string.capacity());
+        assert(vec.get(0).unwrap() == string.nth(0).unwrap());
+
+        string.push(NUMBER1);
+        let mut vec: Vec<u8> = string.into();
+        assert(vec.len() == string.len());
+        assert(vec.capacity() == string.capacity());
+        assert(vec.get(1).unwrap() == string.nth(1).unwrap());
+
+        let result_string = string.pop().unwrap();
+        let result_vec = vec.pop().unwrap();
+        assert(result_vec == result_string);
+        assert(vec.len() == string.len());
+        assert(vec.capacity() == string.capacity());
+        assert(vec.get(0).unwrap() == string.nth(0).unwrap());
     }
 
     fn test_is_empty() {

--- a/tests/src/string/tests/functions/from_bytes.rs
+++ b/tests/src/string/tests/functions/from_bytes.rs
@@ -1,4 +1,4 @@
-use crate::string::tests::utils::{abi_calls::from, test_helpers::setup};
+use crate::string::tests::utils::{abi_calls::from_bytes, test_helpers::setup};
 
 mod success {
 
@@ -8,6 +8,6 @@ mod success {
     async fn converts_from_bytes() {
         let instance = setup().await;
 
-        from(&instance).await;
+        from_bytes(&instance).await;
     }
 }

--- a/tests/src/string/tests/functions/from_vec.rs
+++ b/tests/src/string/tests/functions/from_vec.rs
@@ -1,4 +1,4 @@
-use crate::string::tests::utils::{abi_calls::from_utf8, test_helpers::setup};
+use crate::string::tests::utils::{abi_calls::from_vec, test_helpers::setup};
 
 mod success {
 
@@ -8,6 +8,6 @@ mod success {
     async fn converts_from_utf8_vec() {
         let instance = setup().await;
 
-        from_utf8(&instance).await;
+        from_vec(&instance).await;
     }
 }

--- a/tests/src/string/tests/functions/into_bytes.rs
+++ b/tests/src/string/tests/functions/into_bytes.rs
@@ -1,4 +1,4 @@
-use crate::string::tests::utils::{abi_calls::into, test_helpers::setup};
+use crate::string::tests::utils::{abi_calls::into_bytes, test_helpers::setup};
 
 mod success {
 
@@ -8,6 +8,6 @@ mod success {
     async fn returns_bytes() {
         let instance = setup().await;
 
-        into(&instance).await;
+        into_bytes(&instance).await;
     }
 }

--- a/tests/src/string/tests/functions/into_vec.rs
+++ b/tests/src/string/tests/functions/into_vec.rs
@@ -1,4 +1,4 @@
-use crate::string::tests::utils::{abi_calls::as_vec, test_helpers::setup};
+use crate::string::tests::utils::{abi_calls::into_vec, test_helpers::setup};
 
 mod success {
 
@@ -8,6 +8,6 @@ mod success {
     async fn returns_vec() {
         let instance = setup().await;
 
-        as_vec(&instance).await;
+        into_vec(&instance).await;
     }
 }

--- a/tests/src/string/tests/functions/mod.rs
+++ b/tests/src/string/tests/functions/mod.rs
@@ -1,12 +1,12 @@
 mod append;
-mod as_vec;
+mod into_vec;
 mod capacity;
 mod clear;
-mod from;
+mod from_bytes;
 mod from_raw_slice;
-mod from_utf8;
+mod from_vec;
 mod insert;
-mod into;
+mod into_bytes;
 mod into_raw_slice;
 mod is_empty;
 mod len;

--- a/tests/src/string/tests/functions/mod.rs
+++ b/tests/src/string/tests/functions/mod.rs
@@ -1,5 +1,4 @@
 mod append;
-mod into_vec;
 mod capacity;
 mod clear;
 mod from_bytes;
@@ -8,6 +7,7 @@ mod from_vec;
 mod insert;
 mod into_bytes;
 mod into_raw_slice;
+mod into_vec;
 mod is_empty;
 mod len;
 mod new;

--- a/tests/src/string/tests/utils/mod.rs
+++ b/tests/src/string/tests/utils/mod.rs
@@ -20,8 +20,8 @@ pub mod abi_calls {
         contract.methods().test_append().call().await.unwrap()
     }
 
-    pub async fn as_vec(contract: &StringTestLib<WalletUnlocked>) -> FuelCallResponse<()> {
-        contract.methods().test_as_vec().call().await.unwrap()
+    pub async fn into_vec(contract: &StringTestLib<WalletUnlocked>) -> FuelCallResponse<()> {
+        contract.methods().test_into_vec().call().await.unwrap()
     }
 
     pub async fn capacity(contract: &StringTestLib<WalletUnlocked>) -> FuelCallResponse<()> {
@@ -32,8 +32,8 @@ pub mod abi_calls {
         contract.methods().test_clear().call().await.unwrap()
     }
 
-    pub async fn from(contract: &StringTestLib<WalletUnlocked>) -> FuelCallResponse<()> {
-        contract.methods().test_from().call().await.unwrap()
+    pub async fn from_bytes(contract: &StringTestLib<WalletUnlocked>) -> FuelCallResponse<()> {
+        contract.methods().test_from_bytes().call().await.unwrap()
     }
 
     pub async fn from_raw_slice(contract: &StringTestLib<WalletUnlocked>) -> FuelCallResponse<()> {
@@ -45,16 +45,16 @@ pub mod abi_calls {
             .unwrap()
     }
 
-    pub async fn from_utf8(contract: &StringTestLib<WalletUnlocked>) -> FuelCallResponse<()> {
-        contract.methods().test_from_utf8().call().await.unwrap()
+    pub async fn from_vec(contract: &StringTestLib<WalletUnlocked>) -> FuelCallResponse<()> {
+        contract.methods().test_from_vec().call().await.unwrap()
     }
 
     pub async fn insert(contract: &StringTestLib<WalletUnlocked>) -> FuelCallResponse<()> {
         contract.methods().test_insert().call().await.unwrap()
     }
 
-    pub async fn into(contract: &StringTestLib<WalletUnlocked>) -> FuelCallResponse<()> {
-        contract.methods().test_into().call().await.unwrap()
+    pub async fn into_bytes(contract: &StringTestLib<WalletUnlocked>) -> FuelCallResponse<()> {
+        contract.methods().test_into_bytes().call().await.unwrap()
     }
 
     pub async fn into_raw_slice(contract: &StringTestLib<WalletUnlocked>) -> FuelCallResponse<()> {


### PR DESCRIPTION
## Type of change

<!--Delete points that do not apply-->

- Improvement (refactoring, restructuring repository, cleaning tech debt, ...)

## Changes

The following changes have been made:

- Uses `From<Vec>` instead of `as_vec` and `from_utf8`
- Uses `From<raw_slice>` instead of `from_raw_slice` 

## Notes

- This is a breaking change

## Related Issues

<!--Delete everything after the "#" symbol and replace it with a number. No spaces between hash and number-->

Closes #170 
