### PR TITLE
Add storage_string import example for token library

### DIFF
--- a/libs/token/README.md
+++ b/libs/token/README.md
@@ -48,7 +48,7 @@ use token::{
     _decimals
 };
 use src_20::SRC20;
-use std::{hash::Hash, string::String};
+use std::{hash::Hash, string::String, storage::storage_string::*};
 
 storage {
     total_assets: u64 = 0,


### PR DESCRIPTION
## Type of change

- Documentation

## Changes

The following changes have been made:

- Added the std::storage::storage_string trait to the imports on the README example

## Notes

- The example won't work without trait mentioned above

## Related Issues

https://github.com/FuelLabs/sway-libs/issues/193

