### PR TITLE
Bump to forc v0.48.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,8 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   REGISTRY: ghcr.io
-  RUST_VERSION: 1.71.1
-  FORC_VERSION: 0.47.0
+  RUST_VERSION: 1.73.0
+  FORC_VERSION: 0.48.1
   CORE_VERSION: 0.20.8
   PATH_TO_SCRIPTS: .github/scripts
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ forc test && cargo test
 Any instructions related to using a specific library should be found within the README.md of that library.
 
 > **NOTE:**
-> All projects currently use `forc v0.47.0`, `fuels-rs v0.46.0` and `fuel-core 0.20.8`.
+> All projects currently use `forc v0.48.1`, `fuels-rs v0.53.0` and `fuel-core 0.20.8`.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ forc test && cargo test
 Any instructions related to using a specific library should be found within the README.md of that library.
 
 > **NOTE:**
-> All projects currently use `forc v0.48.1`, `fuels-rs v0.46.0` and `fuel-core 0.20.8`.
+> All projects currently use `forc v0.48.1`, `fuels-rs v0.53.0` and `fuel-core 0.20.8`.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ forc test && cargo test
 Any instructions related to using a specific library should be found within the README.md of that library.
 
 > **NOTE:**
-> All projects currently use `forc v0.48.1`, `fuels-rs v0.53.0` and `fuel-core 0.20.8`.
+> All projects currently use `forc v0.48.1`, `fuels-rs v0.46.0` and `fuel-core 0.20.8`.
 
 ## Contributing
 

--- a/libs/admin/Forc.toml
+++ b/libs/admin/Forc.toml
@@ -6,4 +6,4 @@ name = "admin"
 
 [dependencies]
 ownership = { path = "../ownership" }
-src_5 = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.2.0" }
+src_5 = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.2.2" }

--- a/libs/fixed_point/src/ifp256.sw
+++ b/libs/fixed_point/src/ifp256.sw
@@ -430,7 +430,6 @@ impl IFP256 {
 
 impl IFP256 {
     /// Returns the nearest integer to `self`. Round half-way cases away from zero.
-    //
     /// # Returns
     ///
     /// * [IFP256] - The newly created `IFP256` type.
@@ -446,6 +445,7 @@ impl IFP256 {
     ///     assert(round.underlying == UFP128::from(128).round().underlying);
     /// }
     /// ```
+    //
     pub fn round(self) -> Self {
         let mut underlying = self.underlying;
         let mut non_negative = self.non_negative;

--- a/libs/fixed_point/src/ifp256.sw
+++ b/libs/fixed_point/src/ifp256.sw
@@ -430,6 +430,7 @@ impl IFP256 {
 
 impl IFP256 {
     /// Returns the nearest integer to `self`. Round half-way cases away from zero.
+    ///
     /// # Returns
     ///
     /// * [IFP256] - The newly created `IFP256` type.
@@ -445,7 +446,6 @@ impl IFP256 {
     ///     assert(round.underlying == UFP128::from(128).round().underlying);
     /// }
     /// ```
-    //
     pub fn round(self) -> Self {
         let mut underlying = self.underlying;
         let mut non_negative = self.non_negative;

--- a/libs/ownership/Forc.toml
+++ b/libs/ownership/Forc.toml
@@ -5,4 +5,4 @@ license = "Apache-2.0"
 name = "ownership"
 
 [dependencies]
-src_5 = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.2.0" }
+src_5 = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.2.2" }

--- a/libs/queue/src/main.sw
+++ b/libs/queue/src/main.sw
@@ -138,10 +138,10 @@ impl<T> Queue<T> {
     ///     let mut queue = Queue::new::<u64>();
     ///     queue.enqueue(5);
     ///     let element = queue.peek().unwrap();
-    //      assert(element == 5);
     ///     assert(queue.len() == 1);
     /// }
     /// ```
+    //      assert(element == 5);
     pub fn peek(self) -> Option<T> {
         self.vec.get(0)
     }

--- a/libs/queue/src/main.sw
+++ b/libs/queue/src/main.sw
@@ -138,10 +138,10 @@ impl<T> Queue<T> {
     ///     let mut queue = Queue::new::<u64>();
     ///     queue.enqueue(5);
     ///     let element = queue.peek().unwrap();
+    ///     assert(element == 5);
     ///     assert(queue.len() == 1);
     /// }
     /// ```
-    //      assert(element == 5);
     pub fn peek(self) -> Option<T> {
         self.vec.get(0)
     }

--- a/libs/token/Forc.toml
+++ b/libs/token/Forc.toml
@@ -5,4 +5,4 @@ license = "Apache-2.0"
 name = "token"
 
 [dependencies]
-src_7 = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.2.0" }
+src_7 = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.2.2" }

--- a/libs/token/src/metadata.sw
+++ b/libs/token/src/metadata.sw
@@ -225,7 +225,7 @@ impl Metadata {
     /// ```
     pub fn is_string(self) -> bool {
         match self {
-            Self::String(data) => true,
+            Self::String(_) => true,
             _ => false,
         }
     }
@@ -280,7 +280,7 @@ impl Metadata {
     /// ```
     pub fn is_u64(self) -> bool {
         match self {
-            Self::Int(data) => true,
+            Self::Int(_) => true,
             _ => false,
         }
     }
@@ -335,7 +335,7 @@ impl Metadata {
     /// ```
     pub fn is_bytes(self) -> bool {
         match self {
-            Self::Bytes(data) => true,
+            Self::Bytes(_) => true,
             _ => false,
         }
     }
@@ -390,7 +390,7 @@ impl Metadata {
     /// ```
     pub fn is_b256(self) -> bool {
         match self {
-            Self::B256(data) => true,
+            Self::B256(_) => true,
             _ => false,
         }
     }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 
 [dependencies]
 fuel-merkle = { version = "0.33.0" }
-fuels = { version = "0.46.0", features = ["fuel-core-lib"] }
+fuels = { version = "0.53.0", features = ["fuel-core-lib"] }
 sha2 = { version = "0.10" }
 tokio = { version = "1.12", features = ["rt", "macros"] }
 

--- a/tests/src/admin/Forc.toml
+++ b/tests/src/admin/Forc.toml
@@ -7,4 +7,4 @@ name = "admin_test"
 [dependencies]
 admin = { path = "../../../libs/admin" }
 ownership = { path = "../../../libs/ownership" }
-src_5 = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.2.0" }
+src_5 = { git = "https://github.com/FuelLabs/sway-standards", branch = "bitzoic-bump-0.48.1" }

--- a/tests/src/admin/Forc.toml
+++ b/tests/src/admin/Forc.toml
@@ -7,4 +7,4 @@ name = "admin_test"
 [dependencies]
 admin = { path = "../../../libs/admin" }
 ownership = { path = "../../../libs/ownership" }
-src_5 = { git = "https://github.com/FuelLabs/sway-standards", branch = "bitzoic-bump-0.48.1" }
+src_5 = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.2.2" }

--- a/tests/src/admin/tests/functions/only_admin.rs
+++ b/tests/src/admin/tests/functions/only_admin.rs
@@ -40,7 +40,6 @@ mod reverts {
 
         let owner_identity = Identity::Address(owner.wallet.address().into());
         let admin1_identity = Identity::Address(admin1.wallet.address().into());
-        let admin2_identity = Identity::Address(admin2.wallet.address().into());
         set_ownership(&owner.contract, owner_identity.clone()).await;
         add_admin(&owner.contract, admin1_identity.clone()).await;
 

--- a/tests/src/admin/tests/functions/only_owner_or_admin.rs
+++ b/tests/src/admin/tests/functions/only_owner_or_admin.rs
@@ -33,7 +33,6 @@ mod reverts {
 
         let owner_identity = Identity::Address(owner.wallet.address().into());
         let admin1_identity = Identity::Address(admin1.wallet.address().into());
-        let admin2_identity = Identity::Address(admin2.wallet.address().into());
         set_ownership(&owner.contract, owner_identity.clone()).await;
         add_admin(&owner.contract, admin1_identity.clone()).await;
 

--- a/tests/src/fixed_point/ifp128_div_test/tests/mod.rs
+++ b/tests/src/fixed_point/ifp128_div_test/tests/mod.rs
@@ -13,7 +13,7 @@ mod success {
     async fn runs_ifp128_div_test_script() {
         let path_to_bin = "src/fixed_point/ifp128_div_test/out/debug/ifp128_div_test.bin";
 
-        let wallet = launch_provider_and_get_wallet().await;
+        let wallet = launch_provider_and_get_wallet().await.unwrap();
 
         let instance = TestIfp128Div::new(wallet, path_to_bin);
 

--- a/tests/src/fixed_point/ifp128_test/tests/mod.rs
+++ b/tests/src/fixed_point/ifp128_test/tests/mod.rs
@@ -13,7 +13,7 @@ mod success {
     async fn runs_ifp128_test_script() {
         let path_to_bin = "src/fixed_point/ifp128_test/out/debug/ifp128_test.bin";
 
-        let wallet = launch_provider_and_get_wallet().await;
+        let wallet = launch_provider_and_get_wallet().await.unwrap();
 
         let instance = TestIfp128::new(wallet, path_to_bin);
 

--- a/tests/src/fixed_point/ifp256_div_test/tests/mod.rs
+++ b/tests/src/fixed_point/ifp256_div_test/tests/mod.rs
@@ -13,7 +13,7 @@ mod success {
     async fn runs_ifp256_div_test_script() {
         let path_to_bin = "src/fixed_point/ifp256_div_test/out/debug/ifp256_div_test.bin";
 
-        let wallet = launch_provider_and_get_wallet().await;
+        let wallet = launch_provider_and_get_wallet().await.unwrap();
 
         let instance = TestIfp256Div::new(wallet, path_to_bin);
 

--- a/tests/src/fixed_point/ifp256_test/tests/mod.rs
+++ b/tests/src/fixed_point/ifp256_test/tests/mod.rs
@@ -13,7 +13,7 @@ mod success {
     async fn runs_ifp256_test_script() {
         let path_to_bin = "src/fixed_point/ifp256_test/out/debug/ifp256_test.bin";
 
-        let wallet = launch_provider_and_get_wallet().await;
+        let wallet = launch_provider_and_get_wallet().await.unwrap();
 
         let instance = TestIfp256::new(wallet, path_to_bin);
 

--- a/tests/src/fixed_point/ifp64_div_test/tests/mod.rs
+++ b/tests/src/fixed_point/ifp64_div_test/tests/mod.rs
@@ -13,7 +13,7 @@ mod success {
     async fn runs_ifp64_div_test_script() {
         let path_to_bin = "src/fixed_point/ifp64_div_test/out/debug/ifp64_div_test.bin";
 
-        let wallet = launch_provider_and_get_wallet().await;
+        let wallet = launch_provider_and_get_wallet().await.unwrap();
 
         let instance = TestIfp64Div::new(wallet, path_to_bin);
 

--- a/tests/src/fixed_point/ifp64_exp_test/tests/mod.rs
+++ b/tests/src/fixed_point/ifp64_exp_test/tests/mod.rs
@@ -12,7 +12,7 @@ mod success {
     #[tokio::test]
     async fn runs_ifp64_exp_test_script() {
         let path_to_bin = "src/fixed_point/ifp64_exp_test/out/debug/ifp64_exp_test.bin";
-        let wallet = launch_provider_and_get_wallet().await;
+        let wallet = launch_provider_and_get_wallet().await.unwrap();
 
         let instance = TestIfp64Exp::new(wallet, path_to_bin);
 

--- a/tests/src/fixed_point/ifp64_mul_test/tests/mod.rs
+++ b/tests/src/fixed_point/ifp64_mul_test/tests/mod.rs
@@ -13,7 +13,7 @@ mod success {
     async fn runs_ifp64_mul_test_script() {
         let path_to_bin = "src/fixed_point/ifp64_mul_test/out/debug/ifp64_mul_test.bin";
 
-        let wallet = launch_provider_and_get_wallet().await;
+        let wallet = launch_provider_and_get_wallet().await.unwrap();
 
         let instance = TestIfp64Mul::new(wallet, path_to_bin);
 

--- a/tests/src/fixed_point/ifp64_pow_test/tests/mod.rs
+++ b/tests/src/fixed_point/ifp64_pow_test/tests/mod.rs
@@ -12,7 +12,7 @@ mod success {
     #[tokio::test]
     async fn runs_ifp64_pow_test_script() {
         let path_to_bin = "src/fixed_point/ifp64_pow_test/out/debug/ifp64_pow_test.bin";
-        let wallet = launch_provider_and_get_wallet().await;
+        let wallet = launch_provider_and_get_wallet().await.unwrap();
 
         let instance = TestIfp64Pow::new(wallet, path_to_bin);
 

--- a/tests/src/fixed_point/ifp64_test/tests/mod.rs
+++ b/tests/src/fixed_point/ifp64_test/tests/mod.rs
@@ -13,7 +13,7 @@ mod success {
     async fn runs_ifp64_test_script() {
         let path_to_bin = "src/fixed_point/ifp64_test/out/debug/ifp64_test.bin";
 
-        let wallet = launch_provider_and_get_wallet().await;
+        let wallet = launch_provider_and_get_wallet().await.unwrap();
 
         let instance = TestIfp64::new(wallet, path_to_bin);
 

--- a/tests/src/fixed_point/ufp128_div_test/tests/mod.rs
+++ b/tests/src/fixed_point/ufp128_div_test/tests/mod.rs
@@ -13,7 +13,7 @@ mod success {
     async fn runs_ufp128_div_test_script() {
         let path_to_bin = "src/fixed_point/ufp128_div_test/out/debug/ufp128_div_test.bin";
 
-        let wallet = launch_provider_and_get_wallet().await;
+        let wallet = launch_provider_and_get_wallet().await.unwrap();
 
         let instance = TestUfp128Div::new(wallet, path_to_bin);
 

--- a/tests/src/fixed_point/ufp128_test/tests/mod.rs
+++ b/tests/src/fixed_point/ufp128_test/tests/mod.rs
@@ -13,7 +13,7 @@ mod success {
     async fn runs_ufp128_test_script() {
         let path_to_bin = "src/fixed_point/ufp128_test/out/debug/ufp128_test.bin";
 
-        let wallet = launch_provider_and_get_wallet().await;
+        let wallet = launch_provider_and_get_wallet().await.unwrap();
 
         let instance = TestUfp128::new(wallet, path_to_bin);
 

--- a/tests/src/fixed_point/ufp32_div_test/tests/mod.rs
+++ b/tests/src/fixed_point/ufp32_div_test/tests/mod.rs
@@ -13,7 +13,7 @@ mod success {
     async fn runs_ufp32_div_test_script() {
         let path_to_bin = "src/fixed_point/ufp32_div_test/out/debug/ufp32_div_test.bin";
 
-        let wallet = launch_provider_and_get_wallet().await;
+        let wallet = launch_provider_and_get_wallet().await.unwrap();
 
         let instance = TestUfp32Div::new(wallet, path_to_bin);
 

--- a/tests/src/fixed_point/ufp32_exp_test/tests/mod.rs
+++ b/tests/src/fixed_point/ufp32_exp_test/tests/mod.rs
@@ -12,7 +12,7 @@ mod success {
     #[tokio::test]
     async fn runs_ufp32_exp_test_script() {
         let path_to_bin = "src/fixed_point/ufp32_exp_test/out/debug/ufp32_exp_test.bin";
-        let wallet = launch_provider_and_get_wallet().await;
+        let wallet = launch_provider_and_get_wallet().await.unwrap();
 
         let instance = TestUfp32Exp::new(wallet, path_to_bin);
 

--- a/tests/src/fixed_point/ufp32_mul_test/tests/mod.rs
+++ b/tests/src/fixed_point/ufp32_mul_test/tests/mod.rs
@@ -13,7 +13,7 @@ mod success {
     async fn runs_ufp32_mul_test_script() {
         let path_to_bin = "src/fixed_point/ufp32_mul_test/out/debug/ufp32_mul_test.bin";
 
-        let wallet = launch_provider_and_get_wallet().await;
+        let wallet = launch_provider_and_get_wallet().await.unwrap();
 
         let instance = TestUfp32Mul::new(wallet, path_to_bin);
 

--- a/tests/src/fixed_point/ufp32_pow_test/tests/mod.rs
+++ b/tests/src/fixed_point/ufp32_pow_test/tests/mod.rs
@@ -12,7 +12,7 @@ mod success {
     #[tokio::test]
     async fn runs_ufp32_pow_test_script() {
         let path_to_bin = "src/fixed_point/ufp32_pow_test/out/debug/ufp32_pow_test.bin";
-        let wallet = launch_provider_and_get_wallet().await;
+        let wallet = launch_provider_and_get_wallet().await.unwrap();
 
         let instance = TestUfp32Pow::new(wallet, path_to_bin);
 

--- a/tests/src/fixed_point/ufp32_root_test/tests/mod.rs
+++ b/tests/src/fixed_point/ufp32_root_test/tests/mod.rs
@@ -13,7 +13,7 @@ mod success {
     async fn runs_ufp32_root_test_script() {
         let path_to_bin = "src/fixed_point/ufp32_root_test/out/debug/ufp32_root_test.bin";
 
-        let wallet = launch_provider_and_get_wallet().await;
+        let wallet = launch_provider_and_get_wallet().await.unwrap();
 
         let instance = TestUfp32Root::new(wallet, path_to_bin);
 

--- a/tests/src/fixed_point/ufp32_test/tests/mod.rs
+++ b/tests/src/fixed_point/ufp32_test/tests/mod.rs
@@ -13,7 +13,7 @@ mod success {
     async fn runs_ufp32_test_script() {
         let path_to_bin = "src/fixed_point/ufp32_test/out/debug/ufp32_test.bin";
 
-        let wallet = launch_provider_and_get_wallet().await;
+        let wallet = launch_provider_and_get_wallet().await.unwrap();
 
         let instance = TestUfp32::new(wallet, path_to_bin);
 

--- a/tests/src/fixed_point/ufp64_div_test/tests/mod.rs
+++ b/tests/src/fixed_point/ufp64_div_test/tests/mod.rs
@@ -13,7 +13,7 @@ mod success {
     async fn runs_ufp64_div_test_script() {
         let path_to_bin = "src/fixed_point/ufp64_div_test/out/debug/ufp64_div_test.bin";
 
-        let wallet = launch_provider_and_get_wallet().await;
+        let wallet = launch_provider_and_get_wallet().await.unwrap();
 
         let instance = TestUfp64Div::new(wallet, path_to_bin);
 

--- a/tests/src/fixed_point/ufp64_exp_test/tests/mod.rs
+++ b/tests/src/fixed_point/ufp64_exp_test/tests/mod.rs
@@ -12,7 +12,7 @@ mod success {
     #[tokio::test]
     async fn runs_ufp64_exp_test_script() {
         let path_to_bin = "src/fixed_point/ufp64_exp_test/out/debug/ufp64_exp_test.bin";
-        let wallet = launch_provider_and_get_wallet().await;
+        let wallet = launch_provider_and_get_wallet().await.unwrap();
 
         let instance = TestUfp64Exp::new(wallet, path_to_bin);
 

--- a/tests/src/fixed_point/ufp64_mul_test/tests/mod.rs
+++ b/tests/src/fixed_point/ufp64_mul_test/tests/mod.rs
@@ -13,7 +13,7 @@ mod success {
     async fn runs_ufp64_mul_test_script() {
         let path_to_bin = "src/fixed_point/ufp64_mul_test/out/debug/ufp64_mul_test.bin";
 
-        let wallet = launch_provider_and_get_wallet().await;
+        let wallet = launch_provider_and_get_wallet().await.unwrap();
 
         let instance = TestUfp64Mul::new(wallet, path_to_bin);
 

--- a/tests/src/fixed_point/ufp64_pow_test/tests/mod.rs
+++ b/tests/src/fixed_point/ufp64_pow_test/tests/mod.rs
@@ -12,7 +12,7 @@ mod success {
     #[tokio::test]
     async fn runs_ufp64_pow_test_script() {
         let path_to_bin = "src/fixed_point/ufp64_pow_test/out/debug/ufp64_pow_test.bin";
-        let wallet = launch_provider_and_get_wallet().await;
+        let wallet = launch_provider_and_get_wallet().await.unwrap();
 
         let instance = TestUfp64Pow::new(wallet, path_to_bin);
 

--- a/tests/src/fixed_point/ufp64_root_test/tests/mod.rs
+++ b/tests/src/fixed_point/ufp64_root_test/tests/mod.rs
@@ -13,7 +13,7 @@ mod success {
     async fn runs_ufp64_root_test_script() {
         let path_to_bin = "src/fixed_point/ufp64_root_test/out/debug/ufp64_root_test.bin";
 
-        let wallet = launch_provider_and_get_wallet().await;
+        let wallet = launch_provider_and_get_wallet().await.unwrap();
 
         let instance = TestUfp64Root::new(wallet, path_to_bin);
 

--- a/tests/src/fixed_point/ufp64_test/tests/mod.rs
+++ b/tests/src/fixed_point/ufp64_test/tests/mod.rs
@@ -13,7 +13,7 @@ mod success {
     async fn runs_ufp64_test_script() {
         let path_to_bin = "src/fixed_point/ufp64_test/out/debug/ufp64_test.bin";
 
-        let wallet = launch_provider_and_get_wallet().await;
+        let wallet = launch_provider_and_get_wallet().await.unwrap();
 
         let instance = TestUfp64::new(wallet, path_to_bin);
 

--- a/tests/src/merkle_proof/tests/utils/mod.rs
+++ b/tests/src/merkle_proof/tests/utils/mod.rs
@@ -4,7 +4,7 @@ use fuel_merkle::{
 };
 use fuels::{
     prelude::{
-        abigen, launch_provider_and_get_wallet, Contract, LoadConfiguration, TxParameters,
+        abigen, launch_provider_and_get_wallet, Contract, LoadConfiguration, TxPolicies,
         WalletUnlocked,
     },
     types::Bits256,
@@ -243,14 +243,14 @@ pub mod test_helpers {
     }
 
     pub async fn merkle_proof_instance() -> TestMerkleProofLib<WalletUnlocked> {
-        let wallet = launch_provider_and_get_wallet().await;
+        let wallet = launch_provider_and_get_wallet().await.unwrap();
 
         let contract_id = Contract::load_from(
             "./src/merkle_proof/out/debug/merkle_proof_test.bin",
             LoadConfiguration::default(),
         )
         .unwrap()
-        .deploy(&wallet, TxParameters::default())
+        .deploy(&wallet, TxPolicies::default())
         .await
         .unwrap();
 

--- a/tests/src/ownership/Forc.toml
+++ b/tests/src/ownership/Forc.toml
@@ -6,4 +6,4 @@ name = "ownership_test"
 
 [dependencies]
 ownership = { path = "../../../libs/ownership" }
-src_5 = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.2.0" }
+src_5 = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.2.2" }

--- a/tests/src/ownership/tests/utils/mod.rs
+++ b/tests/src/ownership/tests/utils/mod.rs
@@ -1,7 +1,7 @@
 use fuels::{
     prelude::{
         abigen, launch_custom_provider_and_get_wallets, Contract, LoadConfiguration,
-        StorageConfiguration, TxParameters, WalletUnlocked, WalletsConfig,
+        StorageConfiguration, TxPolicies, WalletUnlocked, WalletsConfig,
     },
     programs::call_response::FuelCallResponse,
     types::Identity,
@@ -79,24 +79,24 @@ pub mod test_helpers {
             None,
             None,
         )
-        .await;
+        .await
+        .unwrap();
 
         // Get the wallets from that provider
         let wallet1 = wallets.pop().unwrap();
         let wallet2 = wallets.pop().unwrap();
         let wallet3 = wallets.pop().unwrap();
 
-        let storage_configuration = StorageConfiguration::load_from(
+        let storage_configuration = StorageConfiguration::default().add_slot_overrides_from_file(
             "src/ownership/out/debug/ownership_test-storage_slots.json",
         );
-        let id = Contract::load_from(
-            "src/ownership/out/debug/ownership_test.bin",
-            LoadConfiguration::default().set_storage_configuration(storage_configuration.unwrap()),
-        )
-        .unwrap()
-        .deploy(&wallet1, TxParameters::default())
-        .await
-        .unwrap();
+        let configuration =
+            LoadConfiguration::default().with_storage_configuration(storage_configuration.unwrap());
+        let id = Contract::load_from("src/ownership/out/debug/ownership_test.bin", configuration)
+            .unwrap()
+            .deploy(&wallet1, TxPolicies::default())
+            .await
+            .unwrap();
 
         let deploy_wallet = Metadata {
             contract: OwnershipLib::new(id.clone(), wallet1.clone()),

--- a/tests/src/signed_integers/signed_i128/tests/mod.rs
+++ b/tests/src/signed_integers/signed_i128/tests/mod.rs
@@ -12,7 +12,7 @@ mod success {
     #[tokio::test]
     async fn runs_i128_test_script() {
         let path_to_bin = "src/signed_integers/signed_i128/out/debug/i128_test.bin";
-        let wallet = launch_provider_and_get_wallet().await;
+        let wallet = launch_provider_and_get_wallet().await.unwrap();
 
         let instance = Testi128::new(wallet, path_to_bin);
 

--- a/tests/src/signed_integers/signed_i16/tests/mod.rs
+++ b/tests/src/signed_integers/signed_i16/tests/mod.rs
@@ -12,7 +12,7 @@ mod success {
     #[tokio::test]
     async fn runs_i16_test_script() {
         let path_to_bin = "src/signed_integers/signed_i16/out/debug/i16_test.bin";
-        let wallet = launch_provider_and_get_wallet().await;
+        let wallet = launch_provider_and_get_wallet().await.unwrap();
 
         let instance = Testi16::new(wallet, path_to_bin);
 

--- a/tests/src/signed_integers/signed_i16_twos_complement/tests/mod.rs
+++ b/tests/src/signed_integers/signed_i16_twos_complement/tests/mod.rs
@@ -13,7 +13,7 @@ mod success {
     async fn runs_i16_twos_complement_test_script() {
         let path_to_bin =
             "src/signed_integers/signed_i16_twos_complement/out/debug/i16_twos_complement_test.bin";
-        let wallet = launch_provider_and_get_wallet().await;
+        let wallet = launch_provider_and_get_wallet().await.unwrap();
 
         let instance = Testi16TwosComplement::new(wallet, path_to_bin);
 

--- a/tests/src/signed_integers/signed_i256/tests/mod.rs
+++ b/tests/src/signed_integers/signed_i256/tests/mod.rs
@@ -12,7 +12,7 @@ mod success {
     #[tokio::test]
     async fn runs_i256_test_script() {
         let path_to_bin = "src/signed_integers/signed_i256/out/debug/i256_test.bin";
-        let wallet = launch_provider_and_get_wallet().await;
+        let wallet = launch_provider_and_get_wallet().await.unwrap();
 
         let instance = Testi256::new(wallet, path_to_bin);
 

--- a/tests/src/signed_integers/signed_i32/tests/mod.rs
+++ b/tests/src/signed_integers/signed_i32/tests/mod.rs
@@ -12,7 +12,7 @@ mod success {
     #[tokio::test]
     async fn runs_i32_test_script() {
         let path_to_bin = "src/signed_integers/signed_i32/out/debug/i32_test.bin";
-        let wallet = launch_provider_and_get_wallet().await;
+        let wallet = launch_provider_and_get_wallet().await.unwrap();
 
         let instance = Testi32::new(wallet, path_to_bin);
 

--- a/tests/src/signed_integers/signed_i32_twos_complement/tests/mod.rs
+++ b/tests/src/signed_integers/signed_i32_twos_complement/tests/mod.rs
@@ -13,7 +13,7 @@ mod success {
     async fn runs_i32_twos_complement_test_script() {
         let path_to_bin =
             "src/signed_integers/signed_i32_twos_complement/out/debug/i32_twos_complement_test.bin";
-        let wallet = launch_provider_and_get_wallet().await;
+        let wallet = launch_provider_and_get_wallet().await.unwrap();
 
         let instance = Testi32TwosComplement::new(wallet, path_to_bin);
 

--- a/tests/src/signed_integers/signed_i64/tests/mod.rs
+++ b/tests/src/signed_integers/signed_i64/tests/mod.rs
@@ -12,7 +12,7 @@ mod success {
     #[tokio::test]
     async fn runs_i64_test_script() {
         let path_to_bin = "src/signed_integers/signed_i64/out/debug/i64_test.bin";
-        let wallet = launch_provider_and_get_wallet().await;
+        let wallet = launch_provider_and_get_wallet().await.unwrap();
 
         let instance = Testi64::new(wallet, path_to_bin);
 

--- a/tests/src/signed_integers/signed_i64_twos_complement/tests/mod.rs
+++ b/tests/src/signed_integers/signed_i64_twos_complement/tests/mod.rs
@@ -13,7 +13,7 @@ mod success {
     async fn runs_i64_twos_complement_test_script() {
         let path_to_bin =
             "src/signed_integers/signed_i64_twos_complement/out/debug/i64_twos_complement_test.bin";
-        let wallet = launch_provider_and_get_wallet().await;
+        let wallet = launch_provider_and_get_wallet().await.unwrap();
 
         let instance = Testi64TwosComplement::new(wallet, path_to_bin);
 

--- a/tests/src/signed_integers/signed_i8/tests/mod.rs
+++ b/tests/src/signed_integers/signed_i8/tests/mod.rs
@@ -12,7 +12,7 @@ mod success {
     #[tokio::test]
     async fn runs_i8_test_script() {
         let path_to_bin = "src/signed_integers/signed_i8/out/debug/i8_test.bin";
-        let wallet = launch_provider_and_get_wallet().await;
+        let wallet = launch_provider_and_get_wallet().await.unwrap();
 
         let instance = Testi8::new(wallet, path_to_bin);
 

--- a/tests/src/signed_integers/signed_i8_twos_complement/tests/mod.rs
+++ b/tests/src/signed_integers/signed_i8_twos_complement/tests/mod.rs
@@ -14,7 +14,7 @@ mod success {
     async fn runs_i8_twos_complement_test_script() {
         let path_to_bin =
             "src/signed_integers/signed_i8_twos_complement/out/debug/i8_twos_complement_test.bin";
-        let wallet = launch_provider_and_get_wallet().await;
+        let wallet = launch_provider_and_get_wallet().await.unwrap();
 
         let instance = Testi8TwosComplement::new(wallet, path_to_bin);
 

--- a/tests/src/token/Forc.toml
+++ b/tests/src/token/Forc.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "token_test"
 
 [dependencies]
-src_20 = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.2.0" }
-src_3 = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.2.0" }
-src_7 = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.2.0" }
+src_20 = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.2.2" }
+src_3 = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.2.2" }
+src_7 = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.2.2" }
 token = { path = "../../../libs/token" }


### PR DESCRIPTION
## Type of change

<!--Delete points that do not apply-->

- Improvement (refactoring, restructuring repository, cleaning tech debt, ...)

## Changes

The following changes have been made:

- Updates the repository to forc v0.48.1
- Updates the repository to sway-standards v0.2.2
- Updates the repository to rust v1.73.0
- Updates the repository to fuel-rs v0.53.0
