### PR TITLE
Fix incorrect native asset URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ These libraries contain helper functions and other tools valuable to blockchain 
 
 #### Assets
 
-- [Native Assets](./libs/native_assets/) provides helper functions for the [SRC-20](https://github.com/FuelLabs/sway-standards/tree/master/standards/src20-native-asset), [SRC-3](https://github.com/FuelLabs/sway-standards/tree/master/standards/src_3), and [SRC-7](https://github.com/FuelLabs/sway-standards/tree/master/standards/src_7) standards.
+- [Native Assets](./libs/native_asset/) provides helper functions for the [SRC-20](https://github.com/FuelLabs/sway-standards/tree/master/standards/src20-native-asset), [SRC-3](https://github.com/FuelLabs/sway-standards/tree/master/standards/src_3), and [SRC-7](https://github.com/FuelLabs/sway-standards/tree/master/standards/src_7) standards.
 
 #### Access Control and Security
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ These libraries contain helper functions and other tools valuable to blockchain 
 
 #### Assets
 
-- [Native Assets](./libs/native_asset/) provides helper functions for the [SRC-20](https://github.com/FuelLabs/sway-standards/tree/master/standards/src20-native-asset), [SRC-3](https://github.com/FuelLabs/sway-standards/tree/master/standards/src_3), and [SRC-7](https://github.com/FuelLabs/sway-standards/tree/master/standards/src_7) standards.
+- [Native Asset](./libs/native_asset/) provides helper functions for the [SRC-20](https://github.com/FuelLabs/sway-standards/tree/master/standards/src20-native-asset), [SRC-3](https://github.com/FuelLabs/sway-standards/tree/master/standards/src_3), and [SRC-7](https://github.com/FuelLabs/sway-standards/tree/master/standards/src_7) standards.
 
 #### Access Control and Security
 


### PR DESCRIPTION
## Type of change

<!--Delete points that do not apply-->

- Documentation

## Changes

The following changes have been made:

- Native Asset link in README


