### PR TITLE
Deploy generated docs to github pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,6 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.RUST_VERSION }}
-          components: rustfmt
 
       - name: Init cache
         uses: Swatinem/rust-cache@v2
@@ -139,7 +138,6 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.RUST_VERSION }}
-          components: rustfmt
 
       - name: Init cache
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,6 @@ env:
 jobs:
   build-sway-lib:
       runs-on: ubuntu-latest
-      
       steps:
         - name: Checkout repository
           uses: actions/checkout@v2
@@ -103,11 +102,9 @@ jobs:
 
   contributing-book:
     runs-on: ubuntu-latest
-
     strategy:
       matrix:
         project: [".docs/contributing-book/src/code"]
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -136,3 +133,37 @@ jobs:
 
       - name: Build Sway
         run: forc build --path ${{ matrix.project }}
+
+  build-forc-doc-sway-libs:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        project:
+          [
+            "admin",
+            "bytecode",
+            "fixed_point",
+            "merkle_proof",
+            "native_asset",
+            "ownership",
+            "pausable",
+            "queue",
+            "reentrancy",
+            "signed_integers",
+          ]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+      - uses: Swatinem/rust-cache@v2
+      - name: Install Forc
+        run: cargo install --locked --debug --path ./forc
+      - name: Install Forc plugins
+        run: |
+          cargo install --locked --debug --path ./forc-plugins/forc-doc
+      - name: Build sway-libs docs
+        run: |
+          cd libs/${{ matrix.project }}
+          forc doc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,37 +18,22 @@ env:
   RUST_VERSION: 1.75.0
   FORC_VERSION: 0.50.0
   CORE_VERSION: 0.22.0
-  PATH_TO_SCRIPTS: .github/scripts
 
 jobs:
   build-sway-lib:
       runs-on: ubuntu-latest
       steps:
         - name: Checkout repository
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
 
         - name: Install Rust toolchain
-          uses: actions-rs/toolchain@v1
+          uses: dtolnay/rust-toolchain@master
           with:
-            profile: minimal
             toolchain: ${{ env.RUST_VERSION }}
-            override: true
+            components: rustfmt
 
         - name: Init cache
-          uses: Swatinem/rust-cache@v1
-
-        - name: Install a modern linker (mold)
-          uses: rui314/setup-mold@v1
-
-        - name: Force Rust to use mold globally for compilation
-          run: |
-            touch ~/.cargo/config.toml
-            echo "[target.x86_64-unknown-linux-gnu]" > ~/.cargo/config.toml
-            echo 'linker = "clang"' >> ~/.cargo/config.toml
-            echo 'rustflags = ["-C", "link-arg=-fuse-ld=/usr/local/bin/mold"]' >> ~/.cargo/config.toml
-
-        - name: Install rustfmt
-          run: rustup component add rustfmt
+          uses: Swatinem/rust-cache@v2
 
         - name: Install Fuel toolchain
           uses: FuelLabs/action-fuel-toolchain@v0.6.0
@@ -76,17 +61,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: ${{ env.RUST_VERSION }}
-          override: true
+          components: rustfmt
 
       - name: Init cache
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@v2
 
       - name: Install Fuel toolchain
         uses: FuelLabs/action-fuel-toolchain@v0.6.0
@@ -107,20 +91,16 @@ jobs:
         project: [".docs/contributing-book/src/code"]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: ${{ env.RUST_VERSION }}
-          override: true
+          components: rustfmt
 
       - name: Init cache
-        uses: Swatinem/rust-cache@v1
-
-      - name: Install rustfmt
-        run: rustup component add rustfmt
+        uses: Swatinem/rust-cache@v2
 
       - name: Install Fuel toolchain
         uses: FuelLabs/action-fuel-toolchain@v0.6.0
@@ -152,17 +132,24 @@ jobs:
             "signed_integers",
           ]
     steps:
-      - uses: actions/checkout@v3
-      - name: Install toolchain
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.RUST_VERSION }}
-      - uses: Swatinem/rust-cache@v2
-      - name: Install Forc
-        run: cargo install --locked --debug --path ./forc
-      - name: Install Forc plugins
-        run: |
-          cargo install --locked --debug --path ./forc-plugins/forc-doc
+          components: rustfmt
+
+      - name: Init cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install Fuel toolchain
+        uses: FuelLabs/action-fuel-toolchain@v0.6.0
+        with:
+          name: my-toolchain
+          components: forc@${{ env.FORC_VERSION }}, fuel-core@${{ env.CORE_VERSION }}
+
       - name: Build sway-libs docs
         run: |
           cd libs/${{ matrix.project }}

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -11,7 +11,7 @@ env:
   RUST_VERSION: 1.63.0
 
 jobs:
-  deploy:
+  deploy-contributing:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -30,3 +30,61 @@ jobs:
           publish_dir: ./.docs/contributing-book/book
           destination_dir: book
         if: github.ref == 'refs/heads/master'
+
+  deploy-forc-doc-sway-libs:
+    strategy:
+      matrix:
+        project:
+          [
+            "admin",
+            "bytecode",
+            "fixed_point",
+            "merkle_proof",
+            "native_asset",
+            "ownership",
+            "pausable",
+            "queue",
+            "reentrancy",
+            "signed_integers",
+          ]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+      
+      - uses: Swatinem/rust-cache@v2 
+      - name: Install Forc
+        run: cargo install --locked --debug --path ./forc
+      
+      - name: Install Forc plugins
+        run: |
+          cargo install --locked --debug --path ./forc-plugins/forc-doc
+      
+      - name: Build sway-libs docs
+        run: |
+          cd libs/${{ matrix.project }}
+          forc doc
+
+      - name: Deploy master std
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./libs/${{ matrix.project }}/out/doc
+          destination_dir: master/${{ matrix.project }}
+        if: github.ref == 'refs/heads/master'
+
+      - name: Get tag
+        id: branch_name
+        run: |
+          echo ::set-output name=BRANCH_NAME::${GITHUB_REF#refs/tags/}
+        if: startsWith(github.ref, 'refs/tags')
+
+      - name: Deploy std tag
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./libs/${{ matrix.project }}/out/doc
+          destination_dir: ${{ steps.branch_name.outputs.BRANCH_NAME }}/${{ matrix.project }}
+        if: startsWith(github.ref, 'refs/tags')

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -55,7 +55,6 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.RUST_VERSION }}
-          components: rustfmt
 
       - name: Init cache
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -8,7 +8,9 @@ on:
       - v*
 
 env:
-  RUST_VERSION: 1.63.0
+  RUST_VERSION: 1.75.0
+  FORC_VERSION: 0.50.0
+  CORE_VERSION: 0.22.0
 
 jobs:
   deploy-contributing:

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -48,20 +48,24 @@ jobs:
             "signed_integers",
           ]
     steps:
-      - uses: actions/checkout@v3
-      - name: Install toolchain
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.RUST_VERSION }}
-      
-      - uses: Swatinem/rust-cache@v2 
-      - name: Install Forc
-        run: cargo install --locked --debug --path ./forc
-      
-      - name: Install Forc plugins
-        run: |
-          cargo install --locked --debug --path ./forc-plugins/forc-doc
-      
+          components: rustfmt
+
+      - name: Init cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install Fuel toolchain
+        uses: FuelLabs/action-fuel-toolchain@v0.6.0
+        with:
+          name: my-toolchain
+          components: forc@${{ env.FORC_VERSION }}, fuel-core@${{ env.CORE_VERSION }}
+
       - name: Build sway-libs docs
         run: |
           cd libs/${{ matrix.project }}


### PR DESCRIPTION
## Type of change

<!--Delete points that do not apply-->

- New feature

## Changes

The following changes have been made:

- Add `forc doc` to CI
- Adds generated docs from `forc doc` to github pages

## Notes

- The repo needs to enable github pages
- `forc doc` does not support workspaces so each library has it's own page