### PR TITLE
Update signed integers library to SRC-2 inline docs standard

### DIFF
--- a/libs/signed_integers/src/common.sw
+++ b/libs/signed_integers/src/common.sw
@@ -1,5 +1,11 @@
 library;
 
+/// Trait for the Two's Complement of a value.
 pub trait TwosComplement {
+    /// Returns the two's complement of a value.
+    ///
+    /// # Returns
+    ///
+    /// * [Self] - The value as two's complement.
     fn twos_complement(self) -> Self;
 }

--- a/libs/signed_integers/src/errors.sw
+++ b/libs/signed_integers/src/errors.sw
@@ -1,5 +1,7 @@
 library;
 
+/// Error log for unexpected behavior has occured.
 pub enum Error {
+    /// Emitted when division by zero has occured.
     ZeroDivisor: (),
 }

--- a/libs/signed_integers/src/i128.sw
+++ b/libs/signed_integers/src/i128.sw
@@ -5,15 +5,35 @@ use ::common::TwosComplement;
 use ::errors::Error;
 
 /// The 128-bit signed integer type.
+///
+/// # Additional Information
+///
 /// Represented as an underlying U128 value.
 /// Actual value is underlying value minus 2 ^ 127
 /// Max value is 2 ^ 127 - 1, min value is - 2 ^ 127
 pub struct I128 {
+    /// The underlying unsigned number representing the `I128` type.
     underlying: U128,
 }
 
 impl I128 {
-    /// The underlying value that corresponds to zero signed value
+    /// The underlying value that corresponds to zero signed value.
+    ///
+    /// # Returns
+    ///
+    /// * [U128] - The unsigned integer value representing a zero signed value.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use signed_integers::I128;
+    /// use std::U128::*;
+    ///
+    /// fn foo() {
+    ///     let zero = I128::indent();
+    ///     assert(zero == U128{upper: 1, lower: 0});
+    /// }
+    /// ```
     pub fn indent() -> U128 {
         U128 {
             upper: 1,
@@ -53,16 +73,68 @@ impl core::ops::Ord for I128 {
 
 impl I128 {
     /// The size of this type in bits.
+    ///
+    /// # Returns
+    ///
+    /// [u32] - The defined size of the `I128` type.
+    ///
+    /// # Examples
+    ///
+    /// ``sway
+    /// use signed_integers::I128;
+    ///
+    /// fn foo() {
+    ///     let bits = I128::bits();
+    ///     assert(bits == 128u32);
+    /// }
+    /// ```
     pub fn bits() -> u32 {
         128
     }
 
-    /// Helper function to get a positive value from an unsigned number
+    /// Helper function to get a positive value from an unsigned number.
+    ///
+    /// # Arguments
+    ///
+    /// * `underlying`: [U128] - The unsigned number to become the underlying value for the `I128`.
+    ///
+    /// # Returns
+    ///
+    /// * [I128] - The newly created `I128` struct.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use signed_integers::I128;
+    /// use std::U128::*;
+    ///
+    /// fn foo() {
+    ///     let underlying = U128::from(0, 1);
+    ///     let i128 = I128::from_uint(underlying);
+    ///     assert(i128.underlying == underlying);
+    /// }
+    /// ```
     pub fn from_uint(underlying: U128) -> Self {
         Self { underlying }
     }
 
-    /// The largest value that can be represented by this integer type,
+    /// The largest value that can be represented by this integer type.
+    ///
+    /// # Returns
+    ///
+    /// * [I128] - The newly created `I128` struct.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use signed_integers::I128;
+    /// use std::U128::*;
+    /// 
+    /// fn foo() {
+    ///     let i128 = I128::max();
+    ///     assert(i128.underlying == U128::max());
+    /// }
+    /// ```
     pub fn max() -> Self {
         Self {
             underlying: U128::max(),
@@ -70,13 +142,49 @@ impl I128 {
     }
 
     /// The smallest value that can be represented by this integer type.
+    ///
+    /// # Returns
+    ///
+    /// * [I128] - The newly created `I128` type.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use signed_integers::I128;
+    /// use std::U128::*;
+    ///
+    /// fn foo() {
+    ///     let i128 = I128::min();
+    ///     assert(i128.underlying == U128::min());
+    /// }
+    /// ```
     pub fn min() -> Self {
         Self {
             underlying: U128::min(),
         }
     }
 
-    /// Helper function to get a negative value of an unsigned number
+    /// Helper function to get a negative value of an unsigned number.
+    ///
+    /// # Arguments
+    ///
+    /// * `value`: [U128] - The unsigned number to negate.
+    ///
+    /// # Returns
+    ///
+    /// * [I128] - The newly created `I128` struct.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use signed_integers::I128;
+    /// use std::U128::*;
+    ///
+    /// fn foo() {
+    ///     let underlying = U128::from(0,1);
+    ///     let i128 = I128::neg_from(underlying);
+    /// }
+    /// ```
     pub fn neg_from(value: U128) -> Self {
         Self {
             underlying: Self::indent() - value,
@@ -84,6 +192,26 @@ impl I128 {
     }
 
     /// Initializes a new, zeroed I128.
+    ///
+    /// # Additional Information
+    ///
+    /// The zero value of I128 is U128{upper: 1, lower: 0}.
+    ///
+    /// # Returns
+    ///
+    /// * [I128] - The newly created `I128` struct.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use signed_integers::I128;
+    /// use std::U128::*;
+    ///
+    /// fn foo() {
+    ///     let i128 = I128::new();
+    ///     assert(i128.underlying == U128{upper: 1, lower: 0});
+    /// }
+    /// ```
     pub fn new() -> Self {
         Self {
             underlying: Self::indent(),

--- a/libs/signed_integers/src/i16.sw
+++ b/libs/signed_integers/src/i16.sw
@@ -4,15 +4,34 @@ use ::errors::Error;
 use ::common::TwosComplement;
 
 /// The 16-bit signed integer type.
+///
+/// # Additional Information
+///
 /// Represented as an underlying u16 value.
 /// Actual value is underlying value minus 2 ^ 15
 /// Max value is 2 ^ 15 - 1, min value is - 2 ^ 15
 pub struct I16 {
+    /// The underlying value representing the signed integer.
     underlying: u16,
 }
 
 impl I16 {
-    /// The underlying value that corresponds to zero signed value
+    /// The underlying value that corresponds to zero signed value.
+    ///
+    /// # Returns
+    ///
+    /// [u16] - The `u16` value that represents the zero signed value.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use signed_integers::I16;
+    ///
+    /// fn foo() {
+    ///     let zero = I16::indent();
+    ///     assert(zero == 32768u16);
+    /// }
+    /// ```
     pub fn indent() -> u16 {
         32768u16
     }
@@ -49,16 +68,66 @@ impl core::ops::Ord for I16 {
 
 impl I16 {
     /// The size of this type in bits.
+    ///
+    /// # Returns
+    ///
+    /// [u32] - The defined size of the `I16` type.
+    ///
+    /// # Examples
+    ///
+    /// ``sway
+    /// use signed_integers::I16;
+    ///
+    /// fn foo() {
+    ///     let bits = I16::bits();
+    ///     assert(bits == 16u32);
+    /// }
+    /// ```
     pub fn bits() -> u32 {
         16
     }
 
     /// Helper function to get a positive value from an unsigned number
+    ///
+    /// # Arguments
+    ///
+    /// * `underlying`: [u16] - The unsigned number to become the underlying value for the `I16`.
+    ///
+    /// # Returns
+    ///
+    /// * [I16] - The newly created `I16` struct.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use signed_integers::I16;
+    ///
+    /// fn foo() {
+    ///     let underlying = 1u16;
+    ///     let i16 = I16::from_uint(underlying);
+    ///     assert(i16.underlying == underlying);
+    /// }
+    /// ```
     pub fn from_uint(underlying: u16) -> Self {
         Self { underlying }
     }
 
-    /// The largest value that can be represented by this integer type,
+    /// The largest value that can be represented by this integer type.
+    ///
+    /// # Returns
+    ///
+    /// * [I16] - The newly created `I16` struct.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use signed_integers::I16;
+    /// 
+    /// fn foo() {
+    ///     let i16 = I16::max();
+    ///     assert(i16.underlying == u16::max());
+    /// }
+    /// ```
     pub fn max() -> Self {
         Self {
             underlying: u16::max(),
@@ -66,13 +135,47 @@ impl I16 {
     }
 
     /// The smallest value that can be represented by this integer type.
+    ///
+    /// # Returns
+    ///
+    /// * [I16] - The newly created `I16` type.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use signed_integers::I16;
+    ///
+    /// fn foo() {
+    ///     let i16 = I16::min();
+    ///     assert(i16.underlying == u16::min());
+    /// }
+    /// ```
     pub fn min() -> Self {
         Self {
             underlying: u16::min(),
         }
     }
 
-    /// Helper function to get a negative value of an unsigned number
+    /// Helper function to get a negative value of an unsigned number.
+    ///
+    /// # Arguments
+    ///
+    /// * `value`: [u16] - The unsigned number to negate.
+    ///
+    /// # Returns
+    ///
+    /// * [I16] - The newly created `I16` struct.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use signed_integers::I16;
+    ///
+    /// fn foo() {
+    ///     let underlying = 1u16;
+    ///     let i16 = I16::neg_from(underlying);
+    /// }
+    /// ```
     pub fn neg_from(value: u16) -> Self {
         Self {
             underlying: Self::indent() - value,
@@ -80,6 +183,25 @@ impl I16 {
     }
 
     /// Initializes a new, zeroed I16.
+    ///
+    /// # Additional Information
+    ///
+    /// The zero value of I16 is 32768u16.
+    ///
+    /// # Returns
+    ///
+    /// * [I16] - The newly created `I16` struct.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use signed_integers::I16;
+    ///
+    /// fn foo() {
+    ///     let i16 = I16::new();
+    ///     assert(i16.underlying == 32768u16);
+    /// }
+    /// ```
     pub fn new() -> Self {
         Self {
             underlying: Self::indent(),

--- a/libs/signed_integers/src/i256.sw
+++ b/libs/signed_integers/src/i256.sw
@@ -5,6 +5,9 @@ use ::common::TwosComplement;
 use ::errors::Error;
 
 /// The 256-bit signed integer type.
+///
+/// # Additional Information
+///
 /// Represented as an underlying U256 value.
 /// Actual value is underlying value minus 2 ^ 255
 /// Max value is 2 ^ 255 - 1, min value is - 2 ^ 255
@@ -13,7 +16,23 @@ pub struct I256 {
 }
 
 impl I256 {
-    /// The underlying value that corresponds to zero signed value
+    /// The underlying value that corresponds to zero signed value.
+    ///
+    /// # Returns
+    ///
+    /// * [U256] - The unsigned integer value representing a zero signed value.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use signed_integers::I256;
+    /// use std::U256::*;
+    ///
+    /// fn foo() {
+    ///     let zero = I256::indent();
+    ///     assert(zero == U256{a: 0, b: 1, c: 0, d: 0});
+    /// }
+    /// ```
     pub fn indent() -> U256 {
         U256 {
             a: 0,
@@ -54,16 +73,68 @@ impl core::ops::Ord for I256 {
 
 impl I256 {
     /// The size of this type in bits.
+    ///
+    /// # Returns
+    ///
+    /// [u32] - The defined size of the `I256` type.
+    ///
+    /// # Examples
+    ///
+    /// ``sway
+    /// use signed_integers::I256;
+    ///
+    /// fn foo() {
+    ///     let bits = I256::bits();
+    ///     assert(bits == 128u32);
+    /// }
+    /// ```
     pub fn bits() -> u32 {
         128
     }
 
-    /// Helper function to get a signed number from with an underlying
+    /// Helper function to get a signed number from with an underlying.
+    ///
+    /// # Arguments
+    ///
+    /// * `underlying`: [U256] - The unsigned number to become the underlying value for the `I256`.
+    ///
+    /// # Returns
+    ///
+    /// * [I256] - The newly created `I256` struct.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use signed_integers::I256;
+    /// use std::U256::*;
+    ///
+    /// fn foo() {
+    ///     let underlying = U256::from(0,0, 0, 1);
+    ///     let i256 = I256::from_uint(underlying);
+    ///     assert(256.underlying == underlying);
+    /// }
+    /// ```
     pub fn from_uint(underlying: U256) -> Self {
         Self { underlying }
     }
 
-    /// The largest value that can be represented by this integer type,
+    /// The largest value that can be represented by this integer type.
+    ///
+    /// # Returns
+    ///
+    /// * [I256] - The newly created `I256` struct.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use signed_integers::I256;
+    /// use std::U256::*;
+    /// 
+    /// fn foo() {
+    ///     let i256 = I256::max();
+    ///     assert(i256.underlying == U256::max());
+    /// }
+    /// ```
     pub fn max() -> Self {
         Self {
             underlying: U256::max(),
@@ -71,13 +142,49 @@ impl I256 {
     }
 
     /// The smallest value that can be represented by this integer type.
+    ///
+    /// # Returns
+    ///
+    /// * [I256] - The newly created `I256` type.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use signed_integers::I256;
+    /// use std::U256::*;
+    ///
+    /// fn foo() {
+    ///     let i256 = I256::min();
+    ///     assert(i256.underlying == U256::min());
+    /// }
+    /// ```
     pub fn min() -> Self {
         Self {
             underlying: U256::min(),
         }
     }
 
-    /// Helper function to get a negative value of an unsigned number
+    /// Helper function to get a negative value of an unsigned number.
+    ///
+    /// # Arguments
+    ///
+    /// * `value`: [U256] - The unsigned number to negate.
+    ///
+    /// # Returns
+    ///
+    /// * [I256] - The newly created `I256` struct.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use signed_integers::I256;
+    /// use std::U256::*;
+    ///
+    /// fn foo() {
+    ///     let underlying = U256::from(0, 0, 0, 1);
+    ///     let i256 = I256::neg_from(underlying);
+    /// }
+    /// ```
     pub fn neg_from(value: U256) -> Self {
         Self {
             underlying: Self::indent() - value,
@@ -85,6 +192,26 @@ impl I256 {
     }
 
     /// Initializes a new, zeroed I256.
+    ///
+    /// # Additional Information
+    ///
+    /// The zero value of I256 is U256{a: 0, b: 1, c: 0, d: 0}.
+    ///
+    /// # Returns
+    ///
+    /// * [I256] - The newly created `I256` struct.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use signed_integers::I256;
+    /// use std::U256::*;
+    ///
+    /// fn foo() {
+    ///     let i256 = I256::new();
+    ///     assert(i256.underlying == U256{a: 0, b: 1, c: 0, d: 0});
+    /// }
+    /// ```  
     pub fn new() -> Self {
         Self {
             underlying: Self::indent(),

--- a/libs/signed_integers/src/i32.sw
+++ b/libs/signed_integers/src/i32.sw
@@ -4,15 +4,34 @@ use ::common::TwosComplement;
 use ::errors::Error;
 
 /// The 32-bit signed integer type.
+///
+/// # Additional Information
+///
 /// Represented as an underlying u32 value.
 /// Actual value is underlying value minus 2 ^ 31
 /// Max value is 2 ^ 31 - 1, min value is - 2 ^ 31
 pub struct I32 {
+    /// The underlying u32 type that represent a I32.
     underlying: u32,
 }
 
 impl I32 {
-    /// The underlying value that corresponds to zero signed value
+    /// The underlying value that corresponds to zero signed value.
+    ///
+    /// # Returns
+    ///
+    /// * [u32] - The unsigned integer value representing a zero signed value.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use signed_integers::I32;
+    ///
+    /// fn foo() {
+    ///     let zero = I32::indent();
+    ///     assert(zero == 2147483648u32);
+    /// }
+    /// ```
     pub fn indent() -> u32 {
         2147483648u32
     }
@@ -48,16 +67,66 @@ impl core::ops::Ord for I32 {
 
 impl I32 {
     /// The size of this type in bits.
+    ///
+    /// # Returns
+    ///
+    /// [u32] - The defined size of the `I32` type.
+    ///
+    /// # Examples
+    ///
+    /// ``sway
+    /// use signed_integers::I32;
+    ///
+    /// fn foo() {
+    ///     let bits = I32::bits();
+    ///     assert(bits == 32u32);
+    /// }
+    /// ```
     pub fn bits() -> u32 {
         32
     }
 
-    /// Helper function to get a signed number from with an underlying
+    /// Helper function to get a signed number from with an underlying.
+    ///
+    /// # Arguments
+    ///
+    /// * `underlying`: [u32] - The unsigned number to become the underlying value for the `I32`.
+    ///
+    /// # Returns
+    ///
+    /// * [I32] - The newly created `I32` struct.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use signed_integers::I32;
+    ///
+    /// fn foo() {
+    ///     let underlying = 1u32;
+    ///     let i32 = I32::from_uint(underlying);
+    ///     assert(i32.underlying == underlying);
+    /// }
+    /// ```
     pub fn from_uint(underlying: u32) -> Self {
         Self { underlying }
     }
 
-    /// The largest value that can be represented by this integer type,
+    /// The largest value that can be represented by this integer type.
+    ///
+    /// # Returns
+    ///
+    /// * [I32] - The newly created `I32` struct.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use signed_integers::I32;
+    /// 
+    /// fn foo() {
+    ///     let i32 = I32::max();
+    ///     assert(i32.underlying == u32::max());
+    /// }
+    /// ```
     pub fn max() -> Self {
         Self {
             underlying: u32::max(),
@@ -65,13 +134,47 @@ impl I32 {
     }
 
     /// The smallest value that can be represented by this integer type.
+    ///
+    /// # Returns
+    ///
+    /// * [I32] - The newly created `I32` type.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use signed_integers::I32;
+    ///
+    /// fn foo() {
+    ///     let i32 = I32::min();
+    ///     assert(i32.underlying == u32::min());
+    /// }
+    /// ```
     pub fn min() -> Self {
         Self {
             underlying: u32::min(),
         }
     }
 
-    /// Helper function to get a negative value of an unsigned numbers
+    /// Helper function to get a negative value of an unsigned numbers.
+    ///
+    /// # Arguments
+    ///
+    /// * `value`: [u32] - The unsigned number to negate.
+    ///
+    /// # Returns
+    ///
+    /// * [I32] - The newly created `I32` struct.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use signed_integers::I32;
+    ///
+    /// fn foo() {
+    ///     let underlying = 1u32;
+    ///     let i32 = I32::neg_from(underlying);
+    /// }
+    /// ```
     pub fn neg_from(value: u32) -> Self {
         Self {
             underlying: Self::indent() - value,
@@ -79,6 +182,25 @@ impl I32 {
     }
 
     /// Initializes a new, zeroed I32.
+    ///
+    /// # Additional Information
+    ///
+    /// The zero value of I32 is 2147483648u32.
+    ///
+    /// # Returns
+    ///
+    /// * [I32] - The newly created `I32` struct.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use signed_integers::I32;
+    ///
+    /// fn foo() {
+    ///     let i32 = I32::new();
+    ///     assert(i32.underlying == 2147483648u32);
+    /// }
+    /// ```
     pub fn new() -> Self {
         Self {
             underlying: Self::indent(),

--- a/libs/signed_integers/src/i64.sw
+++ b/libs/signed_integers/src/i64.sw
@@ -4,15 +4,34 @@ use ::common::TwosComplement;
 use ::errors::Error;
 
 /// The 64-bit signed integer type.
+///
+/// # Additional Information
+///
 /// Represented as an underlying u64 value.
 /// Actual value is underlying value minus 2 ^ 63
 /// Max value is 2 ^ 63 - 1, min value is - 2 ^ 63
 pub struct I64 {
+    /// The underlying unsigned number representing the `I64` type.
     underlying: u64,
 }
 
 impl I64 {
-    /// The underlying value that corresponds to zero signed value
+    /// The underlying value that corresponds to zero signed value.
+    ///
+    /// # Returns
+    ///
+    /// * [u64] - The unsigned integer value representing a zero signed value.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use signed_integers::I64;
+    ///
+    /// fn foo() {
+    ///     let zero = I64::indent();
+    ///     assert(zero == 9223372036854775808u64);
+    /// }
+    /// ```
     pub fn indent() -> u64 {
         9223372036854775808u64
     }
@@ -48,16 +67,66 @@ impl core::ops::Ord for I64 {
 
 impl I64 {
     /// The size of this type in bits.
+    ///
+    /// # Returns
+    ///
+    /// [u32] - The defined size of the `I64` type.
+    ///
+    /// # Examples
+    ///
+    /// ``sway
+    /// use signed_integers::I64;
+    ///
+    /// fn foo() {
+    ///     let bits = I64::bits();
+    ///     assert(bits == 64u32);
+    /// }
+    /// ```
     pub fn bits() -> u32 {
         64
     }
 
-    /// Helper function to get a signed number from with an underlying
+    /// Helper function to get a signed number from with an underlying.
+    ///
+    /// # Arguments
+    ///
+    /// * `underlying`: [u64] - The unsigned number to become the underlying value for the `I64`.
+    ///
+    /// # Returns
+    ///
+    /// * [I64] - The newly created `I64` struct.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use signed_integers::I64;
+    ///
+    /// fn foo() {
+    ///     let underlying = 1u64;
+    ///     let i64 = I64::from_uint(underlying);
+    ///     assert(i64.underlying == underlying);
+    /// }
+    /// ```
     pub fn from_uint(underlying: u64) -> Self {
         Self { underlying }
     }
 
-    /// The largest value that can be represented by this integer type,
+    /// The largest value that can be represented by this integer type.
+    ///
+    /// # Returns
+    ///
+    /// * [I64] - The newly created `I64` struct.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use signed_integers::I64;
+    /// 
+    /// fn foo() {
+    ///     let i64 = I64::max();
+    ///     assert(i64.underlying == u64::max());
+    /// }
+    /// ```
     pub fn max() -> Self {
         Self {
             underlying: u64::max(),
@@ -65,13 +134,47 @@ impl I64 {
     }
 
     /// The smallest value that can be represented by this integer type.
+    ///
+    /// # Returns
+    ///
+    /// * [I64] - The newly created `I64` type.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use signed_integers::I64;
+    ///
+    /// fn foo() {
+    ///     let i64 = I64::min();
+    ///     assert(i64.underlying == u64::min());
+    /// }
+    /// ```
     pub fn min() -> Self {
         Self {
             underlying: u64::min(),
         }
     }
 
-    /// Helper function to get a negative value of an unsigned number
+    /// Helper function to get a negative value of an unsigned number.
+    ///
+    /// # Arguments
+    ///
+    /// * `value`: [u64] - The unsigned number to negate.
+    ///
+    /// # Returns
+    ///
+    /// * [I64] - The newly created `I64` struct.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use signed_integers::I64;
+    ///
+    /// fn foo() {
+    ///     let underlying = 1u64;
+    ///     let i64 = I64::neg_from(underlying);
+    /// }
+    /// ```
     pub fn neg_from(value: u64) -> Self {
         Self {
             underlying: Self::indent() - value,
@@ -79,6 +182,25 @@ impl I64 {
     }
 
     /// Initializes a new, zeroed I64.
+    ///
+    /// # Additional Information
+    ///
+    /// The zero value of I64 is 9223372036854775808.
+    ///
+    /// # Returns
+    ///
+    /// * [I64] - The newly created `I64` struct.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use signed_integers::I64;
+    ///
+    /// fn foo() {
+    ///     let i64 = I64::new();
+    ///     assert(i64.underlying == 9223372036854775808);
+    /// }
+    /// ```
     pub fn new() -> Self {
         Self {
             underlying: Self::indent(),

--- a/libs/signed_integers/src/i8.sw
+++ b/libs/signed_integers/src/i8.sw
@@ -4,15 +4,34 @@ use ::errors::Error;
 use ::common::TwosComplement;
 
 /// The 8-bit signed integer type.
+///
+/// # Additional Information
+///
 /// Represented as an underlying u8 value.
 /// Actual value is underlying value minus 2 ^ 7
 /// Max value is 2 ^ 7 - 1, min value is - 2 ^ 7
 pub struct I8 {
+    /// The underlying unsigned `u8` type that makes up the signed `I8` type.
     underlying: u8,
 }
 
 impl I8 {
-    /// The underlying value that corresponds to zero signed value
+    /// The underlying value that corresponds to zero signed value.
+    ///
+    /// # Returns
+    ///
+    /// * [u8] - The corresponding zero signed value.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use signed_integers::I8;
+    ///
+    /// fn foo() {
+    ///     let zero = I8::indent();
+    ///     assert(zero == 128u8);
+    /// }
+    /// ```
     pub fn indent() -> u8 {
         128u8
     }
@@ -48,16 +67,66 @@ impl core::ops::Ord for I8 {
 
 impl I8 {
     /// The size of this type in bits.
+    ///
+    /// # Returns
+    ///
+    /// * [u32] - The number of bits.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use signed_integers::I8;
+    ///
+    /// fn foo() {
+    ///     let bits = I8::bits();
+    ///     assert(bits == 8u32);
+    /// }
+    /// ```
     pub fn bits() -> u32 {
         8
     }
 
-    /// Helper function to get a signed number from with an underlying
+    /// Helper function to get a signed `I8` from an underlying `u8`.
+    ///
+    /// # Arguments
+    ///
+    /// * `underlying`: [u8] - The `u8` that will represent the `I8`.
+    ///
+    /// # Returns
+    ///
+    /// * [I8] - The newly created `I8` struct.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use signed_integers::I8;
+    ///
+    /// fn foo() {
+    ///     let underlying = 1u8;
+    ///     let i8 = I8::from_uint(underlying);
+    ///     assert(i8.underlying == underlying);
+    /// }
+    /// ```
     pub fn from_uint(underlying: u8) -> Self {
         Self { underlying }
     }
 
-    /// The largest value that can be represented by this integer type,
+    /// The largest value that can be represented by this integer type.
+    ///
+    /// # Returns
+    ///
+    /// * [I8] - The newly created `I8` struct.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use signed_integers::I8;
+    ///
+    /// fn foo() {
+    ///     let i8 = I8::max();
+    ///     assert(i8.underlying == u8::max());
+    /// }
+    /// ```
     pub fn max() -> Self {
         Self {
             underlying: u8::max(),
@@ -65,13 +134,47 @@ impl I8 {
     }
 
     /// The smallest value that can be represented by this integer type.
+    ///
+    /// # Returns
+    ///
+    /// * [I8] - The newly created `I8` struct.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use signed_integers::I8;
+    ///
+    /// fn foo() {
+    ///     let i8 = I8::new();
+    ///     assert(i8.underlying == u8::min());
+    /// }
+    /// ```
     pub fn min() -> Self {
         Self {
             underlying: u8::min(),
         }
     }
 
-    /// Helper function to get a negative value of an unsigned number
+    /// Helper function to get a negative value of an unsigned number.
+    ///
+    /// # Arguments
+    ///
+    /// * `value`: [u8] - The unsigned number to negate.
+    ///
+    /// # Returns
+    ///
+    /// * [I8] - The newly created `I8` struct.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use signed_integers::I8;
+    ///
+    /// fn foo() {
+    ///     let underlying = 1u8;
+    ///     let i8 = I8::neg_from(underlying);
+    /// }
+    /// ```
     pub fn neg_from(value: u8) -> Self {
         Self {
             underlying: Self::indent() - value,
@@ -79,6 +182,25 @@ impl I8 {
     }
 
     /// Initializes a new, zeroed I8.
+    ///
+    /// # Additional Information
+    ///
+    /// The zero value for I8 is 128u8.
+    ///
+    /// # Returns
+    ///
+    /// * [I8] - The newly created `I8` struct.
+    ///
+    /// # Examples
+    /// 
+    /// ```sway
+    /// use signed_integers::I8;
+    ///
+    /// fn foo() {
+    ///     let i8 = I8::new();
+    ///     assert(i8.underlying == 128u8);
+    /// }
+    /// ```
     pub fn new() -> Self {
         Self {
             underlying: Self::indent(),


### PR DESCRIPTION
## Type of change

<!--Delete points that do not apply-->

- Improvement (refactoring, restructuring repository, cleaning tech debt, ...)
- Documentation

## Changes

The following changes have been made:

- Updated inline docs for signed integers library to meet the SRC-2 inline docs standard.