### PR TITLE
Introduce Admin Library

### DIFF
--- a/libs/admin/Forc.toml
+++ b/libs/admin/Forc.toml
@@ -1,0 +1,9 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "admin.sw"
+license = "Apache-2.0"
+name = "admin"
+
+[dependencies]
+ownership = { path = "../ownership" }
+src_5 = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.2.0" }

--- a/libs/admin/src/admin.sw
+++ b/libs/admin/src/admin.sw
@@ -1,0 +1,181 @@
+library;
+
+mod errors;
+
+use errors::AccessError;
+use ownership::{_owner, only_owner};
+use src_5::{State};
+use std::{
+    auth::msg_sender,
+    storage::storage_api::clear,
+};
+
+/// Sets a new administrator.
+///
+/// # Arguments
+///
+/// * `new_admin`: [Identity] = The `Identity` which is to recieve administrator status.
+///
+/// # Reverts
+///
+/// * When the caller is not the contract owner.
+///
+/// # Number of Storage Accesses
+///
+/// * Reads: `1`
+/// * Writes: `1`
+///
+/// # Examples
+///
+/// ```sway
+/// use admin::{add_admin, is_admin};
+///
+/// fn foo(new_admin: Identity) {
+///     add_admin(new_admin);
+///     assert(is_admin(new_admin));
+/// }
+/// ```
+#[storage(read, write)]
+pub fn add_admin(new_admin: Identity) {
+    only_owner();
+
+    let admin_value = match new_admin {
+        Identity::Address(addr) => addr.value,
+        Identity::ContractId(contr) => contr.value,
+    };
+    let admin_key = StorageKey::<Identity>::new(admin_value, 0, admin_value);
+
+    admin_key.write(new_admin);
+}
+
+/// Removes an administrator.
+///
+/// # Arguments
+///
+/// * `old_admin`: [Identity] = The `Identity` which the administrator status is to be removed.
+///
+/// # Reverts
+///
+/// * When the caller is not the contract owner.
+///
+/// # Number of Storage Accesses
+///
+/// * Reads: `1`
+/// * Writes: `1`
+///
+/// # Examples
+///
+/// ```sway
+/// use admin::{remove_admin, is_admin};
+///
+/// fn foo(old_admin: Identity) {
+///     remove_admin(old_admin);
+///     assert(!is_admin(old_admin));
+/// }
+/// ```
+#[storage(read, write)]
+pub fn remove_admin(old_admin: Identity) {
+    only_owner();
+
+    let admin_value = match old_admin {
+        Identity::Address(addr) => addr.value,
+        Identity::ContractId(contr) => contr.value,
+    };    
+    let admin_key = StorageKey::<Identity>::new(admin_value, 0, admin_value);
+
+    // TODO: Update to use StorageKey::clear() on next release
+    // https://github.com/FuelLabs/sway/pull/5284
+    let _ = clear::<Identity>(admin_key.slot, admin_key.offset);
+}
+
+/// Returns whether `admin` is an administrator.
+///
+/// # Arguments
+///
+/// * `admin`: [Identity] = The `Identity` of which to check the administrator status.
+///
+/// # Returns
+///
+/// * [bool] - `true` if the `admin` is an administrator, otherwise `false`.
+///
+/// # Number of Storage Accesses
+///
+/// * Reads: `1`
+///
+/// # Examples
+///
+/// ```sway
+/// use admin::{is_admin};
+///
+/// fn foo(admin: Identity) {
+///     assert(is_admin(admin));
+/// }
+/// ```
+#[storage(read)]
+pub fn is_admin(admin: Identity) -> bool {
+    let admin_value = match admin {
+        Identity::Address(addr) => addr.value,
+        Identity::ContractId(contr) => contr.value,
+    };
+    let admin_key = StorageKey::<Identity>::new(admin_value, 0, admin_value);
+
+    match admin_key.try_read() {
+        Some(identity) => { admin == identity },
+        None => { false },
+    }
+}
+
+/// Ensures that the sender is an administrator.
+///
+/// # Additional Information
+///
+/// NOTE: Owner and administrator are independent of one another. If an Owner calls this function, it will revert.
+///
+/// # Reverts
+///
+/// * When the caller is not an administrator.
+///
+/// # Number of Storage Accesses
+///
+/// * Reads: `1`
+///
+/// # Examples
+///
+/// ```sway
+/// use admin::{only_admin};
+///
+/// fn foo() {
+///     only_admin();
+///     // Only reachable by an administrator
+/// }
+/// ```
+#[storage(read)]
+pub fn only_admin() {
+    require(is_admin(msg_sender().unwrap()), AccessError::NotAdmin);
+}
+
+/// Ensures that the sender is an owner or administrator.
+///
+/// # Reverts
+///
+/// * When the caller is not an owner or administrator.
+///
+/// # Number of Storage Accesses
+///
+/// * Reads: `2`
+///
+/// # Examples
+///
+/// ```sway
+/// use admin::{only_owner_or_admin};
+///
+/// fn foo() {
+///     only_owner_or_admin();
+///     // Only reachable by an owner or administrator
+/// }
+/// ```
+#[storage(read)]
+pub fn only_owner_or_admin() {
+    let sender = msg_sender().unwrap();
+    require(_owner() == State::Initialized(sender) || is_admin(sender), AccessError::NotAdmin);
+}

--- a/libs/admin/src/errors.sw
+++ b/libs/admin/src/errors.sw
@@ -1,0 +1,7 @@
+library;
+
+/// Error log for when access is denied.
+pub enum AccessError {
+    /// Emiited when the caller is not an admin.
+    NotAdmin: (),
+}

--- a/tests/src/admin/Forc.toml
+++ b/tests/src/admin/Forc.toml
@@ -1,0 +1,10 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "admin_test"
+
+[dependencies]
+ownership = { path = "../../../libs/ownership" }
+admin = { path = "../../../libs/admin" }
+src_5 = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.2.0" }

--- a/tests/src/admin/mod.rs
+++ b/tests/src/admin/mod.rs
@@ -1,0 +1,1 @@
+mod tests;

--- a/tests/src/admin/src/main.sw
+++ b/tests/src/admin/src/main.sw
@@ -1,0 +1,85 @@
+contract;
+
+use admin::*;
+use ownership::*;
+use src_5::{SRC5, State};
+
+abi AdminTest {
+    #[storage(read, write)]
+    fn add_admin(new_admin: Identity);
+    #[storage(read, write)]
+    fn remove_admin(old_admin: Identity);
+    #[storage(read)]
+    fn is_admin(admin: Identity) -> bool;
+    #[storage(read)]
+    fn only_admin();
+    #[storage(read)]
+    fn only_owner_or_admin();
+}
+
+abi OwnableTest {
+    #[storage(read)]
+    fn only_owner();
+    #[storage(read, write)]
+    fn renounce_ownership();
+    #[storage(read, write)]
+    fn set_ownership(new_owner: Identity);
+    #[storage(read, write)]
+    fn transfer_ownership(new_owner: Identity);
+}
+
+impl AdminTest for Contract {
+    #[storage(read, write)]
+    fn add_admin(new_admin: Identity) {
+        add_admin(new_admin);
+    }
+
+    #[storage(read, write)]
+    fn remove_admin(old_admin: Identity) {
+        remove_admin(old_admin);
+    }
+
+    #[storage(read)]
+    fn is_admin(admin: Identity) -> bool {
+        is_admin(admin)
+    }
+
+    #[storage(read)]
+    fn only_admin() {
+        only_admin();
+    }
+
+    #[storage(read)]
+    fn only_owner_or_admin() {
+        only_owner_or_admin();
+    }
+}
+
+impl OwnableTest for Contract {
+    #[storage(read)]
+    fn only_owner() {
+        only_owner();
+    }
+
+    #[storage(read, write)]
+    fn renounce_ownership() {
+        renounce_ownership();
+    }
+
+    #[storage(read, write)]
+    fn set_ownership(new_owner: Identity) {
+        initialize_ownership(new_owner);
+    }
+
+    #[storage(read, write)]
+    fn transfer_ownership(new_owner: Identity) {
+        transfer_ownership(new_owner);
+    }
+}
+
+impl SRC5 for Contract {
+    #[storage(read)]
+    fn owner() -> State {
+        _owner()
+    }
+}

--- a/tests/src/admin/tests/functions/add_admin.rs
+++ b/tests/src/admin/tests/functions/add_admin.rs
@@ -1,0 +1,59 @@
+use crate::admin::tests::utils::{
+    abi_calls::{is_admin, add_admin, set_ownership},
+    test_helpers::setup,
+};
+use fuels::types::Identity;
+
+mod success {
+
+    use super::*;
+
+    #[tokio::test]
+    async fn adds_admin() {
+        let (_deployer, owner, admin1, _admin2) = setup().await;
+
+        let owner_identity = Identity::Address(owner.wallet.address().into());
+        let admin1_identity = Identity::Address(admin1.wallet.address().into());
+        set_ownership(&owner.contract, owner_identity.clone()).await;
+
+        assert!(!is_admin(&owner.contract, admin1_identity.clone()).await);
+        set_admin(&owner.contract, admin1_identity.clone()).await;
+        assert!(is_admin(&owner.contract, admin1_identity.clone()).await);
+    }
+
+    #[tokio::test]
+    async fn adds_multiple_admins() {
+        let (_deployer, owner, admin1, admin2) = setup().await;
+
+        let owner_identity = Identity::Address(owner.wallet.address().into());
+        let admin1_identity = Identity::Address(admin1.wallet.address().into());
+        let admin2_identity = Identity::Address(admin2.wallet.address().into());
+        set_ownership(&owner.contract, owner_identity.clone()).await;
+
+        assert!(!is_admin(&owner.contract, admin1_identity.clone()).await);
+        assert!(!is_admin(&owner.contract, admin2_identity.clone()).await);
+
+        set_admin(&owner.contract, admin1_identity.clone()).await;
+        set_admin(&owner.contract, admin2_identity.clone()).await;
+        
+        assert!(is_admin(&owner.contract, admin1_identity.clone()).await);
+        assert!(is_admin(&owner.contract, admin2_identity.clone()).await);
+    }
+}
+
+mod reverts {
+
+    use super::*;
+
+    #[tokio::test]
+    #[should_panic(expected = "NotOwner")]
+    async fn when_caller_is_not_owner() {
+        let (_deployer, owner, admin1, _admin2) = setup().await;
+
+        let owner_identity = Identity::Address(owner.wallet.address().into());
+        let admin1_identity = Identity::Address(admin1.wallet.address().into());
+        set_ownership(&owner.contract, owner_identity.clone()).await;
+        
+        set_admin(&admin1.contract, admin1_identity.clone()).await;
+    }
+}

--- a/tests/src/admin/tests/functions/is_admin.rs
+++ b/tests/src/admin/tests/functions/is_admin.rs
@@ -1,0 +1,42 @@
+use crate::admin::tests::utils::{
+    abi_calls::{is_admin, add_admin, set_ownership},
+    test_helpers::setup,
+};
+use fuels::types::Identity;
+
+mod success {
+
+    use super::*;
+
+    #[tokio::test]
+    async fn checks_if_admin() {
+        let (_deployer, owner, admin1, _admin2) = setup().await;
+
+        let owner_identity = Identity::Address(owner.wallet.address().into());
+        let admin1_identity = Identity::Address(admin1.wallet.address().into());
+        set_ownership(&owner.contract, owner_identity.clone()).await;
+
+        assert!(!is_admin(&owner.contract, admin1_identity.clone()).await);
+        set_admin(&owner.contract, admin1_identity.clone()).await;
+        assert!(is_admin(&owner.contract, admin1_identity.clone()).await);
+    }
+
+    #[tokio::test]
+    async fn checks_multiple_admins() {
+        let (_deployer, owner, admin1, admin2) = setup().await;
+
+        let owner_identity = Identity::Address(owner.wallet.address().into());
+        let admin1_identity = Identity::Address(admin1.wallet.address().into());
+        let admin2_identity = Identity::Address(admin2.wallet.address().into());
+        set_ownership(&owner.contract, owner_identity.clone()).await;
+
+        assert!(!is_admin(&owner.contract, admin1_identity.clone()).await);
+        assert!(!is_admin(&owner.contract, admin2_identity.clone()).await);
+
+        set_admin(&owner.contract, admin1_identity.clone()).await;
+        set_admin(&owner.contract, admin2_identity.clone()).await;
+        
+        assert!(is_admin(&owner.contract, admin1_identity.clone()).await);
+        assert!(is_admin(&owner.contract, admin2_identity.clone()).await);
+    }
+}

--- a/tests/src/admin/tests/functions/mod.rs
+++ b/tests/src/admin/tests/functions/mod.rs
@@ -1,0 +1,5 @@
+mod add_admin;
+mod is_admin;
+mod only_admin;
+mod only_owner_or_admin;
+mod remove_admin;

--- a/tests/src/admin/tests/functions/only_admin.rs
+++ b/tests/src/admin/tests/functions/only_admin.rs
@@ -1,0 +1,49 @@
+use crate::admin::tests::utils::{
+    abi_calls::{only_admin, add_admin, set_ownership},
+    test_helpers::setup,
+};
+use fuels::types::Identity;
+
+mod success {
+
+    use super::*;
+
+    #[tokio::test]
+    async fn only_admin_may_call() {
+        let (_deployer, owner, admin1, _admin2) = setup().await;
+
+        let owner_identity = Identity::Address(owner.wallet.address().into());
+        let admin1_identity = Identity::Address(admin1.wallet.address().into());
+        set_ownership(&owner.contract, owner_identity.clone()).await;
+        set_admin(&owner.contract, admin1_identity.clone()).await;
+
+        only_admin(&admin1.contract).await;
+    }
+}
+
+mod reverts {
+
+    use super::*;
+
+    #[tokio::test]
+    #[should_panic(expected = "NotAdmin")]
+    async fn when_no_admin_set() {
+        let (_deployer, _owner, admin1, _admin2) = setup().await;
+
+        only_admin(admin1.contract).await;
+    }
+
+    #[tokio::test]
+    #[should_panic(expected = "NotAdmin")]
+    async fn when_not_admin() {
+        let (_deployer, owner, admin1, admin2) = setup().await;
+
+        let owner_identity = Identity::Address(owner.wallet.address().into());
+        let admin1_identity = Identity::Address(admin1.wallet.address().into());
+        let admin2_identity = Identity::Address(admin2.wallet.address().into());
+        set_ownership(&owner.contract, owner_identity.clone()).await;
+        set_admin(&owner.contract, admin1_identity.clone()).await;
+
+        only_admin(admin2.contract).await;
+    }
+}

--- a/tests/src/admin/tests/functions/only_owner_or_admin.rs
+++ b/tests/src/admin/tests/functions/only_owner_or_admin.rs
@@ -1,0 +1,42 @@
+use crate::admin::tests::utils::{
+    abi_calls::{only_owner_or_admin, add_admin, set_ownership},
+    test_helpers::setup,
+};
+use fuels::types::Identity;
+
+mod success {
+
+    use super::*;
+
+    #[tokio::test]
+    async fn only_owner_or_admin_may_call() {
+        let (_deployer, owner, admin1, _admin2) = setup().await;
+
+        let owner_identity = Identity::Address(owner.wallet.address().into());
+        let admin1_identity = Identity::Address(admin1.wallet.address().into());
+        set_ownership(&owner.contract, owner_identity.clone()).await;
+        set_admin(&owner.contract, admin1_identity.clone()).await;
+
+        only_owner_or_admin(&owner.contract).await;
+        only_owner_or_admin(&admin1.contract).await;
+    }
+}
+
+mod reverts {
+
+    use super::*;
+
+    #[tokio::test]
+    #[should_panic(expected = "NotAdmin")]
+    async fn when_not_owner_or_admin() {
+        let (_deployer, owner, admin1, admin2) = setup().await;
+
+        let owner_identity = Identity::Address(owner.wallet.address().into());
+        let admin1_identity = Identity::Address(admin1.wallet.address().into());
+        let admin2_identity = Identity::Address(admin2.wallet.address().into());
+        set_ownership(&owner.contract, owner_identity.clone()).await;
+        set_admin(&owner.contract, admin1_identity.clone()).await;
+
+        only_owner_or_admin(admin2.contract).await;
+    }
+}

--- a/tests/src/admin/tests/functions/remove_admin.rs
+++ b/tests/src/admin/tests/functions/remove_admin.rs
@@ -1,0 +1,42 @@
+use crate::admin::tests::utils::{
+    abi_calls::{is_admin, add_admin, remove_admin, set_ownership},
+    test_helpers::setup,
+};
+use fuels::types::Identity;
+
+mod success {
+
+    use super::*;
+
+    #[tokio::test]
+    async fn removes_admin() {
+        let (_deployer, owner, admin1, _admin2) = setup().await;
+
+        let owner_identity = Identity::Address(owner.wallet.address().into());
+        let admin1_identity = Identity::Address(admin1.wallet.address().into());
+        set_ownership(&owner.contract, owner_identity.clone()).await;
+        set_admin(&owner.contract, admin1_identity.clone()).await;
+
+        assert!(is_admin(&owner.contract, admin1_identity.clone()).await);
+        remove_admin(&owner.contract, admin1_identity.clone()).await;
+        assert!(!is_admin(&owner.contract, admin1_identity.clone()).await);
+    }
+}
+
+mod reverts {
+
+    use super::*;
+
+    #[tokio::test]
+    #[should_panic(expected = "NotOwner")]
+    async fn when_caller_is_not_owner() {
+        let (_deployer, owner, admin1, _admin2) = setup().await;
+
+        let owner_identity = Identity::Address(owner.wallet.address().into());
+        let admin1_identity = Identity::Address(admin1.wallet.address().into());
+        set_ownership(&owner.contract, owner_identity.clone()).await;
+        set_admin(&owner.contract, admin1_identity.clone()).await;
+
+        remove_admin(&admin1.contract, admin1_identity.clone()).await;
+    }
+}

--- a/tests/src/admin/tests/mod.rs
+++ b/tests/src/admin/tests/mod.rs
@@ -1,0 +1,2 @@
+mod functions;
+mod utils;

--- a/tests/src/admin/tests/utils/mod.rs
+++ b/tests/src/admin/tests/utils/mod.rs
@@ -1,0 +1,156 @@
+use fuels::{
+    prelude::{
+        abigen, launch_custom_provider_and_get_wallets, Contract, LoadConfiguration,
+        StorageConfiguration, TxParameters, WalletUnlocked, WalletsConfig,
+    },
+    programs::call_response::FuelCallResponse,
+    types::Identity,
+};
+
+// Load abi from json
+abigen!(Contract(
+    name = "AdminLib",
+    abi = "src/admin/out/debug/admin_test-abi.json"
+));
+
+pub struct Metadata {
+    pub contract: AdminLib<WalletUnlocked>,
+    pub wallet: WalletUnlocked,
+}
+
+pub mod abi_calls {
+
+    use super::*;
+
+    pub async fn add_admin(
+        contract: &AdminLib<WalletUnlocked>,
+        new_admin: Identity,
+    ) -> FuelCallResponse<()> {
+        contract
+            .methods()
+            .add_admin(new_admin)
+            .call()
+            .await
+            .unwrap()
+    }
+
+    pub async fn remove_admin(
+        contract: &AdminLib<WalletUnlocked>,
+        old_admin: Identity,
+    ) -> FuelCallResponse<()> {
+        contract
+            .methods()
+            .remove_admin(old_admin)
+            .call()
+            .await
+            .unwrap()
+    }
+
+    pub async fn is_admin(
+        contract: &AdminLib<WalletUnlocked>,
+        admin: Identity,
+    ) -> bool {
+        contract
+            .methods()
+            .is_admin(admin)
+            .call()
+            .await
+            .unwrap()
+            .value
+    }
+
+    pub async fn only_admin(
+        contract: &AdminLib<WalletUnlocked>,
+    ) -> FuelCallResponse<()> {
+        contract
+            .methods()
+            .only_admin()
+            .call()
+            .await
+            .unwrap()
+    }
+
+    pub async fn only_owner_or_admin(
+        contract: &AdminLib<WalletUnlocked>,
+    ) -> FuelCallResponse<()> {
+        contract
+            .methods()
+            .only_owner_or_admin()
+            .call()
+            .await
+            .unwrap()
+    }
+
+    pub async fn only_owner(contract: &AdminLib<WalletUnlocked>) -> FuelCallResponse<()> {
+        contract.methods().only_owner().call().await.unwrap()
+    }
+
+    pub async fn set_ownership(
+        contract: &AdminLib<WalletUnlocked>,
+        new_owner: Identity,
+    ) -> FuelCallResponse<()> {
+        contract
+            .methods()
+            .set_ownership(new_owner)
+            .call()
+            .await
+            .unwrap()
+    }
+}
+
+pub mod test_helpers {
+
+    use super::*;
+
+    pub async fn setup() -> (Metadata, Metadata, Metadata, Metadata) {
+        let num_wallets = 5;
+        let coins_per_wallet = 1;
+        let coin_amount = 1000000;
+        let mut wallets = launch_custom_provider_and_get_wallets(
+            WalletsConfig::new(Some(num_wallets), Some(coins_per_wallet), Some(coin_amount)),
+            None,
+            None,
+        )
+        .await;
+
+        // Get the wallets from that provider
+        let wallet1 = wallets.pop().unwrap();
+        let wallet2 = wallets.pop().unwrap();
+        let wallet3 = wallets.pop().unwrap();
+        let wallet4 = wallets.pop().unwrap();
+
+        let storage_configuration = StorageConfiguration::load_from(
+            "src/admin/out/debug/admin_test-storage_slots.json",
+        );
+        let id = Contract::load_from(
+            "src/admin/out/debug/admin_test.bin",
+            LoadConfiguration::default().set_storage_configuration(storage_configuration.unwrap()),
+        )
+        .unwrap()
+        .deploy(&wallet1, TxParameters::default())
+        .await
+        .unwrap();
+
+        let deploy_wallet = Metadata {
+            contract: AdminLib::new(id.clone(), wallet1.clone()),
+            wallet: wallet1.clone(),
+        };
+
+        let owner = Metadata {
+            contract: AdminLib::new(id.clone(), wallet2.clone()),
+            wallet: wallet2.clone(),
+        };
+
+        let admin1 = Metadata {
+            contract: AdminLib::new(id.clone(), wallet3.clone()),
+            wallet: wallet3.clone(),
+        };
+
+        let admin2 = Metadata {
+            contract: AdminLib::new(id.clone(), wallet4.clone()),
+            wallet: wallet3.clone(),
+        };
+
+        (deploy_wallet, owner, admin1, admin2)
+    }
+}


### PR DESCRIPTION
## Type of change

<!--Delete points that do not apply-->

- New feature

## Changes

The following changes have been made:

- Introduces the admin library which has the following functionality:
     - `add_admin()`
     - `revoke_admin()`
     - `is_admin()`
     - `only_admin()`
     - `only_owner_or_admin()`
- This library allows for multiple administrators rather than a single user.

## Notes

- This library is built atop the ownership library where the owner is the only user who may add administrators. 
