### PR TITLE
Add hash trait import example for token library

### DIFF
--- a/libs/token/README.md
+++ b/libs/token/README.md
@@ -48,7 +48,7 @@ use token::{
     _decimals
 };
 use src_20::SRC20;
-use std::string::String;
+use std::{hash::Hash, string::String};
 
 storage {
     total_assets: u64 = 0,


### PR DESCRIPTION
## Type of change

<!--Delete points that do not apply-->

- Documentation

## Changes

The following changes have been made:

- Added the `std::hash::Hash` trait to the imports on the README example

## Notes

- This can be removed in the future but is added now to avoid confusion
- Closes https://github.com/FuelLabs/sway-libs/issues/193

## Related Issues

<!--Delete everything after the "#" symbol and replace it with a number. No spaces between hash and number-->

Closes https://github.com/FuelLabs/sway-libs/issues/193
