### PR TITLE
Use v0.4.1 of sway-standards

### DIFF
--- a/libs/Forc.toml
+++ b/libs/Forc.toml
@@ -5,4 +5,4 @@ license = "Apache-2.0"
 name = "sway_libs"
 
 [dependencies]
-standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.4.0" }
+standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.4.1" }

--- a/tests/src/admin/Forc.toml
+++ b/tests/src/admin/Forc.toml
@@ -5,5 +5,5 @@ license = "Apache-2.0"
 name = "admin_test"
 
 [dependencies]
-standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.4.0" }
+standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.4.1" }
 sway_libs = { path = "../../../libs" }

--- a/tests/src/native_asset/Forc.toml
+++ b/tests/src/native_asset/Forc.toml
@@ -5,5 +5,5 @@ license = "Apache-2.0"
 name = "asset_test"
 
 [dependencies]
-standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.4.0" }
+standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.4.1" }
 sway_libs = { path = "../../../libs" }

--- a/tests/src/ownership/Forc.toml
+++ b/tests/src/ownership/Forc.toml
@@ -5,5 +5,5 @@ license = "Apache-2.0"
 name = "ownership_test"
 
 [dependencies]
-standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.4.0" }
+standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.4.1" }
 sway_libs = { path = "../../../libs" }


### PR DESCRIPTION
## Type of change

<!--Delete points that do not apply-->

- Improvement (refactoring, restructuring repository, cleaning tech debt, ...)

## Changes

The following changes have been made:

- Updates sway-standards from v0.4.0 to v0.4.1
