### PR TITLE
Add SDK tests to native asset library

### DIFF
--- a/tests/src/harness.rs
+++ b/tests/src/harness.rs
@@ -4,6 +4,7 @@ mod admin;
 mod bytecode;
 mod fixed_point;
 mod merkle_proof;
+mod native_asset;
 mod ownership;
 mod reentrancy;
 mod signed_integers;

--- a/tests/src/native_asset/Forc.toml
+++ b/tests/src/native_asset/Forc.toml
@@ -2,7 +2,7 @@
 authors = ["Fuel Labs <contact@fuel.sh>"]
 entry = "main.sw"
 license = "Apache-2.0"
-name = "asset_test"
+name = "native_asset_lib"
 
 [dependencies]
 standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.4.1" }

--- a/tests/src/native_asset/mod.rs
+++ b/tests/src/native_asset/mod.rs
@@ -1,0 +1,1 @@
+mod tests;

--- a/tests/src/native_asset/tests/functions/burn.rs
+++ b/tests/src/native_asset/tests/functions/burn.rs
@@ -1,0 +1,160 @@
+use crate::native_asset::tests::utils::{
+    interface::{burn, mint, total_assets, total_supply},
+    setup::{defaults, get_wallet_balance, setup},
+};
+
+mod success {
+
+    use super::*;
+
+    #[tokio::test]
+    async fn burn_assets() {
+        let (owner_wallet, other_wallet, id, instance_1, instance_2) = setup().await;
+        let (asset_id_1, _asset_id_2, sub_id_1, _sub_id_2, _owner_identity, identity2) =
+            defaults(id, owner_wallet, other_wallet.clone());
+
+        mint(&instance_1, identity2, sub_id_1, 100).await;
+
+        assert_eq!(get_wallet_balance(&other_wallet, &asset_id_1).await, 100);
+        assert_eq!(total_supply(&instance_1, asset_id_1).await, Some(100));
+        assert_eq!(total_assets(&instance_1).await, 1);
+
+        burn(&instance_2, asset_id_1, sub_id_1, 50).await;
+
+        assert_eq!(get_wallet_balance(&other_wallet, &asset_id_1).await, 50);
+        assert_eq!(total_supply(&instance_1, asset_id_1).await, Some(50));
+        assert_eq!(total_assets(&instance_1).await, 1);
+    }
+
+    #[tokio::test]
+    async fn burns_multiple_assets() {
+        let (owner_wallet, other_wallet, id, instance_1, instance_2) = setup().await;
+        let (asset_id_1, asset_id_2, sub_id_1, sub_id_2, _owner_identity, identity2) =
+            defaults(id, owner_wallet, other_wallet.clone());
+
+        mint(&instance_1, identity2.clone(), sub_id_1, 100).await;
+        mint(&instance_1, identity2, sub_id_2, 200).await;
+
+        assert_eq!(get_wallet_balance(&other_wallet, &asset_id_1).await, 100);
+        assert_eq!(get_wallet_balance(&other_wallet, &asset_id_2).await, 200);
+        assert_eq!(total_supply(&instance_1, asset_id_1).await, Some(100));
+        assert_eq!(total_supply(&instance_1, asset_id_2).await, Some(200));
+        assert_eq!(total_assets(&instance_1).await, 2);
+
+        burn(&instance_2, asset_id_1, sub_id_1, 50).await;
+
+        assert_eq!(get_wallet_balance(&other_wallet, &asset_id_1).await, 50);
+        assert_eq!(get_wallet_balance(&other_wallet, &asset_id_2).await, 200);
+        assert_eq!(total_supply(&instance_1, asset_id_1).await, Some(50));
+        assert_eq!(total_supply(&instance_1, asset_id_2).await, Some(200));
+        assert_eq!(total_assets(&instance_1).await, 2);
+
+        burn(&instance_2, asset_id_2, sub_id_2, 100).await;
+
+        assert_eq!(get_wallet_balance(&other_wallet, &asset_id_1).await, 50);
+        assert_eq!(get_wallet_balance(&other_wallet, &asset_id_2).await, 100);
+        assert_eq!(total_supply(&instance_1, asset_id_1).await, Some(50));
+        assert_eq!(total_supply(&instance_1, asset_id_2).await, Some(100));
+        assert_eq!(total_assets(&instance_1).await, 2);
+    }
+
+    #[tokio::test]
+    async fn burn_to_zero() {
+        let (owner_wallet, other_wallet, id, instance_1, instance_2) = setup().await;
+        let (asset_id_1, _asset_id_2, sub_id_1, _sub_id_2, _owner_identity, identity2) =
+            defaults(id, owner_wallet, other_wallet.clone());
+
+        mint(&instance_1, identity2, sub_id_1, 100).await;
+
+        assert_eq!(get_wallet_balance(&other_wallet, &asset_id_1).await, 100);
+        assert_eq!(total_supply(&instance_1, asset_id_1).await, Some(100));
+        assert_eq!(total_assets(&instance_1).await, 1);
+
+        burn(&instance_2, asset_id_1, sub_id_1, 50).await;
+
+        assert_eq!(get_wallet_balance(&other_wallet, &asset_id_1).await, 50);
+        assert_eq!(total_supply(&instance_1, asset_id_1).await, Some(50));
+        assert_eq!(total_assets(&instance_1).await, 1);
+
+        burn(&instance_2, asset_id_1, sub_id_1, 25).await;
+
+        assert_eq!(get_wallet_balance(&other_wallet, &asset_id_1).await, 25);
+        assert_eq!(total_supply(&instance_1, asset_id_1).await, Some(25));
+        assert_eq!(total_assets(&instance_1).await, 1);
+
+        burn(&instance_2, asset_id_1, sub_id_1, 25).await;
+
+        assert_eq!(get_wallet_balance(&other_wallet, &asset_id_1).await, 0);
+        assert_eq!(total_supply(&instance_1, asset_id_1).await, Some(0));
+        assert_eq!(total_assets(&instance_1).await, 1);
+    }
+}
+
+mod revert {
+
+    use super::*;
+    use fuels::prelude::{CallParameters, TxPolicies, BASE_ASSET_ID};
+
+    #[tokio::test]
+    #[should_panic(expected = "NotEnoughCoins")]
+    async fn when_not_enough_coins() {
+        let (owner_wallet, other_wallet, id, instance_1, instance_2) = setup().await;
+        let (asset_id_1, _asset_id_2, sub_id_1, _sub_id_2, _identity1, identity2) =
+            defaults(id, owner_wallet, other_wallet.clone());
+
+        mint(&instance_1, identity2, sub_id_1, 100).await;
+
+        let call_params = CallParameters::new(50, asset_id_1, 1_000_000);
+        instance_2
+            .methods()
+            .burn(sub_id_1, 150)
+            .with_tx_policies(TxPolicies::default().with_script_gas_limit(2_000_000))
+            .call_params(call_params)
+            .unwrap()
+            .call()
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    #[should_panic(expected = "NotEnoughCoins")]
+    async fn when_invalid_sub_id() {
+        let (owner_wallet, other_wallet, id, instance_1, instance_2) = setup().await;
+        let (asset_id_1, _asset_id_2, sub_id_1, sub_id_2, _identity1, identity2) =
+            defaults(id, owner_wallet, other_wallet.clone());
+
+        mint(&instance_1, identity2, sub_id_1, 100).await;
+
+        let call_params = CallParameters::new(50, asset_id_1, 1_000_000);
+        instance_2
+            .methods()
+            .burn(sub_id_2, 50)
+            .with_tx_policies(TxPolicies::default().with_script_gas_limit(2_000_000))
+            .call_params(call_params)
+            .unwrap()
+            .call()
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    #[should_panic(expected = "NotEnoughCoins")]
+    async fn when_invalid_asset() {
+        let (owner_wallet, other_wallet, id, instance_1, instance_2) = setup().await;
+        let (_asset_id_1, _asset_id_2, sub_id_1, _sub_id_2, _identity1, identity2) =
+            defaults(id, owner_wallet, other_wallet.clone());
+
+        mint(&instance_1, identity2, sub_id_1, 100).await;
+
+        let call_params = CallParameters::new(50, BASE_ASSET_ID, 1_000_000);
+        instance_2
+            .methods()
+            .burn(sub_id_1, 50)
+            .with_tx_policies(TxPolicies::default().with_script_gas_limit(2_000_000))
+            .call_params(call_params)
+            .unwrap()
+            .call()
+            .await
+            .unwrap();
+    }
+}

--- a/tests/src/native_asset/tests/functions/decimals.rs
+++ b/tests/src/native_asset/tests/functions/decimals.rs
@@ -1,0 +1,52 @@
+use crate::native_asset::tests::utils::{
+    interface::{decimals, set_decimals},
+    setup::{defaults, get_asset_id, setup},
+};
+use fuels::tx::Bytes32;
+
+mod success {
+
+    use super::*;
+
+    #[tokio::test]
+    async fn one_asset() {
+        let (owner_wallet, other_wallet, id, instance_1, _instance_2) = setup().await;
+        let (asset_id_1, _asset_id_2, _sub_id_1, _sub_id_2, _identity1, _other_identity) =
+            defaults(id, owner_wallet, other_wallet.clone());
+
+        assert_eq!(decimals(&instance_1, asset_id_1).await, None);
+
+        set_decimals(&instance_1, asset_id_1, 9u8).await;
+        assert_eq!(decimals(&instance_1, asset_id_1).await, Some(9u8));
+    }
+
+    #[tokio::test]
+    async fn multiple_assets() {
+        let (owner_wallet, other_wallet, id, instance_1, _instance_2) = setup().await;
+        let (asset_id_1, asset_id_2, _sub_id_1, _sub_id_2, _identity1, _other_identity) =
+            defaults(id, owner_wallet, other_wallet.clone());
+
+        assert_eq!(decimals(&instance_1, asset_id_1).await, None);
+        set_decimals(&instance_1, asset_id_1, 9u8).await;
+        assert_eq!(decimals(&instance_1, asset_id_1).await, Some(9u8));
+
+        assert_eq!(decimals(&instance_1, asset_id_2).await, None);
+        set_decimals(&instance_1, asset_id_2, 8u8).await;
+        assert_eq!(decimals(&instance_1, asset_id_2).await, Some(8u8));
+
+        let asset_id_3 = get_asset_id(Bytes32::from([3u8; 32]), id);
+        assert_eq!(decimals(&instance_1, asset_id_3).await, None);
+        set_decimals(&instance_1, asset_id_3, 7u8).await;
+        assert_eq!(decimals(&instance_1, asset_id_3).await, Some(7u8));
+
+        let asset_id_4 = get_asset_id(Bytes32::from([4u8; 32]), id);
+        assert_eq!(decimals(&instance_1, asset_id_4).await, None);
+        set_decimals(&instance_1, asset_id_4, 6u8).await;
+        assert_eq!(decimals(&instance_1, asset_id_4).await, Some(6u8));
+
+        let asset_id_5 = get_asset_id(Bytes32::from([5u8; 32]), id);
+        assert_eq!(decimals(&instance_1, asset_id_5).await, None);
+        set_decimals(&instance_1, asset_id_5, 5u8).await;
+        assert_eq!(decimals(&instance_1, asset_id_5).await, Some(5u8));
+    }
+}

--- a/tests/src/native_asset/tests/functions/metadata.rs
+++ b/tests/src/native_asset/tests/functions/metadata.rs
@@ -1,0 +1,110 @@
+use crate::native_asset::tests::utils::{
+    interface::{metadata, set_metadata},
+    setup::{defaults, get_asset_id, setup, Metadata},
+};
+use fuels::{tx::Bytes32, types::Bytes};
+
+mod success {
+
+    use super::*;
+
+    #[ignore]
+    #[tokio::test]
+    async fn gets_one_asset() {
+        let (owner_wallet, other_wallet, id, instance_1, _instance_2) = setup().await;
+        let (asset_id_1, _asset_id_2, _sub_id_1, _sub_id_2, _identity1, _other_identity) =
+            defaults(id, owner_wallet, other_wallet.clone());
+        let metadata1 = Metadata::String(String::from("Fuel NFT Metadata"));
+        let key = String::from("key1");
+
+        assert_eq!(metadata(&instance_1, asset_id_1, key.clone()).await, None);
+
+        set_metadata(&instance_1, asset_id_1, key.clone(), metadata1.clone()).await;
+        assert_eq!(
+            metadata(&instance_1, asset_id_1, key).await,
+            Some(metadata1)
+        );
+    }
+
+    #[ignore]
+    #[tokio::test]
+    async fn gets_multiple_assets() {
+        let (owner_wallet, other_wallet, id, instance_1, _instance_2) = setup().await;
+        let (asset_id_1, asset_id_2, _sub_id_1, _sub_id_2, _identity1, _other_identity) =
+            defaults(id, owner_wallet, other_wallet.clone());
+        let metadata1 = Metadata::String(String::from("Fuel NFT Metadata 1"));
+        let metadata2 = Metadata::String(String::from("Fuel NFT Metadata 2"));
+        let metadata3 = Metadata::String(String::from("Fuel NFT Metadata 3"));
+        let key = String::from("key1");
+
+        assert_eq!(metadata(&instance_1, asset_id_1, key.clone()).await, None);
+        set_metadata(&instance_1, asset_id_1, key.clone(), metadata1.clone()).await;
+        assert_eq!(
+            metadata(&instance_1, asset_id_1, key.clone()).await,
+            Some(metadata1)
+        );
+
+        assert_eq!(metadata(&instance_1, asset_id_2, key.clone()).await, None);
+        set_metadata(&instance_1, asset_id_2, key.clone(), metadata2.clone()).await;
+        assert_eq!(
+            metadata(&instance_1, asset_id_2, key.clone()).await,
+            Some(metadata2)
+        );
+
+        let asset_id_3 = get_asset_id(Bytes32::from([3u8; 32]), id);
+        assert_eq!(metadata(&instance_1, asset_id_3, key.clone()).await, None);
+        set_metadata(&instance_1, asset_id_3, key.clone(), metadata3.clone()).await;
+        assert_eq!(
+            metadata(&instance_1, asset_id_3, key).await,
+            Some(metadata3)
+        );
+    }
+
+    #[ignore]
+    #[tokio::test]
+    async fn gets_multiple_types() {
+        let (owner_wallet, other_wallet, id, instance_1, _instance_2) = setup().await;
+        let (asset_id_1, _asset_id_2, _sub_id_1, _sub_id_2, _identity1, _other_identity) =
+            defaults(id, owner_wallet, other_wallet.clone());
+        let metadata1 = Metadata::String(String::from("Fuel NFT Metadata 1"));
+        let metadata2 = Metadata::Int(1);
+        let metadata3 =
+            Metadata::Bytes(Bytes::from_hex_str("bytes").expect("failed to conver to bytes"));
+        let key1 = String::from("key1");
+        let key2 = String::from("key2");
+        let key3 = String::from("key3");
+
+        assert_eq!(metadata(&instance_1, asset_id_1, key1.clone()).await, None);
+        set_metadata(&instance_1, asset_id_1, key1.clone(), metadata1.clone()).await;
+        assert_eq!(
+            metadata(&instance_1, asset_id_1, key1.clone()).await,
+            Some(metadata1.clone())
+        );
+
+        assert_eq!(metadata(&instance_1, asset_id_1, key2.clone()).await, None);
+        set_metadata(&instance_1, asset_id_1, key2.clone(), metadata2.clone()).await;
+        assert_eq!(
+            metadata(&instance_1, asset_id_1, key2.clone()).await,
+            Some(metadata2.clone())
+        );
+        assert_eq!(
+            metadata(&instance_1, asset_id_1, key1.clone()).await,
+            Some(metadata1.clone())
+        );
+
+        assert_eq!(metadata(&instance_1, asset_id_1, key3.clone()).await, None);
+        set_metadata(&instance_1, asset_id_1, key3.clone(), metadata3.clone()).await;
+        assert_eq!(
+            metadata(&instance_1, asset_id_1, key3).await,
+            Some(metadata3)
+        );
+        assert_eq!(
+            metadata(&instance_1, asset_id_1, key2.clone()).await,
+            Some(metadata2)
+        );
+        assert_eq!(
+            metadata(&instance_1, asset_id_1, key1.clone()).await,
+            Some(metadata1)
+        );
+    }
+}

--- a/tests/src/native_asset/tests/functions/mint.rs
+++ b/tests/src/native_asset/tests/functions/mint.rs
@@ -1,0 +1,49 @@
+use crate::native_asset::tests::utils::{
+    interface::{mint, total_assets, total_supply},
+    setup::{defaults, get_wallet_balance, setup},
+};
+
+mod success {
+
+    use super::*;
+
+    #[tokio::test]
+    async fn mints_assets() {
+        let (owner_wallet, other_wallet, id, instance_1, _instance_2) = setup().await;
+        let (asset_id_1, _asset_id_2, sub_id_1, _sub_id_2, _identity1, identity2) =
+            defaults(id, owner_wallet, other_wallet.clone());
+
+        assert_eq!(get_wallet_balance(&other_wallet, &asset_id_1).await, 0);
+        assert_eq!(total_supply(&instance_1, asset_id_1).await, None);
+        assert_eq!(total_assets(&instance_1).await, 0);
+
+        mint(&instance_1, identity2, sub_id_1, 100).await;
+
+        assert_eq!(get_wallet_balance(&other_wallet, &asset_id_1).await, 100);
+        assert_eq!(total_supply(&instance_1, asset_id_1).await, Some(100));
+        assert_eq!(total_assets(&instance_1).await, 1);
+    }
+
+    #[tokio::test]
+    async fn mints_multiple_assets() {
+        let (owner_wallet, other_wallet, id, instance_1, _instance_2) = setup().await;
+        let (asset_id_1, asset_id_2, sub_id_1, sub_id_2, _identity1, identity2) =
+            defaults(id, owner_wallet, other_wallet.clone());
+
+        mint(&instance_1, identity2.clone(), sub_id_1, 100).await;
+
+        assert_eq!(get_wallet_balance(&other_wallet, &asset_id_1).await, 100);
+        assert_eq!(get_wallet_balance(&other_wallet, &asset_id_2).await, 0);
+        assert_eq!(total_supply(&instance_1, asset_id_1).await, Some(100));
+        assert_eq!(total_supply(&instance_1, asset_id_2).await, None);
+        assert_eq!(total_assets(&instance_1).await, 1);
+
+        mint(&instance_1, identity2, sub_id_2, 200).await;
+
+        assert_eq!(get_wallet_balance(&other_wallet, &asset_id_1).await, 100);
+        assert_eq!(get_wallet_balance(&other_wallet, &asset_id_2).await, 200);
+        assert_eq!(total_supply(&instance_1, asset_id_1).await, Some(100));
+        assert_eq!(total_supply(&instance_1, asset_id_2).await, Some(200));
+        assert_eq!(total_assets(&instance_1).await, 2);
+    }
+}

--- a/tests/src/native_asset/tests/functions/mod.rs
+++ b/tests/src/native_asset/tests/functions/mod.rs
@@ -1,0 +1,12 @@
+mod burn;
+mod decimals;
+mod metadata;
+mod mint;
+mod name;
+mod set_decimals;
+mod set_metadata;
+mod set_name;
+mod set_symbol;
+mod symbol;
+mod total_assets;
+mod total_supply;

--- a/tests/src/native_asset/tests/functions/name.rs
+++ b/tests/src/native_asset/tests/functions/name.rs
@@ -1,0 +1,96 @@
+use crate::native_asset::tests::utils::{
+    interface::{name, set_name},
+    setup::{defaults, get_asset_id, setup},
+};
+use fuels::tx::Bytes32;
+
+mod success {
+
+    use super::*;
+
+    #[tokio::test]
+    async fn one_asset() {
+        let (owner_wallet, other_wallet, id, instance_1, _instance_2) = setup().await;
+        let (asset_id_1, _asset_id_2, _sub_id_1, _sub_id_2, _identity1, _other_identity) =
+            defaults(id, owner_wallet, other_wallet.clone());
+
+        assert_eq!(name(&instance_1, asset_id_1).await, None);
+
+        set_name(&instance_1, asset_id_1, String::from("Fuel Asset 1")).await;
+        assert_eq!(
+            name(&instance_1, asset_id_1).await,
+            Some(String::from("Fuel Asset 1"))
+        );
+    }
+
+    #[tokio::test]
+    async fn multiple_assets() {
+        let (owner_wallet, other_wallet, id, instance_1, _instance_2) = setup().await;
+        let (asset_id_1, asset_id_2, _sub_id_1, _sub_id_2, _identity1, _other_identity) =
+            defaults(id, owner_wallet, other_wallet.clone());
+
+        assert_eq!(name(&instance_1, asset_id_1).await, None);
+        set_name(&instance_1, asset_id_1, String::from("Fuel Asset 1")).await;
+        assert_eq!(
+            name(&instance_1, asset_id_1).await,
+            Some(String::from("Fuel Asset 1"))
+        );
+
+        assert_eq!(name(&instance_1, asset_id_2).await, None);
+        set_name(&instance_1, asset_id_2, String::from("Fuel Asset 2")).await;
+        assert_eq!(
+            name(&instance_1, asset_id_2).await,
+            Some(String::from("Fuel Asset 2"))
+        );
+
+        let asset_id_3 = get_asset_id(Bytes32::from([3u8; 32]), id);
+        assert_eq!(name(&instance_1, asset_id_3).await, None);
+        set_name(&instance_1, asset_id_3, String::from("Fuel Asset 3")).await;
+        assert_eq!(
+            name(&instance_1, asset_id_3).await,
+            Some(String::from("Fuel Asset 3"))
+        );
+
+        let asset_id_4 = get_asset_id(Bytes32::from([4u8; 32]), id);
+        assert_eq!(name(&instance_1, asset_id_4).await, None);
+        set_name(&instance_1, asset_id_4, String::from("Fuel Asset 4")).await;
+        assert_eq!(
+            name(&instance_1, asset_id_4).await,
+            Some(String::from("Fuel Asset 4"))
+        );
+
+        let asset_id_5 = get_asset_id(Bytes32::from([5u8; 32]), id);
+        assert_eq!(name(&instance_1, asset_id_5).await, None);
+        set_name(&instance_1, asset_id_5, String::from("Fuel Asset 5")).await;
+        assert_eq!(
+            name(&instance_1, asset_id_5).await,
+            Some(String::from("Fuel Asset 5"))
+        );
+    }
+
+    #[tokio::test]
+    async fn does_not_overwrite_other_names() {
+        let (owner_wallet, other_wallet, id, instance_1, _instance_2) = setup().await;
+        let (asset_id_1, asset_id_2, _sub_id_1, _sub_id_2, _identity1, _other_identity) =
+            defaults(id, owner_wallet, other_wallet.clone());
+
+        assert_eq!(name(&instance_1, asset_id_1).await, None);
+        set_name(&instance_1, asset_id_1, String::from("Fuel Asset 1")).await;
+        assert_eq!(
+            name(&instance_1, asset_id_1).await,
+            Some(String::from("Fuel Asset 1"))
+        );
+
+        assert_eq!(name(&instance_1, asset_id_2).await, None);
+        set_name(&instance_1, asset_id_2, String::from("Fuel Asset 2")).await;
+
+        assert_eq!(
+            name(&instance_1, asset_id_1).await,
+            Some(String::from("Fuel Asset 1"))
+        );
+        assert_eq!(
+            name(&instance_1, asset_id_2).await,
+            Some(String::from("Fuel Asset 2"))
+        );
+    }
+}

--- a/tests/src/native_asset/tests/functions/set_decimals.rs
+++ b/tests/src/native_asset/tests/functions/set_decimals.rs
@@ -1,0 +1,69 @@
+use crate::native_asset::tests::utils::{
+    interface::{decimals, set_decimals},
+    setup::{defaults, get_asset_id, setup},
+};
+use fuels::tx::Bytes32;
+
+mod success {
+
+    use super::*;
+
+    #[tokio::test]
+    async fn sets_one_asset() {
+        let (owner_wallet, other_wallet, id, instance_1, _instance_2) = setup().await;
+        let (asset_id_1, _asset_id_2, _sub_id_1, _sub_id_2, _identity1, _other_identity) =
+            defaults(id, owner_wallet, other_wallet.clone());
+
+        assert_eq!(decimals(&instance_1, asset_id_1).await, None);
+
+        set_decimals(&instance_1, asset_id_1, 9u8).await;
+        assert_eq!(decimals(&instance_1, asset_id_1).await, Some(9u8));
+    }
+
+    #[tokio::test]
+    async fn sets_multiple_assets() {
+        let (owner_wallet, other_wallet, id, instance_1, _instance_2) = setup().await;
+        let (asset_id_1, asset_id_2, _sub_id_1, _sub_id_2, _identity1, _other_identity) =
+            defaults(id, owner_wallet, other_wallet.clone());
+
+        assert_eq!(decimals(&instance_1, asset_id_1).await, None);
+        set_decimals(&instance_1, asset_id_1, 9u8).await;
+        assert_eq!(decimals(&instance_1, asset_id_1).await, Some(9u8));
+
+        assert_eq!(decimals(&instance_1, asset_id_2).await, None);
+        set_decimals(&instance_1, asset_id_2, 8u8).await;
+        assert_eq!(decimals(&instance_1, asset_id_2).await, Some(8u8));
+
+        let asset_id_3 = get_asset_id(Bytes32::from([3u8; 32]), id);
+        assert_eq!(decimals(&instance_1, asset_id_3).await, None);
+        set_decimals(&instance_1, asset_id_3, 7u8).await;
+        assert_eq!(decimals(&instance_1, asset_id_3).await, Some(7u8));
+
+        let asset_id_4 = get_asset_id(Bytes32::from([4u8; 32]), id);
+        assert_eq!(decimals(&instance_1, asset_id_4).await, None);
+        set_decimals(&instance_1, asset_id_4, 6u8).await;
+        assert_eq!(decimals(&instance_1, asset_id_4).await, Some(6u8));
+
+        let asset_id_5 = get_asset_id(Bytes32::from([5u8; 32]), id);
+        assert_eq!(decimals(&instance_1, asset_id_5).await, None);
+        set_decimals(&instance_1, asset_id_5, 5u8).await;
+        assert_eq!(decimals(&instance_1, asset_id_5).await, Some(5u8));
+    }
+
+    #[tokio::test]
+    async fn does_not_overwrite_other_decimals() {
+        let (owner_wallet, other_wallet, id, instance_1, _instance_2) = setup().await;
+        let (asset_id_1, asset_id_2, _sub_id_1, _sub_id_2, _identity1, _other_identity) =
+            defaults(id, owner_wallet, other_wallet.clone());
+
+        assert_eq!(decimals(&instance_1, asset_id_1).await, None);
+        set_decimals(&instance_1, asset_id_1, 9u8).await;
+        assert_eq!(decimals(&instance_1, asset_id_1).await, Some(9u8));
+
+        assert_eq!(decimals(&instance_1, asset_id_2).await, None);
+        set_decimals(&instance_1, asset_id_2, 8u8).await;
+
+        assert_eq!(decimals(&instance_1, asset_id_1).await, Some(9u8));
+        assert_eq!(decimals(&instance_1, asset_id_2).await, Some(8u8));
+    }
+}

--- a/tests/src/native_asset/tests/functions/set_metadata.rs
+++ b/tests/src/native_asset/tests/functions/set_metadata.rs
@@ -1,0 +1,158 @@
+use crate::native_asset::tests::utils::{
+    interface::{metadata, set_metadata},
+    setup::{defaults, get_asset_id, setup, Metadata},
+};
+use fuels::{tx::Bytes32, types::Bytes};
+
+mod success {
+
+    use super::*;
+
+    #[ignore]
+    #[tokio::test]
+    async fn sets_one_asset() {
+        let (owner_wallet, other_wallet, id, instance_1, _instance_2) = setup().await;
+        let (asset_id_1, _asset_id_2, _sub_id_1, _sub_id_2, _identity1, _other_identity) =
+            defaults(id, owner_wallet, other_wallet.clone());
+        let metadata1 = Metadata::String(String::from("Fuel NFT Metadata"));
+        let key = String::from("key1");
+
+        assert_eq!(metadata(&instance_1, asset_id_1, key.clone()).await, None);
+
+        set_metadata(&instance_1, asset_id_1, key.clone(), metadata1.clone()).await;
+        assert_eq!(
+            metadata(&instance_1, asset_id_1, key).await,
+            Some(metadata1)
+        );
+    }
+
+    #[ignore]
+    #[tokio::test]
+    async fn sets_multiple_assets() {
+        let (owner_wallet, other_wallet, id, instance_1, _instance_2) = setup().await;
+        let (asset_id_1, asset_id_2, _sub_id_1, _sub_id_2, _identity1, _other_identity) =
+            defaults(id, owner_wallet, other_wallet.clone());
+        let metadata1 = Metadata::String(String::from("Fuel NFT Metadata 1"));
+        let metadata2 = Metadata::String(String::from("Fuel NFT Metadata 2"));
+        let metadata3 = Metadata::String(String::from("Fuel NFT Metadata 3"));
+        let key = String::from("key1");
+
+        assert_eq!(metadata(&instance_1, asset_id_1, key.clone()).await, None);
+        set_metadata(&instance_1, asset_id_1, key.clone(), metadata1.clone()).await;
+        assert_eq!(
+            metadata(&instance_1, asset_id_1, key.clone()).await,
+            Some(metadata1)
+        );
+
+        assert_eq!(metadata(&instance_1, asset_id_2, key.clone()).await, None);
+        set_metadata(&instance_1, asset_id_2, key.clone(), metadata2.clone()).await;
+        assert_eq!(
+            metadata(&instance_1, asset_id_2, key.clone()).await,
+            Some(metadata2)
+        );
+
+        let asset_id_3 = get_asset_id(Bytes32::from([3u8; 32]), id);
+        assert_eq!(metadata(&instance_1, asset_id_3, key.clone()).await, None);
+        set_metadata(&instance_1, asset_id_3, key.clone(), metadata3.clone()).await;
+        assert_eq!(
+            metadata(&instance_1, asset_id_3, key).await,
+            Some(metadata3)
+        );
+    }
+
+    #[ignore]
+    #[tokio::test]
+    async fn does_not_overwrite_other_names() {
+        let (owner_wallet, other_wallet, id, instance_1, _instance_2) = setup().await;
+        let (asset_id_1, asset_id_2, _sub_id_1, _sub_id_2, _identity1, _other_identity) =
+            defaults(id, owner_wallet, other_wallet.clone());
+        let metadata1 = Metadata::String(String::from("Fuel NFT Metadata 1"));
+        let metadata2 = Metadata::String(String::from("Fuel NFT Metadata 2"));
+        let metadata3 = Metadata::String(String::from("Fuel NFT Metadata 3"));
+        let key = String::from("key1");
+
+        assert_eq!(metadata(&instance_1, asset_id_1, key.clone()).await, None);
+        set_metadata(&instance_1, asset_id_1, key.clone(), metadata1.clone()).await;
+        assert_eq!(
+            metadata(&instance_1, asset_id_1.clone(), key.clone()).await,
+            Some(metadata1.clone())
+        );
+
+        assert_eq!(metadata(&instance_1, asset_id_2, key.clone()).await, None);
+        set_metadata(&instance_1, asset_id_2, key.clone(), metadata2.clone()).await;
+
+        assert_eq!(
+            metadata(&instance_1, asset_id_1, key.clone()).await,
+            Some(metadata1.clone())
+        );
+        assert_eq!(
+            metadata(&instance_1, asset_id_2, key.clone()).await,
+            Some(metadata2.clone())
+        );
+
+        let asset_id_3 = get_asset_id(Bytes32::from([3u8; 32]), id);
+        assert_eq!(metadata(&instance_1, asset_id_3, key.clone()).await, None);
+        set_metadata(&instance_1, asset_id_3, key.clone(), metadata3.clone()).await;
+
+        assert_eq!(
+            metadata(&instance_1, asset_id_1, key.clone()).await,
+            Some(metadata1)
+        );
+        assert_eq!(
+            metadata(&instance_1, asset_id_2, key.clone()).await,
+            Some(metadata2)
+        );
+        assert_eq!(
+            metadata(&instance_1, asset_id_3, key).await,
+            Some(metadata3)
+        );
+    }
+
+    #[ignore]
+    #[tokio::test]
+    async fn sets_multiple_types() {
+        let (owner_wallet, other_wallet, id, instance_1, _instance_2) = setup().await;
+        let (asset_id_1, _asset_id_2, _sub_id_1, _sub_id_2, _identity1, _other_identity) =
+            defaults(id, owner_wallet, other_wallet.clone());
+        let metadata1 = Metadata::String(String::from("Fuel NFT Metadata 1"));
+        let metadata2 = Metadata::Int(1);
+        let metadata3 =
+            Metadata::Bytes(Bytes::from_hex_str("bytes").expect("failed to conver to bytes"));
+        let key1 = String::from("key1");
+        let key2 = String::from("key2");
+        let key3 = String::from("key3");
+
+        assert_eq!(metadata(&instance_1, asset_id_1, key1.clone()).await, None);
+        set_metadata(&instance_1, asset_id_1, key1.clone(), metadata1.clone()).await;
+        assert_eq!(
+            metadata(&instance_1, asset_id_1, key1.clone()).await,
+            Some(metadata1.clone())
+        );
+
+        assert_eq!(metadata(&instance_1, asset_id_1, key2.clone()).await, None);
+        set_metadata(&instance_1, asset_id_1, key2.clone(), metadata2.clone()).await;
+        assert_eq!(
+            metadata(&instance_1, asset_id_1, key2.clone()).await,
+            Some(metadata2.clone())
+        );
+        assert_eq!(
+            metadata(&instance_1, asset_id_1, key1.clone()).await,
+            Some(metadata1.clone())
+        );
+
+        assert_eq!(metadata(&instance_1, asset_id_1, key3.clone()).await, None);
+        set_metadata(&instance_1, asset_id_1, key3.clone(), metadata3.clone()).await;
+        assert_eq!(
+            metadata(&instance_1, asset_id_1, key3).await,
+            Some(metadata3)
+        );
+        assert_eq!(
+            metadata(&instance_1, asset_id_1, key2.clone()).await,
+            Some(metadata2)
+        );
+        assert_eq!(
+            metadata(&instance_1, asset_id_1, key1.clone()).await,
+            Some(metadata1)
+        );
+    }
+}

--- a/tests/src/native_asset/tests/functions/set_name.rs
+++ b/tests/src/native_asset/tests/functions/set_name.rs
@@ -1,0 +1,96 @@
+use crate::native_asset::tests::utils::{
+    interface::{name, set_name},
+    setup::{defaults, get_asset_id, setup},
+};
+use fuels::tx::Bytes32;
+
+mod success {
+
+    use super::*;
+
+    #[tokio::test]
+    async fn sets_one_asset() {
+        let (owner_wallet, other_wallet, id, instance_1, _instance_2) = setup().await;
+        let (asset_id_1, _asset_id_2, _sub_id_1, _sub_id_2, _identity1, _other_identity) =
+            defaults(id, owner_wallet, other_wallet.clone());
+
+        assert_eq!(name(&instance_1, asset_id_1).await, None);
+
+        set_name(&instance_1, asset_id_1, String::from("Fuel Asset 1")).await;
+        assert_eq!(
+            name(&instance_1, asset_id_1).await,
+            Some(String::from("Fuel Asset 1"))
+        );
+    }
+
+    #[tokio::test]
+    async fn sets_multiple_assets() {
+        let (owner_wallet, other_wallet, id, instance_1, _instance_2) = setup().await;
+        let (asset_id_1, asset_id_2, _sub_id_1, _sub_id_2, _identity1, _other_identity) =
+            defaults(id, owner_wallet, other_wallet.clone());
+
+        assert_eq!(name(&instance_1, asset_id_1).await, None);
+        set_name(&instance_1, asset_id_1, String::from("Fuel Asset 1")).await;
+        assert_eq!(
+            name(&instance_1, asset_id_1).await,
+            Some(String::from("Fuel Asset 1"))
+        );
+
+        assert_eq!(name(&instance_1, asset_id_2).await, None);
+        set_name(&instance_1, asset_id_2, String::from("Fuel Asset 2")).await;
+        assert_eq!(
+            name(&instance_1, asset_id_2).await,
+            Some(String::from("Fuel Asset 2"))
+        );
+
+        let asset_id_3 = get_asset_id(Bytes32::from([3u8; 32]), id);
+        assert_eq!(name(&instance_1, asset_id_3).await, None);
+        set_name(&instance_1, asset_id_3, String::from("Fuel Asset 3")).await;
+        assert_eq!(
+            name(&instance_1, asset_id_3).await,
+            Some(String::from("Fuel Asset 3"))
+        );
+
+        let asset_id_4 = get_asset_id(Bytes32::from([4u8; 32]), id);
+        assert_eq!(name(&instance_1, asset_id_4).await, None);
+        set_name(&instance_1, asset_id_4, String::from("Fuel Asset 4")).await;
+        assert_eq!(
+            name(&instance_1, asset_id_4).await,
+            Some(String::from("Fuel Asset 4"))
+        );
+
+        let asset_id_5 = get_asset_id(Bytes32::from([5u8; 32]), id);
+        assert_eq!(name(&instance_1, asset_id_5).await, None);
+        set_name(&instance_1, asset_id_5, String::from("Fuel Asset 5")).await;
+        assert_eq!(
+            name(&instance_1, asset_id_5).await,
+            Some(String::from("Fuel Asset 5"))
+        );
+    }
+
+    #[tokio::test]
+    async fn does_not_overwrite_other_names() {
+        let (owner_wallet, other_wallet, id, instance_1, _instance_2) = setup().await;
+        let (asset_id_1, asset_id_2, _sub_id_1, _sub_id_2, _identity1, _other_identity) =
+            defaults(id, owner_wallet, other_wallet.clone());
+
+        assert_eq!(name(&instance_1, asset_id_1).await, None);
+        set_name(&instance_1, asset_id_1, String::from("Fuel Asset 1")).await;
+        assert_eq!(
+            name(&instance_1, asset_id_1).await,
+            Some(String::from("Fuel Asset 1"))
+        );
+
+        assert_eq!(name(&instance_1, asset_id_2).await, None);
+        set_name(&instance_1, asset_id_2, String::from("Fuel Asset 2")).await;
+
+        assert_eq!(
+            name(&instance_1, asset_id_1).await,
+            Some(String::from("Fuel Asset 1"))
+        );
+        assert_eq!(
+            name(&instance_1, asset_id_2).await,
+            Some(String::from("Fuel Asset 2"))
+        );
+    }
+}

--- a/tests/src/native_asset/tests/functions/set_symbol.rs
+++ b/tests/src/native_asset/tests/functions/set_symbol.rs
@@ -1,0 +1,96 @@
+use crate::native_asset::tests::utils::{
+    interface::{set_symbol, symbol},
+    setup::{defaults, get_asset_id, setup},
+};
+use fuels::tx::Bytes32;
+
+mod success {
+
+    use super::*;
+
+    #[tokio::test]
+    async fn sets_one_asset() {
+        let (owner_wallet, other_wallet, id, instance_1, _instance_2) = setup().await;
+        let (asset_id_1, _asset_id_2, _sub_id_1, _sub_id_2, _identity1, _other_identity) =
+            defaults(id, owner_wallet, other_wallet.clone());
+
+        assert_eq!(symbol(&instance_1, asset_id_1).await, None);
+
+        set_symbol(&instance_1, asset_id_1, String::from("FA1")).await;
+        assert_eq!(
+            symbol(&instance_1, asset_id_1).await,
+            Some(String::from("FA1"))
+        );
+    }
+
+    #[tokio::test]
+    async fn sets_multiple_assets() {
+        let (owner_wallet, other_wallet, id, instance_1, _instance_2) = setup().await;
+        let (asset_id_1, asset_id_2, _sub_id_1, _sub_id_2, _identity1, _other_identity) =
+            defaults(id, owner_wallet, other_wallet.clone());
+
+        assert_eq!(symbol(&instance_1, asset_id_1).await, None);
+        set_symbol(&instance_1, asset_id_1, String::from("FA1")).await;
+        assert_eq!(
+            symbol(&instance_1, asset_id_1).await,
+            Some(String::from("FA1"))
+        );
+
+        assert_eq!(symbol(&instance_1, asset_id_2).await, None);
+        set_symbol(&instance_1, asset_id_2, String::from("FA2")).await;
+        assert_eq!(
+            symbol(&instance_1, asset_id_2).await,
+            Some(String::from("FA2"))
+        );
+
+        let asset_id_3 = get_asset_id(Bytes32::from([3u8; 32]), id);
+        assert_eq!(symbol(&instance_1, asset_id_3).await, None);
+        set_symbol(&instance_1, asset_id_3, String::from("FA3")).await;
+        assert_eq!(
+            symbol(&instance_1, asset_id_3).await,
+            Some(String::from("FA3"))
+        );
+
+        let asset_id_4 = get_asset_id(Bytes32::from([4u8; 32]), id);
+        assert_eq!(symbol(&instance_1, asset_id_4).await, None);
+        set_symbol(&instance_1, asset_id_4, String::from("FA4")).await;
+        assert_eq!(
+            symbol(&instance_1, asset_id_4).await,
+            Some(String::from("FA4"))
+        );
+
+        let asset_id_5 = get_asset_id(Bytes32::from([5u8; 32]), id);
+        assert_eq!(symbol(&instance_1, asset_id_5).await, None);
+        set_symbol(&instance_1, asset_id_5, String::from("FA5")).await;
+        assert_eq!(
+            symbol(&instance_1, asset_id_5).await,
+            Some(String::from("FA5"))
+        );
+    }
+
+    #[tokio::test]
+    async fn does_not_overwrite_other_symbols() {
+        let (owner_wallet, other_wallet, id, instance_1, _instance_2) = setup().await;
+        let (asset_id_1, asset_id_2, _sub_id_1, _sub_id_2, _identity1, _other_identity) =
+            defaults(id, owner_wallet, other_wallet.clone());
+
+        assert_eq!(symbol(&instance_1, asset_id_1).await, None);
+        set_symbol(&instance_1, asset_id_1, String::from("FA1")).await;
+        assert_eq!(
+            symbol(&instance_1, asset_id_1).await,
+            Some(String::from("FA1"))
+        );
+
+        assert_eq!(symbol(&instance_1, asset_id_2).await, None);
+        set_symbol(&instance_1, asset_id_2, String::from("FA2")).await;
+
+        assert_eq!(
+            symbol(&instance_1, asset_id_1).await,
+            Some(String::from("FA1"))
+        );
+        assert_eq!(
+            symbol(&instance_1, asset_id_2).await,
+            Some(String::from("FA2"))
+        );
+    }
+}

--- a/tests/src/native_asset/tests/functions/symbol.rs
+++ b/tests/src/native_asset/tests/functions/symbol.rs
@@ -1,0 +1,96 @@
+use crate::native_asset::tests::utils::{
+    interface::{set_symbol, symbol},
+    setup::{defaults, get_asset_id, setup},
+};
+use fuels::tx::Bytes32;
+
+mod success {
+
+    use super::*;
+
+    #[tokio::test]
+    async fn one_asset() {
+        let (owner_wallet, other_wallet, id, instance_1, _instance_2) = setup().await;
+        let (asset_id_1, _asset_id_2, _sub_id_1, _sub_id_2, _identity1, _other_identity) =
+            defaults(id, owner_wallet, other_wallet.clone());
+
+        assert_eq!(symbol(&instance_1, asset_id_1).await, None);
+
+        set_symbol(&instance_1, asset_id_1, String::from("FA1")).await;
+        assert_eq!(
+            symbol(&instance_1, asset_id_1).await,
+            Some(String::from("FA1"))
+        );
+    }
+
+    #[tokio::test]
+    async fn multiple_assets() {
+        let (owner_wallet, other_wallet, id, instance_1, _instance_2) = setup().await;
+        let (asset_id_1, asset_id_2, _sub_id_1, _sub_id_2, _identity1, _other_identity) =
+            defaults(id, owner_wallet, other_wallet.clone());
+
+        assert_eq!(symbol(&instance_1, asset_id_1).await, None);
+        set_symbol(&instance_1, asset_id_1, String::from("FA1")).await;
+        assert_eq!(
+            symbol(&instance_1, asset_id_1).await,
+            Some(String::from("FA1"))
+        );
+
+        assert_eq!(symbol(&instance_1, asset_id_2).await, None);
+        set_symbol(&instance_1, asset_id_2, String::from("FA2")).await;
+        assert_eq!(
+            symbol(&instance_1, asset_id_2).await,
+            Some(String::from("FA2"))
+        );
+
+        let asset_id_3 = get_asset_id(Bytes32::from([3u8; 32]), id);
+        assert_eq!(symbol(&instance_1, asset_id_3).await, None);
+        set_symbol(&instance_1, asset_id_3, String::from("FA3")).await;
+        assert_eq!(
+            symbol(&instance_1, asset_id_3).await,
+            Some(String::from("FA3"))
+        );
+
+        let asset_id_4 = get_asset_id(Bytes32::from([4u8; 32]), id);
+        assert_eq!(symbol(&instance_1, asset_id_4).await, None);
+        set_symbol(&instance_1, asset_id_4, String::from("FA4")).await;
+        assert_eq!(
+            symbol(&instance_1, asset_id_4).await,
+            Some(String::from("FA4"))
+        );
+
+        let asset_id_5 = get_asset_id(Bytes32::from([5u8; 32]), id);
+        assert_eq!(symbol(&instance_1, asset_id_5).await, None);
+        set_symbol(&instance_1, asset_id_5, String::from("FA5")).await;
+        assert_eq!(
+            symbol(&instance_1, asset_id_5).await,
+            Some(String::from("FA5"))
+        );
+    }
+
+    #[tokio::test]
+    async fn does_not_overwrite_other_symbols() {
+        let (owner_wallet, other_wallet, id, instance_1, _instance_2) = setup().await;
+        let (asset_id_1, asset_id_2, _sub_id_1, _sub_id_2, _identity1, _other_identity) =
+            defaults(id, owner_wallet, other_wallet.clone());
+
+        assert_eq!(symbol(&instance_1, asset_id_1).await, None);
+        set_symbol(&instance_1, asset_id_1, String::from("FA1")).await;
+        assert_eq!(
+            symbol(&instance_1, asset_id_1).await,
+            Some(String::from("FA1"))
+        );
+
+        assert_eq!(symbol(&instance_1, asset_id_2).await, None);
+        set_symbol(&instance_1, asset_id_2, String::from("FA2")).await;
+
+        assert_eq!(
+            symbol(&instance_1, asset_id_1).await,
+            Some(String::from("FA1"))
+        );
+        assert_eq!(
+            symbol(&instance_1, asset_id_2).await,
+            Some(String::from("FA2"))
+        );
+    }
+}

--- a/tests/src/native_asset/tests/functions/total_assets.rs
+++ b/tests/src/native_asset/tests/functions/total_assets.rs
@@ -1,0 +1,64 @@
+use crate::native_asset::tests::utils::{
+    interface::{mint, total_assets},
+    setup::{defaults, setup},
+};
+use fuels::types::Bits256;
+
+mod success {
+
+    use super::*;
+
+    #[tokio::test]
+    async fn one_asset() {
+        let (owner_wallet, other_wallet, id, instance_1, _instance_2) = setup().await;
+        let (_asset_id_1, _asset_id_2, sub_id_1, _sub_id_2, _identity1, identity2) =
+            defaults(id, owner_wallet, other_wallet.clone());
+
+        assert_eq!(total_assets(&instance_1).await, 0);
+
+        mint(&instance_1, identity2, sub_id_1, 100).await;
+        assert_eq!(total_assets(&instance_1).await, 1);
+    }
+
+    #[tokio::test]
+    async fn multiple_assets() {
+        let (owner_wallet, other_wallet, id, instance_1, _instance_2) = setup().await;
+        let (_asset_id_1, _asset_id_2, sub_id_1, sub_id_2, _identity1, identity2) =
+            defaults(id, owner_wallet, other_wallet.clone());
+
+        assert_eq!(total_assets(&instance_1).await, 0);
+
+        mint(&instance_1, identity2.clone(), sub_id_1, 100).await;
+        assert_eq!(total_assets(&instance_1).await, 1);
+
+        mint(&instance_1, identity2.clone(), sub_id_2, 200).await;
+        assert_eq!(total_assets(&instance_1).await, 2);
+
+        mint(&instance_1, identity2.clone(), Bits256([3u8; 32]), 300).await;
+        assert_eq!(total_assets(&instance_1).await, 3);
+
+        mint(&instance_1, identity2.clone(), Bits256([4u8; 32]), 400).await;
+        assert_eq!(total_assets(&instance_1).await, 4);
+
+        mint(&instance_1, identity2, Bits256([5u8; 32]), 200).await;
+        assert_eq!(total_assets(&instance_1).await, 5);
+    }
+
+    #[tokio::test]
+    async fn only_increments_on_new_asset() {
+        let (owner_wallet, other_wallet, id, instance_1, _instance_2) = setup().await;
+        let (_asset_id_1, _asset_id_2, sub_id_1, _sub_id_2, _identity1, identity2) =
+            defaults(id, owner_wallet, other_wallet.clone());
+
+        assert_eq!(total_assets(&instance_1).await, 0);
+
+        mint(&instance_1, identity2.clone(), sub_id_1, 100).await;
+        assert_eq!(total_assets(&instance_1).await, 1);
+
+        mint(&instance_1, identity2.clone(), sub_id_1, 100).await;
+        assert_eq!(total_assets(&instance_1).await, 1);
+
+        mint(&instance_1, identity2.clone(), sub_id_1, 100).await;
+        assert_eq!(total_assets(&instance_1).await, 1);
+    }
+}

--- a/tests/src/native_asset/tests/functions/total_supply.rs
+++ b/tests/src/native_asset/tests/functions/total_supply.rs
@@ -1,0 +1,82 @@
+use crate::native_asset::tests::utils::{
+    interface::{burn, mint, total_supply},
+    setup::{defaults, get_asset_id, setup},
+};
+use fuels::{tx::Bytes32, types::Bits256};
+
+mod success {
+
+    use super::*;
+
+    #[tokio::test]
+    async fn one_asset() {
+        let (owner_wallet, other_wallet, id, instance_1, _instance_2) = setup().await;
+        let (asset_id_1, _asset_id_2, sub_id_1, _sub_id_2, _identity1, identity2) =
+            defaults(id, owner_wallet, other_wallet.clone());
+
+        assert_eq!(total_supply(&instance_1, asset_id_1).await, None);
+        mint(&instance_1, identity2, sub_id_1, 100).await;
+        assert_eq!(total_supply(&instance_1, asset_id_1).await, Some(100));
+    }
+
+    #[tokio::test]
+    async fn multiple_assets() {
+        let (owner_wallet, other_wallet, id, instance_1, _instance_2) = setup().await;
+        let (asset_id_1, asset_id_2, sub_id_1, sub_id_2, _identity1, identity2) =
+            defaults(id, owner_wallet, other_wallet.clone());
+
+        assert_eq!(total_supply(&instance_1, asset_id_1).await, None);
+        mint(&instance_1, identity2.clone(), sub_id_1, 100).await;
+        assert_eq!(total_supply(&instance_1, asset_id_1).await, Some(100));
+
+        assert_eq!(total_supply(&instance_1, asset_id_2).await, None);
+        mint(&instance_1, identity2.clone(), sub_id_2, 200).await;
+        assert_eq!(total_supply(&instance_1, asset_id_2).await, Some(200));
+
+        let asset_id_3 = get_asset_id(Bytes32::from([3u8; 32]), id);
+        assert_eq!(total_supply(&instance_1, asset_id_3).await, None);
+        mint(&instance_1, identity2.clone(), Bits256([3u8; 32]), 300).await;
+        assert_eq!(total_supply(&instance_1, asset_id_3).await, Some(300));
+
+        let asset_id_4 = get_asset_id(Bytes32::from([4u8; 32]), id);
+        assert_eq!(total_supply(&instance_1, asset_id_4).await, None);
+        mint(&instance_1, identity2.clone(), Bits256([4u8; 32]), 400).await;
+        assert_eq!(total_supply(&instance_1, asset_id_4).await, Some(400));
+
+        let asset_id_5 = get_asset_id(Bytes32::from([5u8; 32]), id);
+        assert_eq!(total_supply(&instance_1, asset_id_5).await, None);
+        mint(&instance_1, identity2, Bits256([5u8; 32]), 500).await;
+        assert_eq!(total_supply(&instance_1, asset_id_5).await, Some(500));
+    }
+
+    #[tokio::test]
+    async fn only_increments_on_one_asset() {
+        let (owner_wallet, other_wallet, id, instance_1, _instance_2) = setup().await;
+        let (asset_id_1, _asset_id_2, sub_id_1, sub_id_2, _identity1, identity2) =
+            defaults(id, owner_wallet, other_wallet.clone());
+
+        assert_eq!(total_supply(&instance_1, asset_id_1).await, None);
+        mint(&instance_1, identity2.clone(), sub_id_1, 100).await;
+        assert_eq!(total_supply(&instance_1, asset_id_1).await, Some(100));
+
+        mint(&instance_1, identity2.clone(), sub_id_2, 200).await;
+        assert_eq!(total_supply(&instance_1, asset_id_1).await, Some(100));
+
+        mint(&instance_1, identity2.clone(), sub_id_2, 300).await;
+        assert_eq!(total_supply(&instance_1, asset_id_1).await, Some(100));
+    }
+
+    #[tokio::test]
+    async fn decrements_on_burn() {
+        let (owner_wallet, other_wallet, id, instance_1, instance_2) = setup().await;
+        let (asset_id_1, _asset_id_2, sub_id_1, _sub_id_2, _identity1, identity2) =
+            defaults(id, owner_wallet, other_wallet.clone());
+
+        assert_eq!(total_supply(&instance_1, asset_id_1).await, None);
+        mint(&instance_1, identity2.clone(), sub_id_1, 100).await;
+        assert_eq!(total_supply(&instance_1, asset_id_1).await, Some(100));
+
+        burn(&instance_2, asset_id_1, sub_id_1, 50).await;
+        assert_eq!(total_supply(&instance_1, asset_id_1).await, Some(50));
+    }
+}

--- a/tests/src/native_asset/tests/mod.rs
+++ b/tests/src/native_asset/tests/mod.rs
@@ -1,0 +1,2 @@
+mod functions;
+mod utils;

--- a/tests/src/native_asset/tests/utils/interface.rs
+++ b/tests/src/native_asset/tests/utils/interface.rs
@@ -1,0 +1,148 @@
+use crate::native_asset::tests::utils::setup::{AssetLib, Metadata};
+use fuels::{
+    prelude::{AssetId, CallParameters, TxPolicies, WalletUnlocked},
+    programs::{call_response::FuelCallResponse, call_utils::TxDependencyExtension},
+    types::{Bits256, Identity},
+};
+
+pub(crate) async fn total_assets(contract: &AssetLib<WalletUnlocked>) -> u64 {
+    contract
+        .methods()
+        .total_assets()
+        .call()
+        .await
+        .unwrap()
+        .value
+}
+
+pub(crate) async fn total_supply(
+    contract: &AssetLib<WalletUnlocked>,
+    asset: AssetId,
+) -> Option<u64> {
+    contract
+        .methods()
+        .total_supply(asset)
+        .call()
+        .await
+        .unwrap()
+        .value
+}
+
+pub(crate) async fn name(contract: &AssetLib<WalletUnlocked>, asset: AssetId) -> Option<String> {
+    contract.methods().name(asset).call().await.unwrap().value
+}
+
+pub(crate) async fn symbol(contract: &AssetLib<WalletUnlocked>, asset: AssetId) -> Option<String> {
+    contract.methods().symbol(asset).call().await.unwrap().value
+}
+
+pub(crate) async fn decimals(contract: &AssetLib<WalletUnlocked>, asset: AssetId) -> Option<u8> {
+    contract
+        .methods()
+        .decimals(asset)
+        .call()
+        .await
+        .unwrap()
+        .value
+}
+
+pub(crate) async fn mint(
+    contract: &AssetLib<WalletUnlocked>,
+    recipient: Identity,
+    sub_id: Bits256,
+    amount: u64,
+) -> FuelCallResponse<()> {
+    contract
+        .methods()
+        .mint(recipient, sub_id, amount)
+        .append_variable_outputs(1)
+        .call()
+        .await
+        .unwrap()
+}
+
+pub(crate) async fn burn(
+    contract: &AssetLib<WalletUnlocked>,
+    asset_id: AssetId,
+    sub_id: Bits256,
+    amount: u64,
+) -> FuelCallResponse<()> {
+    let call_params = CallParameters::new(amount, asset_id, 1_000_000);
+
+    contract
+        .methods()
+        .burn(sub_id, amount)
+        .with_tx_policies(TxPolicies::default().with_script_gas_limit(2_000_000))
+        .call_params(call_params)
+        .unwrap()
+        .call()
+        .await
+        .unwrap()
+}
+
+pub(crate) async fn set_name(
+    contract: &AssetLib<WalletUnlocked>,
+    asset: AssetId,
+    name: String,
+) -> FuelCallResponse<()> {
+    contract
+        .methods()
+        .set_name(asset, name)
+        .call()
+        .await
+        .unwrap()
+}
+
+pub(crate) async fn set_symbol(
+    contract: &AssetLib<WalletUnlocked>,
+    asset: AssetId,
+    name: String,
+) -> FuelCallResponse<()> {
+    contract
+        .methods()
+        .set_symbol(asset, name)
+        .call()
+        .await
+        .unwrap()
+}
+
+pub(crate) async fn set_decimals(
+    contract: &AssetLib<WalletUnlocked>,
+    asset: AssetId,
+    decimals: u8,
+) -> FuelCallResponse<()> {
+    contract
+        .methods()
+        .set_decimals(asset, decimals)
+        .call()
+        .await
+        .unwrap()
+}
+
+pub(crate) async fn metadata(
+    contract: &AssetLib<WalletUnlocked>,
+    asset: AssetId,
+    key: String,
+) -> Option<Metadata> {
+    contract
+        .methods()
+        .metadata(asset, key)
+        .call()
+        .await
+        .unwrap()
+        .value
+}
+
+pub(crate) async fn set_metadata(
+    contract: &AssetLib<WalletUnlocked>,
+    asset: AssetId,
+    key: String,
+    metadata: Metadata,
+) -> FuelCallResponse<()> {
+    contract
+        .methods()
+        .set_metadata(asset, key, metadata)
+        .call()
+        .await
+        .unwrap()
+}

--- a/tests/src/native_asset/tests/utils/mod.rs
+++ b/tests/src/native_asset/tests/utils/mod.rs
@@ -1,0 +1,2 @@
+pub mod interface;
+pub mod setup;

--- a/tests/src/native_asset/tests/utils/setup.rs
+++ b/tests/src/native_asset/tests/utils/setup.rs
@@ -1,0 +1,93 @@
+use fuels::{
+    accounts::ViewOnlyAccount,
+    prelude::{
+        abigen, launch_custom_provider_and_get_wallets, AssetConfig, Contract, ContractId,
+        LoadConfiguration, TxPolicies, WalletUnlocked, WalletsConfig, BASE_ASSET_ID,
+    },
+    tx::Bytes32,
+    types::{Address, AssetId, Bits256, Identity},
+};
+use sha2::{Digest, Sha256};
+
+abigen!(Contract(
+    name = "AssetLib",
+    abi = "src/native_asset/out/debug/native_asset_lib-abi.json"
+),);
+
+const NATIVE_ASSET_TEST_CONTRACT_BINARY_PATH: &str =
+    "./src/native_asset/out/debug/native_asset_lib.bin";
+
+pub(crate) fn defaults(
+    contract_id: ContractId,
+    wallet_1: WalletUnlocked,
+    wallet_2: WalletUnlocked,
+) -> (AssetId, AssetId, Bits256, Bits256, Identity, Identity) {
+    let sub_id_1 = Bytes32::from([1u8; 32]);
+    let sub_id_2 = Bytes32::from([2u8; 32]);
+    let asset1 = get_asset_id(sub_id_1, contract_id);
+    let asset2 = get_asset_id(sub_id_2, contract_id);
+
+    let identity_1 = Identity::Address(Address::from(wallet_1.address()));
+    let identity_2 = Identity::Address(Address::from(wallet_2.address()));
+
+    (
+        asset1,
+        asset2,
+        Bits256(*sub_id_1),
+        Bits256(*sub_id_2),
+        identity_1,
+        identity_2,
+    )
+}
+
+pub(crate) async fn setup() -> (
+    WalletUnlocked,
+    WalletUnlocked,
+    ContractId,
+    AssetLib<WalletUnlocked>,
+    AssetLib<WalletUnlocked>,
+) {
+    let number_of_coins = 1;
+    let coin_amount = 100_000_000;
+    let number_of_wallets = 2;
+
+    let base_asset = AssetConfig {
+        id: BASE_ASSET_ID,
+        num_coins: number_of_coins,
+        coin_amount,
+    };
+    let assets = vec![base_asset];
+
+    let wallet_config = WalletsConfig::new_multiple_assets(number_of_wallets, assets);
+    let mut wallets = launch_custom_provider_and_get_wallets(wallet_config, None, None)
+        .await
+        .unwrap();
+
+    let wallet1 = wallets.pop().unwrap();
+    let wallet2 = wallets.pop().unwrap();
+
+    let id = Contract::load_from(
+        NATIVE_ASSET_TEST_CONTRACT_BINARY_PATH,
+        LoadConfiguration::default(),
+    )
+    .unwrap()
+    .deploy(&wallet1, TxPolicies::default())
+    .await
+    .unwrap();
+
+    let instance_1 = AssetLib::new(id.clone(), wallet1.clone());
+    let instance_2 = AssetLib::new(id.clone(), wallet2.clone());
+
+    (wallet1, wallet2, id.into(), instance_1, instance_2)
+}
+
+pub(crate) fn get_asset_id(sub_id: Bytes32, contract: ContractId) -> AssetId {
+    let mut hasher = Sha256::new();
+    hasher.update(*contract);
+    hasher.update(*sub_id);
+    AssetId::new(*Bytes32::from(<[u8; 32]>::from(hasher.finalize())))
+}
+
+pub(crate) async fn get_wallet_balance(wallet: &WalletUnlocked, asset: &AssetId) -> u64 {
+    wallet.get_asset_balance(asset).await.unwrap()
+}


### PR DESCRIPTION
## Type of change

<!--Delete points that do not apply-->

- New feature

## Changes

The following changes have been made:

- Adds SDK tests to the Native Asset Library that were previously missing

## Notes

- Inline tests have been left and will continue to be tested

## Related Issues

<!--Delete everything after the "#" symbol and replace it with a number. No spaces between hash and number-->

Closes #230 
