### PR TITLE
Bump repo to forc v0.46.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ env:
   CARGO_TERM_COLOR: always
   REGISTRY: ghcr.io
   RUST_VERSION: 1.71.1
-  FORC_VERSION: 0.44.1
+  FORC_VERSION: 0.46.0
   CORE_VERSION: 0.20.3
   PATH_TO_SCRIPTS: .github/scripts
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
     <a href="https://github.com/FuelLabs/sway-libs/actions/workflows/ci.yml" alt="CI">
         <img src="https://github.com/FuelLabs/sway-libs/actions/workflows/ci.yml/badge.svg" />
     </a>
-    <a href="https://crates.io/crates/forc/0.40.1" alt="forc">
-        <img src="https://img.shields.io/badge/forc-v0.40.1-orange" />
+    <a href="https://crates.io/crates/forc/0.46.0" alt="forc">
+        <img src="https://img.shields.io/badge/forc-v0.46.0-orange" />
     </a>
     <a href="./LICENSE" alt="forc">
         <img src="https://img.shields.io/github/license/FuelLabs/sway-libs" />
@@ -81,7 +81,7 @@ cargo test
 Any instructions related to using a specific library should be found within the README.md of that library.
 
 > **Note**
-> All projects currently use `forc v0.40.1`, `fuels-rs v0.42.0` and `fuel-core 0.18.1`.
+> All projects currently use `forc v0.46.0`, `fuels-rs v0.46.0` and `fuel-core 0.20.3`.
 
 ## Contributing
 

--- a/libs/merkle_proof/src/binary_merkle_proof.sw
+++ b/libs/merkle_proof/src/binary_merkle_proof.sw
@@ -1,6 +1,6 @@
 library;
 
-use std::{bytes::Bytes, hash::sha256};
+use std::{bytes::Bytes, hash::{Hash, sha256}};
 
 pub enum ProofError {
     InvalidKey: (),
@@ -44,7 +44,7 @@ pub fn leaf_digest(data: b256) -> b256 {
     __addr_of(data).copy_bytes_to(new_ptr, 32);
     bytes.len = 33;
 
-    bytes.sha256()
+    sha256(bytes)
 }
 
 /// Returns the computed node hash of "MTH(D[n]) = SHA-256(0x01 || MTH(D[0:k]) || MTH(D[k:n]))".
@@ -81,7 +81,7 @@ pub fn node_digest(left: b256, right: b256) -> b256 {
     __addr_of(right).copy_bytes_to(new_ptr_right, 32);
     bytes.len = 65;
 
-    bytes.sha256()
+    sha256(bytes)
 }
 
 /// Calculates the length of the path to a leaf

--- a/libs/token/README.md
+++ b/libs/token/README.md
@@ -29,8 +29,8 @@ Once imported, the Token library's functions should be available. To use them, b
 storage {
     total_assets: u64 = 0,
     total_supply: StorageMap<AssetId, u64> = StorageMap {},
-    name: StorageMap<AssetId, StorageKey<StorageString>> = StorageMap {},
-    symbol: StorageMap<AssetId, StorageKey<StorageString>> = StorageMap {},
+    name: StorageMap<AssetId, StorageString> = StorageMap {},
+    symbol: StorageMap<AssetId, StorageString> = StorageMap {},
     decimals: StorageMap<AssetId, u8> = StorageMap {},
 }
 ```
@@ -53,8 +53,8 @@ use std::string::String;
 storage {
     total_assets: u64 = 0,
     total_supply: StorageMap<AssetId, u64> = StorageMap {},
-    name: StorageMap<AssetId, StorageKey<StorageString>> = StorageMap {},
-    symbol: StorageMap<AssetId, StorageKey<StorageString>> = StorageMap {},
+    name: StorageMap<AssetId, StorageString> = StorageMap {},
+    symbol: StorageMap<AssetId, StorageString> = StorageMap {},
     decimals: StorageMap<AssetId, u8> = StorageMap {},
 }
 

--- a/libs/token/src/lib.sw
+++ b/libs/token/src/lib.sw
@@ -165,7 +165,6 @@ pub fn _symbol(
 ) -> Option<String> {
     symbol_key.get(asset).read_slice()
 }
-
 /// Returns the number of decimals the asset uses.
 ///
 /// # Additional Information
@@ -349,7 +348,7 @@ pub fn _set_name(
     asset: AssetId,
     name: String,
 ) {
-    name_key.insert(asset, StorageString{});
+    name_key.insert(asset, StorageString {});
     name_key.get(asset).write_slice(name);
 }
 /// Unconditionally sets the symbol of an asset.
@@ -390,7 +389,7 @@ pub fn _set_symbol(
     asset: AssetId,
     symbol: String,
 ) {
-    symbol_key.insert(asset, StorageString{});
+    symbol_key.insert(asset, StorageString {});
     symbol_key.get(asset).write_slice(symbol);
 }
 /// Unconditionally sets the decimals of an asset.

--- a/libs/token/src/lib.sw
+++ b/libs/token/src/lib.sw
@@ -123,13 +123,10 @@ pub fn _total_supply(
 /// ```
 #[storage(read)]
 pub fn _name(
-    name_key: StorageKey<StorageMap<AssetId, StorageKey<StorageString>>>,
+    name_key: StorageKey<StorageMap<AssetId, StorageString>>,
     asset: AssetId,
 ) -> Option<String> {
-    match name_key.get(asset).try_read() {
-        Option::Some(s) => s.read_slice(),
-        Option::None(s) => Option::None,
-    }
+    name_key.get(asset).read_slice()
 }
 /// Returns the symbol of the asset, such as “ETH”.
 ///
@@ -163,13 +160,10 @@ pub fn _name(
 /// ```
 #[storage(read)]
 pub fn _symbol(
-    symbol_key: StorageKey<StorageMap<AssetId, StorageKey<StorageString>>>,
+    symbol_key: StorageKey<StorageMap<AssetId, StorageString>>,
     asset: AssetId,
 ) -> Option<String> {
-    match symbol_key.get(asset).try_read() {
-        Option::Some(s) => s.read_slice(),
-        Option::None(s) => Option::None,
-    }
+    symbol_key.get(asset).read_slice()
 }
 
 /// Returns the number of decimals the asset uses.
@@ -351,17 +345,12 @@ pub fn _burn(
 /// ```
 #[storage(write)]
 pub fn _set_name(
-    name_key: StorageKey<StorageMap<AssetId, StorageKey<StorageString>>>,
+    name_key: StorageKey<StorageMap<AssetId, StorageString>>,
     asset: AssetId,
     name: String,
 ) {
-    let name_string_key: StorageKey<StorageString> = StorageKey {
-        slot: sha256((asset, String::from_ascii_str("name_slot"))),
-        offset: 0,
-        field_id: sha256((asset, String::from_ascii_str("name_field_id"))),
-    };
-    name_string_key.write_slice(name);
-    name_key.insert(asset, name_string_key);
+    name_key.insert(asset, StorageString{});
+    name_key.get(asset).write_slice(name);
 }
 /// Unconditionally sets the symbol of an asset.
 ///
@@ -397,17 +386,12 @@ pub fn _set_name(
 /// ```
 #[storage(write)]
 pub fn _set_symbol(
-    symbol_key: StorageKey<StorageMap<AssetId, StorageKey<StorageString>>>,
+    symbol_key: StorageKey<StorageMap<AssetId, StorageString>>,
     asset: AssetId,
     symbol: String,
 ) {
-    let symbol_string_key: StorageKey<StorageString> = StorageKey {
-        slot: sha256((asset, String::from_ascii_str("symbol_slot"))),
-        offset: 0,
-        field_id: sha256((asset, String::from_ascii_str("symbol_field_id"))),
-    };
-    symbol_string_key.write_slice(symbol);
-    symbol_key.insert(asset, symbol_string_key);
+    symbol_key.insert(asset, StorageString{});
+    symbol_key.get(asset).write_slice(symbol);
 }
 /// Unconditionally sets the decimals of an asset.
 ///

--- a/libs/token/src/lib.sw
+++ b/libs/token/src/lib.sw
@@ -4,13 +4,15 @@ mod errors;
 
 use errors::BurnError;
 use std::{
-    asset_id::construct_asset_id,
     call_frames::{
         contract_id,
         msg_asset_id,
     },
     context::this_balance,
-    hash::sha256,
+    hash::{
+        Hash,
+        sha256,
+    },
     storage::storage_string::*,
     string::String,
     token::{
@@ -254,7 +256,7 @@ pub fn _mint(
     sub_id: SubId,
     amount: u64,
 ) -> AssetId {
-    let asset_id = construct_asset_id(contract_id(), sub_id);
+    let asset_id = AssetId::new(contract_id(), sub_id);
     let supply = _total_supply(total_supply_key, asset_id);
     // Only increment the number of assets minted by this contract if it hasn't been minted before.
     if supply.is_none() {
@@ -308,7 +310,7 @@ pub fn _burn(
     sub_id: SubId,
     amount: u64,
 ) {
-    let asset_id = construct_asset_id(contract_id(), sub_id);
+    let asset_id = AssetId::new(contract_id(), sub_id);
     require(this_balance(asset_id) >= amount, BurnError::NotEnoughTokens);
     // If we pass the check above, we can assume it is safe to unwrap.
     let supply = _total_supply(total_supply_key, asset_id).unwrap();

--- a/tests/Forc.toml
+++ b/tests/Forc.toml
@@ -41,5 +41,5 @@ members = [
   "./src/signed_integers/signed_i16_twos_complement",
   "./src/signed_integers/signed_i32_twos_complement",
   "./src/signed_integers/signed_i64_twos_complement",
-  "./src/token"
+  "./src/token",
 ]

--- a/tests/src/fixed_point/ufp32_test/src/main.sw
+++ b/tests/src/fixed_point/ufp32_test/src/main.sw
@@ -25,32 +25,24 @@ fn main() -> bool {
     assert(UFP32::from_uint(156) == res);
 
     // recip
-    let mut value = UFP32 {
-        value: 3u32,
-    };
+    let mut value = UFP32 { value: 3u32 };
     res = UFP32::recip(value);
     assert(UFP32 {
         value: 536870912,
     } == res);
 
     // trunc
-    value = UFP32 {
-        value: 3u32,
-    };
+    value = UFP32 { value: 3u32 };
     res = value.trunc();
     assert(UFP32::from_uint(1) == res);
 
     // floor
-    value = UFP32 {
-        value: 3u32,
-    };
+    value = UFP32 { value: 3u32 };
     res = value.floor();
     assert(UFP32::from_uint(1) == res);
 
     // fract
-    value = UFP32 {
-        value: 3u32,
-    };
+    value = UFP32 { value: 3u32 };
     res = value.fract();
     assert(UFP32 { value: 3 } == res);
 
@@ -59,9 +51,7 @@ fn main() -> bool {
     assert(UFP32::from_uint(0) == res);
 
     // ceil
-    value = UFP32 {
-        value: 3u32,
-    };
+    value = UFP32 { value: 3u32 };
     res = value.ceil();
     assert(UFP32::from_uint(2) == res);
 
@@ -70,9 +60,7 @@ fn main() -> bool {
     assert(UFP32::from_uint(1) == res);
 
     // round
-    value = UFP32 {
-        value: 3u32,
-    };
+    value = UFP32 { value: 3u32 };
     res = value.round();
     assert(UFP32::from_uint(1) == res);
 

--- a/tests/src/token/Forc.toml
+++ b/tests/src/token/Forc.toml
@@ -5,6 +5,6 @@ license = "Apache-2.0"
 name = "token_test"
 
 [dependencies]
-src_3 = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.1.1" }
 src_20 = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.1.1" }
+src_3 = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.1.1" }
 token = { path = "../../../libs/token" }

--- a/tests/src/token/src/main.sw
+++ b/tests/src/token/src/main.sw
@@ -15,7 +15,7 @@ use token::{
     _total_supply,
     SetTokenAttributes,
 };
-use std::{asset_id::construct_asset_id, storage::storage_string::*, string::String};
+use std::{hash::Hash, storage::storage_string::*, string::String};
 
 storage {
     total_assets: u64 = 0,
@@ -106,7 +106,7 @@ fn test_total_supply() {
 
     let recipient = Identity::ContractId(ContractId::from(CONTRACT_ID));
     let sub_id = 0x0000000000000000000000000000000000000000000000000000000000000000;
-    let asset_id = construct_asset_id(ContractId::from(CONTRACT_ID), sub_id);
+    let asset_id = AssetId::new(ContractId::from(CONTRACT_ID), sub_id);
 
     assert(src20_abi.total_supply(asset_id).is_none());
 
@@ -124,7 +124,7 @@ fn test_name() {
 
     let recipient = Identity::ContractId(ContractId::from(CONTRACT_ID));
     let sub_id = 0x0000000000000000000000000000000000000000000000000000000000000000;
-    let asset_id = construct_asset_id(ContractId::from(CONTRACT_ID), sub_id);
+    let asset_id = AssetId::new(ContractId::from(CONTRACT_ID), sub_id);
     let name = String::from_ascii_str("Fuel Token");
 
     assert(src20_abi.name(asset_id).is_none());
@@ -140,7 +140,7 @@ fn test_symbol() {
 
     let recipient = Identity::ContractId(ContractId::from(CONTRACT_ID));
     let sub_id = 0x0000000000000000000000000000000000000000000000000000000000000000;
-    let asset_id = construct_asset_id(ContractId::from(CONTRACT_ID), sub_id);
+    let asset_id = AssetId::new(ContractId::from(CONTRACT_ID), sub_id);
     let symbol = String::from_ascii_str("FUEL");
 
     assert(src20_abi.symbol(asset_id).is_none());
@@ -156,7 +156,7 @@ fn test_decimals() {
 
     let recipient = Identity::ContractId(ContractId::from(CONTRACT_ID));
     let sub_id = 0x0000000000000000000000000000000000000000000000000000000000000000;
-    let asset_id = construct_asset_id(ContractId::from(CONTRACT_ID), sub_id);
+    let asset_id = AssetId::new(ContractId::from(CONTRACT_ID), sub_id);
     let decimals = 8u8;
 
     assert(src20_abi.decimals(asset_id).is_none());
@@ -174,7 +174,7 @@ fn test_mint() {
 
     let recipient = Identity::ContractId(ContractId::from(CONTRACT_ID));
     let sub_id = 0x0000000000000000000000000000000000000000000000000000000000000000;
-    let asset_id = construct_asset_id(ContractId::from(CONTRACT_ID), sub_id);
+    let asset_id = AssetId::new(ContractId::from(CONTRACT_ID), sub_id);
 
     assert(balance_of(ContractId::from(CONTRACT_ID), asset_id) == 0);
 
@@ -191,7 +191,7 @@ fn test_burn() {
 
     let recipient = Identity::ContractId(ContractId::from(CONTRACT_ID));
     let sub_id = 0x0000000000000000000000000000000000000000000000000000000000000000;
-    let asset_id = construct_asset_id(ContractId::from(CONTRACT_ID), sub_id);
+    let asset_id = AssetId::new(ContractId::from(CONTRACT_ID), sub_id);
 
     src3_abi.mint(recipient, sub_id, 10);
     assert(balance_of(ContractId::from(CONTRACT_ID), asset_id) == 10);

--- a/tests/src/token/src/main.sw
+++ b/tests/src/token/src/main.sw
@@ -20,8 +20,8 @@ use std::{hash::Hash, storage::storage_string::*, string::String};
 storage {
     total_assets: u64 = 0,
     total_supply: StorageMap<AssetId, u64> = StorageMap {},
-    name: StorageMap<AssetId, StorageKey<StorageString>> = StorageMap {},
-    symbol: StorageMap<AssetId, StorageKey<StorageString>> = StorageMap {},
+    name: StorageMap<AssetId, StorageString> = StorageMap {},
+    symbol: StorageMap<AssetId, StorageString> = StorageMap {},
     decimals: StorageMap<AssetId, u8> = StorageMap {},
 }
 


### PR DESCRIPTION
## Type of change

<!--Delete points that do not apply-->

- Improvement (refactoring, restructuring repository, cleaning tech debt, ...)

## Changes

The following changes have been made:

- Updated repo to use forc v0.46.0
