### PR TITLE
Bump Libraries to forc v0.50 and rust v0.75.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,8 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   REGISTRY: ghcr.io
-  RUST_VERSION: 1.73.0
-  FORC_VERSION: 0.49.1
+  RUST_VERSION: 1.75.0
+  FORC_VERSION: 0.50.0
   CORE_VERSION: 0.22.0
   PATH_TO_SCRIPTS: .github/scripts
 

--- a/libs/fixed_point/src/ifp128.sw
+++ b/libs/fixed_point/src/ifp128.sw
@@ -10,9 +10,9 @@ use ::ufp64::UFP64;
 /// Represented by an underlying `UFP64` number and a boolean.
 pub struct IFP128 {
     /// The underlying value representing the `IFP128` type.
-    underlying: UFP64,
+    pub underlying: UFP64,
     /// The underlying boolean representing a negative value for the `IFP128` type.
-    non_negative: bool,
+    pub non_negative: bool,
 }
 
 impl From<UFP64> for IFP128 {
@@ -22,10 +22,6 @@ impl From<UFP64> for IFP128 {
             underlying: value,
             non_negative: true,
         }
-    }
-
-    fn into(self) -> UFP64 {
-        self.underlying
     }
 }
 

--- a/libs/fixed_point/src/ifp256.sw
+++ b/libs/fixed_point/src/ifp256.sw
@@ -10,9 +10,9 @@ use ::ufp128::UFP128;
 /// Represented by an underlying `UFP128` number and a boolean.
 pub struct IFP256 {
     /// The underlying value representing the `IFP256` type.
-    underlying: UFP128,
+    pub underlying: UFP128,
     /// The underlying boolean representing a negative value for the `IFP256` type.
-    non_negative: bool,
+    pub non_negative: bool,
 }
 
 impl From<UFP128> for IFP256 {
@@ -22,10 +22,6 @@ impl From<UFP128> for IFP256 {
             underlying: value,
             non_negative: true,
         }
-    }
-
-    fn into(self) -> UFP128 {
-        self.underlying
     }
 }
 

--- a/libs/fixed_point/src/ifp64.sw
+++ b/libs/fixed_point/src/ifp64.sw
@@ -10,9 +10,9 @@ use ::ufp32::UFP32;
 /// Represented by an underlying `UFP32` number and a boolean.
 pub struct IFP64 {
     /// The underlying value representing the `IFP64` type.
-    underlying: UFP32,
+    pub underlying: UFP32,
     /// The underlying boolean representing a negative value for the `IFP64` type.
-    non_negative: bool,
+    pub non_negative: bool,
 }
 
 impl From<UFP32> for IFP64 {
@@ -22,10 +22,6 @@ impl From<UFP32> for IFP64 {
             underlying: value,
             non_negative: true,
         }
-    }
-
-    fn into(self) -> UFP32 {
-        self.underlying
     }
 }
 

--- a/libs/fixed_point/src/ufp128.sw
+++ b/libs/fixed_point/src/ufp128.sw
@@ -9,7 +9,7 @@ use std::{math::{Exponent, Power, Root}, u128::U128, u256::U256};
 /// Represented by an underlying `U128` number.
 pub struct UFP128 {
     /// The underlying value representing the `UFP128` type.
-    value: U128,
+    pub value: U128,
 }
 
 impl From<(u64, u64)> for UFP128 {
@@ -17,10 +17,6 @@ impl From<(u64, u64)> for UFP128 {
         Self {
             value: U128::from(int_fract_tuple),
         }
-    }
-
-    fn into(self) -> (u64, u64) {
-        self.value.into()
     }
 }
 

--- a/libs/fixed_point/src/ufp32.sw
+++ b/libs/fixed_point/src/ufp32.sw
@@ -9,17 +9,13 @@ use std::math::*;
 /// Represented by an underlying `u32` number.
 pub struct UFP32 {
     /// The underlying value representing the `UFP32` type.
-    value: u32,
+    pub value: u32,
 }
 
 impl From<u32> for UFP32 {
     /// Creates UFP32 from u32. Note that UFP32::from(1) is 1 / 2^32 and not 1.
     fn from(value: u32) -> Self {
         Self { value }
-    }
-
-    fn into(self) -> u32 {
-        self.value
     }
 }
 

--- a/libs/fixed_point/src/ufp64.sw
+++ b/libs/fixed_point/src/ufp64.sw
@@ -9,17 +9,13 @@ use std::{math::{Exponent, Power, Root}, u128::U128};
 /// Represented by an underlying `u64` number.
 pub struct UFP64 {
     /// The underlying value representing the `UFP64` type.
-    value: u64,
+    pub value: u64,
 }
 
 impl From<u64> for UFP64 {
     /// Creates UFP64 from u64. Note that UFP64::from(1) is 1 / 2^32 and not 1.
     fn from(value: u64) -> Self {
         Self { value }
-    }
-
-    fn into(self) -> u64 {
-        self.value
     }
 }
 

--- a/libs/ownership/src/events.sw
+++ b/libs/ownership/src/events.sw
@@ -3,19 +3,19 @@ library;
 /// Logged when ownership is renounced.
 pub struct OwnershipRenounced {
     /// The user which revoked the ownership.
-    previous_owner: Identity,
+    pub previous_owner: Identity,
 }
 
 /// Logged when ownership is given to a user.
 pub struct OwnershipSet {
     /// The user which is now the owner.
-    new_owner: Identity,
+    pub new_owner: Identity,
 }
 
 /// Logged when ownership is given from one user to another.
 pub struct OwnershipTransferred {
     /// The user which is now the owner.
-    new_owner: Identity,
+    pub new_owner: Identity,
     /// The user which has given up their ownership.
-    previous_owner: Identity,
+    pub previous_owner: Identity,
 }

--- a/libs/signed_integers/src/i128.sw
+++ b/libs/signed_integers/src/i128.sw
@@ -13,7 +13,7 @@ use ::errors::Error;
 /// Max value is 2 ^ 127 - 1, min value is - 2 ^ 127
 pub struct I128 {
     /// The underlying unsigned number representing the `I128` type.
-    underlying: U128,
+    pub underlying: U128,
 }
 
 impl I128 {
@@ -48,10 +48,6 @@ impl From<U128> for I128 {
         // as the minimal value of I128 is -I128::indent() (1 << 63) we should add I128::indent() (1 << 63) 
         let underlying: U128 = value + Self::indent();
         Self { underlying }
-    }
-
-    fn into(self) -> U128 {
-        self.underlying - Self::indent()
     }
 }
 

--- a/libs/signed_integers/src/i16.sw
+++ b/libs/signed_integers/src/i16.sw
@@ -12,7 +12,7 @@ use ::common::TwosComplement;
 /// Max value is 2 ^ 15 - 1, min value is - 2 ^ 15
 pub struct I16 {
     /// The underlying value representing the signed integer.
-    underlying: u16,
+    pub underlying: u16,
 }
 
 impl I16 {
@@ -43,10 +43,6 @@ impl From<u16> for I16 {
         // as the minimal value of I16 is -I16::indent() (1 << 15) we should add I16::indent() (1 << 15)
         let underlying: u16 = value + Self::indent();
         Self { underlying }
-    }
-
-    fn into(self) -> u16 {
-        self.underlying - Self::indent()
     }
 }
 

--- a/libs/signed_integers/src/i256.sw
+++ b/libs/signed_integers/src/i256.sw
@@ -12,7 +12,7 @@ use ::errors::Error;
 /// Actual value is underlying value minus 2 ^ 255
 /// Max value is 2 ^ 255 - 1, min value is - 2 ^ 255
 pub struct I256 {
-    underlying: U256,
+    pub underlying: U256,
 }
 
 impl I256 {
@@ -48,10 +48,6 @@ impl From<U256> for I256 {
         // as the minimal value of I256 is -I256::indent() (1 << 63) we should add I256::indent() (1 << 63) 
         let underlying = value + Self::indent();
         Self { underlying }
-    }
-
-    fn into(self) -> U256 {
-        self.underlying - Self::indent()
     }
 }
 

--- a/libs/signed_integers/src/i32.sw
+++ b/libs/signed_integers/src/i32.sw
@@ -12,7 +12,7 @@ use ::errors::Error;
 /// Max value is 2 ^ 31 - 1, min value is - 2 ^ 31
 pub struct I32 {
     /// The underlying u32 type that represent a I32.
-    underlying: u32,
+    pub underlying: u32,
 }
 
 impl I32 {
@@ -42,10 +42,6 @@ impl From<u32> for I32 {
         // as the minimal value of I32 is 2147483648 (1 << 31) we should add I32::indent() (1 << 31) 
         let underlying = value + Self::indent();
         Self { underlying }
-    }
-
-    fn into(self) -> u32 {
-        self.underlying - Self::indent()
     }
 }
 

--- a/libs/signed_integers/src/i64.sw
+++ b/libs/signed_integers/src/i64.sw
@@ -12,7 +12,7 @@ use ::errors::Error;
 /// Max value is 2 ^ 63 - 1, min value is - 2 ^ 63
 pub struct I64 {
     /// The underlying unsigned number representing the `I64` type.
-    underlying: u64,
+    pub underlying: u64,
 }
 
 impl I64 {
@@ -42,10 +42,6 @@ impl From<u64> for I64 {
         // as the minimal value of I64 is -I64::indent() (1 << 63) we should add I64::indent() (1 << 63) 
         let underlying = value + Self::indent();
         Self { underlying }
-    }
-
-    fn into(self) -> u64 {
-        self.underlying - Self::indent()
     }
 }
 

--- a/libs/signed_integers/src/i8.sw
+++ b/libs/signed_integers/src/i8.sw
@@ -12,7 +12,7 @@ use ::common::TwosComplement;
 /// Max value is 2 ^ 7 - 1, min value is - 2 ^ 7
 pub struct I8 {
     /// The underlying unsigned `u8` type that makes up the signed `I8` type.
-    underlying: u8,
+    pub underlying: u8,
 }
 
 impl I8 {
@@ -42,10 +42,6 @@ impl From<u8> for I8 {
         // as the minimal value of I8 is -I8::indent() (1 << 7) we should add I8::indent() (1 << 7) 
         let underlying: u8 = value + Self::indent();
         Self { underlying }
-    }
-
-    fn into(self) -> u8 {
-        self.underlying
     }
 }
 

--- a/tests/src/native_asset/Forc.toml
+++ b/tests/src/native_asset/Forc.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "asset_test"
 
 [dependencies]
+asset = { path = "../../../libs/native_asset" }
 src20 = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.3.3" }
 src3 = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.3.3" }
 src7 = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.3.3" }
-asset = { path = "../../../libs/native_asset" }


### PR DESCRIPTION
## Type of change

<!--Delete points that do not apply-->

- Improvement (refactoring, restructuring repository, cleaning tech debt, ...)

## Changes

The following changes have been made:

- Updates libraries to forc v0.50
- Updates CI to Rust v1.75.0

## Notes

- This new version of forc makes struct fields private by default. These have left public and will be made private in a future PR.
