### PR TITLE
Update Bits from `u32` to `u64`

### DIFF
--- a/libs/fixed_point/src/ifp128.sw
+++ b/libs/fixed_point/src/ifp128.sw
@@ -34,7 +34,7 @@ impl IFP128 {
     ///
     /// # Returns
     ///
-    /// [u32] - The defined size of the `IFP128` type.
+    /// [u64] - The defined size of the `IFP128` type.
     ///
     /// # Examples
     ///
@@ -43,10 +43,10 @@ impl IFP128 {
     ///
     /// fn foo() {
     ///     let bits = IFP128::bits();
-    ///     assert(bits == 72u32);
+    ///     assert(bits == 72);
     /// }
     /// ```
-    pub fn bits() -> u32 {
+    pub fn bits() -> u64 {
         72
     }
 

--- a/libs/fixed_point/src/ifp256.sw
+++ b/libs/fixed_point/src/ifp256.sw
@@ -34,7 +34,7 @@ impl IFP256 {
     ///
     /// # Returns
     ///
-    /// [u32] - The defined size of the `IFP256` type.
+    /// [u64] - The defined size of the `IFP256` type.
     ///
     /// # Examples
     ///
@@ -43,10 +43,10 @@ impl IFP256 {
     ///
     /// fn foo() {
     ///     let bits = IFP256::bits();
-    ///     assert(bits == 136u32);
+    ///     assert(bits == 136);
     /// }
     /// ```
-    pub fn bits() -> u32 {
+    pub fn bits() -> u64 {
         136
     }
 

--- a/libs/fixed_point/src/ifp64.sw
+++ b/libs/fixed_point/src/ifp64.sw
@@ -34,7 +34,7 @@ impl IFP64 {
     ///
     /// # Returns
     ///
-    /// [u32] - The defined size of the `IFP64` type.
+    /// [u64] - The defined size of the `IFP64` type.
     ///
     /// # Examples
     ///
@@ -43,10 +43,10 @@ impl IFP64 {
     ///
     /// fn foo() {
     ///     let bits = IFP64::bits();
-    ///     assert(bits == 64u32);
+    ///     assert(bits == 64);
     /// }
     /// ```
-    pub fn bits() -> u32 {
+    pub fn bits() -> u64 {
         64
     }
 

--- a/libs/fixed_point/src/ufp128.sw
+++ b/libs/fixed_point/src/ufp128.sw
@@ -97,7 +97,7 @@ impl UFP128 {
     ///
     /// # Returns
     ///
-    /// [u32] - The defined size of the `UFP128` type.
+    /// [u64] - The defined size of the `UFP128` type.
     ///
     /// # Examples
     ///
@@ -106,10 +106,10 @@ impl UFP128 {
     ///
     /// fn foo() {
     ///     let bits = UFP128::bits();
-    ///     assert(bits == 128u32);
+    ///     assert(bits == 128);
     /// }
     /// ```
-    pub fn bits() -> u32 {
+    pub fn bits() -> u64 {
         128
     }
 }

--- a/libs/fixed_point/src/ufp32.sw
+++ b/libs/fixed_point/src/ufp32.sw
@@ -28,7 +28,7 @@ impl UFP32 {
     ///
     /// # Returns
     ///
-    /// [u32] - The defined size of the `UFP32` type.
+    /// [u64] - The defined size of the `UFP32` type.
     ///
     /// # Examples
     ///
@@ -37,10 +37,10 @@ impl UFP32 {
     ///
     /// fn foo() {
     ///     let bits = UFP32::bits();
-    ///     assert(bits == 32u32);
+    ///     assert(bits == 32);
     /// }
     /// ```
-    pub fn bits() -> u32 {
+    pub fn bits() -> u64 {
         32
     }
 

--- a/libs/fixed_point/src/ufp64.sw
+++ b/libs/fixed_point/src/ufp64.sw
@@ -28,7 +28,7 @@ impl UFP64 {
     ///
     /// # Returns
     ///
-    /// [u32] - The defined size of the `UFP64` type.
+    /// [u64] - The defined size of the `UFP64` type.
     ///
     /// # Examples
     ///
@@ -37,10 +37,10 @@ impl UFP64 {
     ///
     /// fn foo() {
     ///     let bits = UFP64::bits();
-    ///     assert(bits == 64u32);
+    ///     assert(bits == 64);
     /// }
     /// ```
-    pub fn bits() -> u32 {
+    pub fn bits() -> u64 {
         64
     }
 

--- a/libs/signed_integers/src/i128.sw
+++ b/libs/signed_integers/src/i128.sw
@@ -76,7 +76,7 @@ impl I128 {
     ///
     /// # Returns
     ///
-    /// [u32] - The defined size of the `I128` type.
+    /// [u64] - The defined size of the `I128` type.
     ///
     /// # Examples
     ///
@@ -85,10 +85,10 @@ impl I128 {
     ///
     /// fn foo() {
     ///     let bits = I128::bits();
-    ///     assert(bits == 128u32);
+    ///     assert(bits == 128);
     /// }
     /// ```
-    pub fn bits() -> u32 {
+    pub fn bits() -> u64 {
         128
     }
 

--- a/libs/signed_integers/src/i16.sw
+++ b/libs/signed_integers/src/i16.sw
@@ -71,7 +71,7 @@ impl I16 {
     ///
     /// # Returns
     ///
-    /// [u32] - The defined size of the `I16` type.
+    /// [u64] - The defined size of the `I16` type.
     ///
     /// # Examples
     ///
@@ -80,10 +80,10 @@ impl I16 {
     ///
     /// fn foo() {
     ///     let bits = I16::bits();
-    ///     assert(bits == 16u32);
+    ///     assert(bits == 16);
     /// }
     /// ```
-    pub fn bits() -> u32 {
+    pub fn bits() -> u64 {
         16
     }
 

--- a/libs/signed_integers/src/i256.sw
+++ b/libs/signed_integers/src/i256.sw
@@ -76,7 +76,7 @@ impl I256 {
     ///
     /// # Returns
     ///
-    /// [u32] - The defined size of the `I256` type.
+    /// [u64] - The defined size of the `I256` type.
     ///
     /// # Examples
     ///
@@ -85,10 +85,10 @@ impl I256 {
     ///
     /// fn foo() {
     ///     let bits = I256::bits();
-    ///     assert(bits == 128u32);
+    ///     assert(bits == 128);
     /// }
     /// ```
-    pub fn bits() -> u32 {
+    pub fn bits() -> u64 {
         128
     }
 

--- a/libs/signed_integers/src/i32.sw
+++ b/libs/signed_integers/src/i32.sw
@@ -70,7 +70,7 @@ impl I32 {
     ///
     /// # Returns
     ///
-    /// [u32] - The defined size of the `I32` type.
+    /// [u64] - The defined size of the `I32` type.
     ///
     /// # Examples
     ///
@@ -79,10 +79,10 @@ impl I32 {
     ///
     /// fn foo() {
     ///     let bits = I32::bits();
-    ///     assert(bits == 32u32);
+    ///     assert(bits == 32);
     /// }
     /// ```
-    pub fn bits() -> u32 {
+    pub fn bits() -> u64 {
         32
     }
 

--- a/libs/signed_integers/src/i64.sw
+++ b/libs/signed_integers/src/i64.sw
@@ -70,7 +70,7 @@ impl I64 {
     ///
     /// # Returns
     ///
-    /// [u32] - The defined size of the `I64` type.
+    /// [u64] - The defined size of the `I64` type.
     ///
     /// # Examples
     ///
@@ -79,10 +79,10 @@ impl I64 {
     ///
     /// fn foo() {
     ///     let bits = I64::bits();
-    ///     assert(bits == 64u32);
+    ///     assert(bits == 64);
     /// }
     /// ```
-    pub fn bits() -> u32 {
+    pub fn bits() -> u64 {
         64
     }
 

--- a/libs/signed_integers/src/i8.sw
+++ b/libs/signed_integers/src/i8.sw
@@ -70,7 +70,7 @@ impl I8 {
     ///
     /// # Returns
     ///
-    /// * [u32] - The number of bits.
+    /// * [u64] - The number of bits.
     ///
     /// # Examples
     ///
@@ -79,10 +79,10 @@ impl I8 {
     ///
     /// fn foo() {
     ///     let bits = I8::bits();
-    ///     assert(bits == 8u32);
+    ///     assert(bits == 8);
     /// }
     /// ```
-    pub fn bits() -> u32 {
+    pub fn bits() -> u64 {
         8
     }
 


### PR DESCRIPTION
## Type of change

<!--Delete points that do not apply-->

- Improvement (refactoring, restructuring repository, cleaning tech debt, ...)

## Changes

The following changes have been made:

- Updates the returning value for `bits()` from a `u32` to a `u64`.  This change was made in the standard library and the same is being done here.
