### PR TITLE
Change `sway_libs::asset::mint::*` to `sway_libs::asset::supply::*`

### DIFF
--- a/libs/src/asset.sw
+++ b/libs/src/asset.sw
@@ -3,4 +3,4 @@ library;
 pub mod errors;
 pub mod base;
 pub mod metadata;
-pub mod mint;
+pub mod supply;

--- a/libs/src/asset/supply.sw
+++ b/libs/src/asset/supply.sw
@@ -42,7 +42,7 @@ use std::{
 /// # Examples
 ///
 /// ```sway
-/// use sway_libs::asset::mint::_mint;
+/// use sway_libs::asset::supply::_mint;
 /// use std::{constants::ZERO_B256, context::balance_of};
 ///
 /// storage {
@@ -100,7 +100,7 @@ pub fn _mint(
 /// # Examples
 ///
 /// ```sway
-/// use sway_libs::asset::mint::_burn;
+/// use sway_libs::asset::supply::_burn;
 /// use std::{call_frames::contract_id, constants::ZERO_B256, context::balance_of};
 ///
 /// storage {

--- a/tests/src/native_asset/src/main.sw
+++ b/tests/src/native_asset/src/main.sw
@@ -16,7 +16,7 @@ use sway_libs::asset::{
         SetAssetAttributes,
     },
     metadata::*,
-    mint::{
+    supply::{
         _burn,
         _mint,
     },


### PR DESCRIPTION
## Type of change

<!--Delete points that do not apply-->

- Improvement (refactoring, restructuring repository, cleaning tech debt, ...)

## Notes

- After internal discussion it was decided that the term supply is more appropriate than mint for the minting and burning portion of the asset library. 
- This should be merged after https://github.com/FuelLabs/sway-libs/pull/225

## Changes

The following changes have been made:

- The `mint.sw` file has been changed to `supply.sw`, changing the import path from `sway_libs::asset::mint::*` to `sway_libs::asset::supply::*`

## Related Issues

<!--Delete everything after the "#" symbol and replace it with a number. No spaces between hash and number-->

Closes #222 
