### PR TITLE
Update tests to use `--release` on build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,10 +48,10 @@ jobs:
           run: cargo fmt --manifest-path tests/Cargo.toml --verbose --check
 
         - name: Build All Libs
-          run: forc build --path libs
+          run: forc build --path libs --release
 
         - name: Build All Tests
-          run: forc build --path tests
+          run: forc build --path tests --release
           
         - name: Cargo Test sway-lib
           run: |
@@ -78,10 +78,10 @@ jobs:
           components: forc@${{ env.FORC_VERSION }}, fuel-core@${{ env.CORE_VERSION }}
 
       - name: Run Libs Tests
-        run: forc build --path libs && forc test --path libs
+        run: forc build --path libs --release && forc test --path libs
 
       - name: Run Tests Tests
-        run: forc build --path tests && forc test --path tests
+        run: forc build --path tests --release && forc test --path tests
 
   contributing-book:
     runs-on: ubuntu-latest
@@ -111,7 +111,7 @@ jobs:
         run: forc fmt --path ${{ matrix.project }} --check
 
       - name: Build Sway
-        run: forc build --path ${{ matrix.project }}
+        run: forc build --path ${{ matrix.project }} --release
 
   build-forc-doc-sway-libs:
     runs-on: ubuntu-latest

--- a/tests/src/admin/tests/utils/mod.rs
+++ b/tests/src/admin/tests/utils/mod.rs
@@ -10,7 +10,7 @@ use fuels::{
 // Load abi from json
 abigen!(Contract(
     name = "AdminLib",
-    abi = "src/admin/out/debug/admin_test-abi.json"
+    abi = "src/admin/out/release/admin_test-abi.json"
 ));
 
 pub struct Metadata {
@@ -105,10 +105,10 @@ pub mod test_helpers {
         let wallet4 = wallets.pop().unwrap();
 
         let storage_configuration = StorageConfiguration::default()
-            .add_slot_overrides_from_file("src/admin/out/debug/admin_test-storage_slots.json");
+            .add_slot_overrides_from_file("src/admin/out/release/admin_test-storage_slots.json");
         let configuration =
             LoadConfiguration::default().with_storage_configuration(storage_configuration.unwrap());
-        let id = Contract::load_from("src/admin/out/debug/admin_test.bin", configuration)
+        let id = Contract::load_from("src/admin/out/release/admin_test.bin", configuration)
             .unwrap()
             .deploy(&wallet1, TxPolicies::default())
             .await

--- a/tests/src/bytecode/tests/utils/mod.rs
+++ b/tests/src/bytecode/tests/utils/mod.rs
@@ -44,7 +44,7 @@ const SIMPLE_PREDICATE_OFFSET: u64 = 100;
 const SIMPLE_CONTRACT_OFFSET: u64 = 68;
 const COMPLEX_CONTRACT_OFFSET_1: u64 = 18268;
 const COMPLEX_CONTRACT_OFFSET_2: u64 = 18276;
-const COMPLEX_CONTRACT_OFFSET_3 : u64= 18316;
+const COMPLEX_CONTRACT_OFFSET_3: u64 = 18316;
 
 pub mod abi_calls {
 
@@ -254,7 +254,11 @@ pub mod test_helpers {
     pub fn defaults() -> (u64, u64, u8) {
         let config_value = 119;
 
-        (SIMPLE_CONTRACT_OFFSET, SIMPLE_PREDICATE_OFFSET, config_value)
+        (
+            SIMPLE_CONTRACT_OFFSET,
+            SIMPLE_PREDICATE_OFFSET,
+            config_value,
+        )
     }
 
     pub fn complex_defaults() -> (SimpleStruct, SimpleEnum) {

--- a/tests/src/bytecode/tests/utils/mod.rs
+++ b/tests/src/bytecode/tests/utils/mod.rs
@@ -13,33 +13,38 @@ use std::{fs, str::FromStr};
 abigen!(
     Contract(
         name = "SimpleContract",
-        abi = "src/bytecode/test_artifacts/simple_contract/out/debug/simple_contract-abi.json"
+        abi = "src/bytecode/test_artifacts/simple_contract/out/release/simple_contract-abi.json"
     ),
     Contract(
         name = "ComplexContract",
-        abi = "src/bytecode/test_artifacts/complex_contract/out/debug/complex_contract-abi.json"
+        abi = "src/bytecode/test_artifacts/complex_contract/out/release/complex_contract-abi.json"
     ),
     Contract(
         name = "BytecodeTestContract",
-        abi = "src/bytecode/test_contract/out/debug/bytecode_test-abi.json"
+        abi = "src/bytecode/test_contract/out/release/bytecode_test-abi.json"
     ),
     Predicate(
         name = "SimplePredicate",
-        abi = "src/bytecode/test_artifacts/simple_predicate/out/debug/simple_predicate-abi.json"
+        abi = "src/bytecode/test_artifacts/simple_predicate/out/release/simple_predicate-abi.json"
     ),
 );
 
 const SIMPLE_CONTRACT_BYTECODE_PATH: &str =
-    "src/bytecode/test_artifacts/simple_contract/out/debug/simple_contract.bin";
+    "src/bytecode/test_artifacts/simple_contract/out/release/simple_contract.bin";
 const COMPLEX_CONTRACT_BYTECODE_PATH: &str =
-    "src/bytecode/test_artifacts/complex_contract/out/debug/complex_contract.bin";
+    "src/bytecode/test_artifacts/complex_contract/out/release/complex_contract.bin";
 const PREDICATE_BYTECODE_PATH: &str =
-    "src/bytecode/test_artifacts/simple_predicate/out/debug/simple_predicate.bin";
+    "src/bytecode/test_artifacts/simple_predicate/out/release/simple_predicate.bin";
 const DEFAULT_PREDICATE_BALANCE: u64 = 512;
 
 const HEX_STR_1: &str = "0xacbe4bfc77e55c071db31f2e37c824d75794867d88499107dc8318cb22aceea5";
 const HEX_STR_2: &str = "0x0b1af92ac5a3e8cfeafede9586a1f853a9e0258e7cdccae5e5181edac081f2c1b";
 const HEX_STR_3: &str = "0x0345c74edfb0ce0820409176d0cbc2c44eac1e5e4c7382ee7e7c38d611d9ba767";
+const SIMPLE_PREDICATE_OFFSET: u64 = 100;
+const SIMPLE_CONTRACT_OFFSET: u64 = 68;
+const COMPLEX_CONTRACT_OFFSET_1: u64 = 18268;
+const COMPLEX_CONTRACT_OFFSET_2: u64 = 18276;
+const COMPLEX_CONTRACT_OFFSET_3 : u64= 18316;
 
 pub mod abi_calls {
 
@@ -247,11 +252,9 @@ pub mod test_helpers {
     use super::*;
 
     pub fn defaults() -> (u64, u64, u8) {
-        let contract_offset = 68;
-        let predicate_offset = 156;
         let config_value = 119;
 
-        (contract_offset, predicate_offset, config_value)
+        (SIMPLE_CONTRACT_OFFSET, SIMPLE_PREDICATE_OFFSET, config_value)
     }
 
     pub fn complex_defaults() -> (SimpleStruct, SimpleEnum) {
@@ -288,7 +291,7 @@ pub mod test_helpers {
         let wallet = wallets.pop().unwrap();
 
         let id = Contract::load_from(
-            "src/bytecode/test_contract/out/debug/bytecode_test.bin",
+            "src/bytecode/test_contract/out/release/bytecode_test.bin",
             LoadConfiguration::default(),
         )
         .unwrap()
@@ -627,7 +630,7 @@ pub mod test_helpers {
 
         let mut data1: Vec<u8> = Vec::new();
         data1.extend_from_slice(&[0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, config_value]);
-        my_configurables.push((231496, data1));
+        my_configurables.push((COMPLEX_CONTRACT_OFFSET_1, data1));
 
         let mut data2: Vec<u8> = Vec::new();
         data2.extend_from_slice(&[
@@ -642,7 +645,7 @@ pub mod test_helpers {
         ]);
         let bits1 = *Bytes32::from_str(HEX_STR_1).expect("failed to create Bytes32 from string");
         data2.extend_from_slice(&bits1);
-        my_configurables.push((231504, data2));
+        my_configurables.push((COMPLEX_CONTRACT_OFFSET_2, data2));
 
         let mut data3: Vec<u8> = Vec::new();
         data3.extend_from_slice(&[0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 2u8]);
@@ -650,7 +653,7 @@ pub mod test_helpers {
         let bits3 = *Bytes32::from_str(HEX_STR_3).expect("failed to create Bytes32 from string");
         data3.extend_from_slice(&bits2);
         data3.extend_from_slice(&bits3);
-        my_configurables.push((231544, data3));
+        my_configurables.push((COMPLEX_CONTRACT_OFFSET_3, data3));
 
         my_configurables
     }

--- a/tests/src/fixed_point/ifp128_div_test/tests/mod.rs
+++ b/tests/src/fixed_point/ifp128_div_test/tests/mod.rs
@@ -2,7 +2,7 @@ use fuels::prelude::{abigen, launch_provider_and_get_wallet};
 
 abigen!(Script(
     name = "TestIfp128Div",
-    abi = "src/fixed_point/ifp128_div_test/out/debug/ifp128_div_test-abi.json"
+    abi = "src/fixed_point/ifp128_div_test/out/release/ifp128_div_test-abi.json"
 ),);
 
 mod success {
@@ -11,7 +11,7 @@ mod success {
 
     #[tokio::test]
     async fn runs_ifp128_div_test_script() {
-        let path_to_bin = "src/fixed_point/ifp128_div_test/out/debug/ifp128_div_test.bin";
+        let path_to_bin = "src/fixed_point/ifp128_div_test/out/release/ifp128_div_test.bin";
 
         let wallet = launch_provider_and_get_wallet().await.unwrap();
 

--- a/tests/src/fixed_point/ifp128_test/tests/mod.rs
+++ b/tests/src/fixed_point/ifp128_test/tests/mod.rs
@@ -2,7 +2,7 @@ use fuels::prelude::{abigen, launch_provider_and_get_wallet};
 
 abigen!(Script(
     name = "TestIfp128",
-    abi = "src/fixed_point/ifp128_test/out/debug/ifp128_test-abi.json"
+    abi = "src/fixed_point/ifp128_test/out/release/ifp128_test-abi.json"
 ),);
 
 mod success {
@@ -11,7 +11,7 @@ mod success {
 
     #[tokio::test]
     async fn runs_ifp128_test_script() {
-        let path_to_bin = "src/fixed_point/ifp128_test/out/debug/ifp128_test.bin";
+        let path_to_bin = "src/fixed_point/ifp128_test/out/release/ifp128_test.bin";
 
         let wallet = launch_provider_and_get_wallet().await.unwrap();
 

--- a/tests/src/fixed_point/ifp256_div_test/tests/mod.rs
+++ b/tests/src/fixed_point/ifp256_div_test/tests/mod.rs
@@ -2,7 +2,7 @@ use fuels::prelude::{abigen, launch_provider_and_get_wallet};
 
 abigen!(Script(
     name = "TestIfp256Div",
-    abi = "src/fixed_point/ifp256_div_test/out/debug/ifp256_div_test-abi.json"
+    abi = "src/fixed_point/ifp256_div_test/out/release/ifp256_div_test-abi.json"
 ),);
 
 mod success {
@@ -11,7 +11,7 @@ mod success {
 
     #[tokio::test]
     async fn runs_ifp256_div_test_script() {
-        let path_to_bin = "src/fixed_point/ifp256_div_test/out/debug/ifp256_div_test.bin";
+        let path_to_bin = "src/fixed_point/ifp256_div_test/out/release/ifp256_div_test.bin";
 
         let wallet = launch_provider_and_get_wallet().await.unwrap();
 

--- a/tests/src/fixed_point/ifp256_test/tests/mod.rs
+++ b/tests/src/fixed_point/ifp256_test/tests/mod.rs
@@ -2,7 +2,7 @@ use fuels::prelude::{abigen, launch_provider_and_get_wallet};
 
 abigen!(Script(
     name = "TestIfp256",
-    abi = "src/fixed_point/ifp256_test/out/debug/ifp256_test-abi.json"
+    abi = "src/fixed_point/ifp256_test/out/release/ifp256_test-abi.json"
 ),);
 
 mod success {
@@ -11,7 +11,7 @@ mod success {
 
     #[tokio::test]
     async fn runs_ifp256_test_script() {
-        let path_to_bin = "src/fixed_point/ifp256_test/out/debug/ifp256_test.bin";
+        let path_to_bin = "src/fixed_point/ifp256_test/out/release/ifp256_test.bin";
 
         let wallet = launch_provider_and_get_wallet().await.unwrap();
 

--- a/tests/src/fixed_point/ifp64_div_test/tests/mod.rs
+++ b/tests/src/fixed_point/ifp64_div_test/tests/mod.rs
@@ -2,7 +2,7 @@ use fuels::prelude::{abigen, launch_provider_and_get_wallet};
 
 abigen!(Script(
     name = "TestIfp64Div",
-    abi = "src/fixed_point/ifp64_div_test/out/debug/ifp64_div_test-abi.json"
+    abi = "src/fixed_point/ifp64_div_test/out/release/ifp64_div_test-abi.json"
 ),);
 
 mod success {
@@ -11,7 +11,7 @@ mod success {
 
     #[tokio::test]
     async fn runs_ifp64_div_test_script() {
-        let path_to_bin = "src/fixed_point/ifp64_div_test/out/debug/ifp64_div_test.bin";
+        let path_to_bin = "src/fixed_point/ifp64_div_test/out/release/ifp64_div_test.bin";
 
         let wallet = launch_provider_and_get_wallet().await.unwrap();
 

--- a/tests/src/fixed_point/ifp64_exp_test/tests/mod.rs
+++ b/tests/src/fixed_point/ifp64_exp_test/tests/mod.rs
@@ -2,7 +2,7 @@ use fuels::prelude::{abigen, launch_provider_and_get_wallet};
 
 abigen!(Script(
     name = "TestIfp64Exp",
-    abi = "src/fixed_point/ifp64_exp_test/out/debug/ifp64_exp_test-abi.json"
+    abi = "src/fixed_point/ifp64_exp_test/out/release/ifp64_exp_test-abi.json"
 ),);
 
 mod success {
@@ -11,7 +11,7 @@ mod success {
 
     #[tokio::test]
     async fn runs_ifp64_exp_test_script() {
-        let path_to_bin = "src/fixed_point/ifp64_exp_test/out/debug/ifp64_exp_test.bin";
+        let path_to_bin = "src/fixed_point/ifp64_exp_test/out/release/ifp64_exp_test.bin";
         let wallet = launch_provider_and_get_wallet().await.unwrap();
 
         let instance = TestIfp64Exp::new(wallet, path_to_bin);

--- a/tests/src/fixed_point/ifp64_mul_test/tests/mod.rs
+++ b/tests/src/fixed_point/ifp64_mul_test/tests/mod.rs
@@ -2,7 +2,7 @@ use fuels::prelude::{abigen, launch_provider_and_get_wallet};
 
 abigen!(Script(
     name = "TestIfp64Mul",
-    abi = "src/fixed_point/ifp64_mul_test/out/debug/ifp64_mul_test-abi.json"
+    abi = "src/fixed_point/ifp64_mul_test/out/release/ifp64_mul_test-abi.json"
 ),);
 
 mod success {
@@ -11,7 +11,7 @@ mod success {
 
     #[tokio::test]
     async fn runs_ifp64_mul_test_script() {
-        let path_to_bin = "src/fixed_point/ifp64_mul_test/out/debug/ifp64_mul_test.bin";
+        let path_to_bin = "src/fixed_point/ifp64_mul_test/out/release/ifp64_mul_test.bin";
 
         let wallet = launch_provider_and_get_wallet().await.unwrap();
 

--- a/tests/src/fixed_point/ifp64_pow_test/tests/mod.rs
+++ b/tests/src/fixed_point/ifp64_pow_test/tests/mod.rs
@@ -2,7 +2,7 @@ use fuels::prelude::{abigen, launch_provider_and_get_wallet};
 
 abigen!(Script(
     name = "TestIfp64Pow",
-    abi = "src/fixed_point/ifp64_pow_test/out/debug/ifp64_pow_test-abi.json"
+    abi = "src/fixed_point/ifp64_pow_test/out/release/ifp64_pow_test-abi.json"
 ),);
 
 mod success {
@@ -11,7 +11,7 @@ mod success {
 
     #[tokio::test]
     async fn runs_ifp64_pow_test_script() {
-        let path_to_bin = "src/fixed_point/ifp64_pow_test/out/debug/ifp64_pow_test.bin";
+        let path_to_bin = "src/fixed_point/ifp64_pow_test/out/release/ifp64_pow_test.bin";
         let wallet = launch_provider_and_get_wallet().await.unwrap();
 
         let instance = TestIfp64Pow::new(wallet, path_to_bin);

--- a/tests/src/fixed_point/ifp64_test/tests/mod.rs
+++ b/tests/src/fixed_point/ifp64_test/tests/mod.rs
@@ -2,7 +2,7 @@ use fuels::prelude::{abigen, launch_provider_and_get_wallet};
 
 abigen!(Script(
     name = "TestIfp64",
-    abi = "src/fixed_point/ifp64_test/out/debug/ifp64_test-abi.json"
+    abi = "src/fixed_point/ifp64_test/out/release/ifp64_test-abi.json"
 ),);
 
 mod success {
@@ -11,7 +11,7 @@ mod success {
 
     #[tokio::test]
     async fn runs_ifp64_test_script() {
-        let path_to_bin = "src/fixed_point/ifp64_test/out/debug/ifp64_test.bin";
+        let path_to_bin = "src/fixed_point/ifp64_test/out/release/ifp64_test.bin";
 
         let wallet = launch_provider_and_get_wallet().await.unwrap();
 

--- a/tests/src/fixed_point/ufp128_div_test/tests/mod.rs
+++ b/tests/src/fixed_point/ufp128_div_test/tests/mod.rs
@@ -2,7 +2,7 @@ use fuels::prelude::{abigen, launch_provider_and_get_wallet};
 
 abigen!(Script(
     name = "TestUfp128Div",
-    abi = "src/fixed_point/ufp128_div_test/out/debug/ufp128_div_test-abi.json"
+    abi = "src/fixed_point/ufp128_div_test/out/release/ufp128_div_test-abi.json"
 ),);
 
 mod success {
@@ -11,7 +11,7 @@ mod success {
 
     #[tokio::test]
     async fn runs_ufp128_div_test_script() {
-        let path_to_bin = "src/fixed_point/ufp128_div_test/out/debug/ufp128_div_test.bin";
+        let path_to_bin = "src/fixed_point/ufp128_div_test/out/release/ufp128_div_test.bin";
 
         let wallet = launch_provider_and_get_wallet().await.unwrap();
 

--- a/tests/src/fixed_point/ufp128_test/tests/mod.rs
+++ b/tests/src/fixed_point/ufp128_test/tests/mod.rs
@@ -2,7 +2,7 @@ use fuels::prelude::{abigen, launch_provider_and_get_wallet};
 
 abigen!(Script(
     name = "TestUfp128",
-    abi = "src/fixed_point/ufp128_test/out/debug/ufp128_test-abi.json"
+    abi = "src/fixed_point/ufp128_test/out/release/ufp128_test-abi.json"
 ),);
 
 mod success {
@@ -11,7 +11,7 @@ mod success {
 
     #[tokio::test]
     async fn runs_ufp128_test_script() {
-        let path_to_bin = "src/fixed_point/ufp128_test/out/debug/ufp128_test.bin";
+        let path_to_bin = "src/fixed_point/ufp128_test/out/release/ufp128_test.bin";
 
         let wallet = launch_provider_and_get_wallet().await.unwrap();
 

--- a/tests/src/fixed_point/ufp32_div_test/tests/mod.rs
+++ b/tests/src/fixed_point/ufp32_div_test/tests/mod.rs
@@ -2,7 +2,7 @@ use fuels::prelude::{abigen, launch_provider_and_get_wallet};
 
 abigen!(Script(
     name = "TestUfp32Div",
-    abi = "src/fixed_point/ufp32_div_test/out/debug/ufp32_div_test-abi.json"
+    abi = "src/fixed_point/ufp32_div_test/out/release/ufp32_div_test-abi.json"
 ),);
 
 mod success {
@@ -11,7 +11,7 @@ mod success {
 
     #[tokio::test]
     async fn runs_ufp32_div_test_script() {
-        let path_to_bin = "src/fixed_point/ufp32_div_test/out/debug/ufp32_div_test.bin";
+        let path_to_bin = "src/fixed_point/ufp32_div_test/out/release/ufp32_div_test.bin";
 
         let wallet = launch_provider_and_get_wallet().await.unwrap();
 

--- a/tests/src/fixed_point/ufp32_exp_test/tests/mod.rs
+++ b/tests/src/fixed_point/ufp32_exp_test/tests/mod.rs
@@ -2,7 +2,7 @@ use fuels::prelude::{abigen, launch_provider_and_get_wallet};
 
 abigen!(Script(
     name = "TestUfp32Exp",
-    abi = "src/fixed_point/ufp32_exp_test/out/debug/ufp32_exp_test-abi.json"
+    abi = "src/fixed_point/ufp32_exp_test/out/release/ufp32_exp_test-abi.json"
 ),);
 
 mod success {
@@ -11,7 +11,7 @@ mod success {
 
     #[tokio::test]
     async fn runs_ufp32_exp_test_script() {
-        let path_to_bin = "src/fixed_point/ufp32_exp_test/out/debug/ufp32_exp_test.bin";
+        let path_to_bin = "src/fixed_point/ufp32_exp_test/out/release/ufp32_exp_test.bin";
         let wallet = launch_provider_and_get_wallet().await.unwrap();
 
         let instance = TestUfp32Exp::new(wallet, path_to_bin);

--- a/tests/src/fixed_point/ufp32_mul_test/tests/mod.rs
+++ b/tests/src/fixed_point/ufp32_mul_test/tests/mod.rs
@@ -2,7 +2,7 @@ use fuels::prelude::{abigen, launch_provider_and_get_wallet};
 
 abigen!(Script(
     name = "TestUfp32Mul",
-    abi = "src/fixed_point/ufp32_mul_test/out/debug/ufp32_mul_test-abi.json"
+    abi = "src/fixed_point/ufp32_mul_test/out/release/ufp32_mul_test-abi.json"
 ),);
 
 mod success {
@@ -11,7 +11,7 @@ mod success {
 
     #[tokio::test]
     async fn runs_ufp32_mul_test_script() {
-        let path_to_bin = "src/fixed_point/ufp32_mul_test/out/debug/ufp32_mul_test.bin";
+        let path_to_bin = "src/fixed_point/ufp32_mul_test/out/release/ufp32_mul_test.bin";
 
         let wallet = launch_provider_and_get_wallet().await.unwrap();
 

--- a/tests/src/fixed_point/ufp32_pow_test/tests/mod.rs
+++ b/tests/src/fixed_point/ufp32_pow_test/tests/mod.rs
@@ -2,7 +2,7 @@ use fuels::prelude::{abigen, launch_provider_and_get_wallet};
 
 abigen!(Script(
     name = "TestUfp32Pow",
-    abi = "src/fixed_point/ufp32_pow_test/out/debug/ufp32_pow_test-abi.json"
+    abi = "src/fixed_point/ufp32_pow_test/out/release/ufp32_pow_test-abi.json"
 ),);
 
 mod success {
@@ -11,7 +11,7 @@ mod success {
 
     #[tokio::test]
     async fn runs_ufp32_pow_test_script() {
-        let path_to_bin = "src/fixed_point/ufp32_pow_test/out/debug/ufp32_pow_test.bin";
+        let path_to_bin = "src/fixed_point/ufp32_pow_test/out/release/ufp32_pow_test.bin";
         let wallet = launch_provider_and_get_wallet().await.unwrap();
 
         let instance = TestUfp32Pow::new(wallet, path_to_bin);

--- a/tests/src/fixed_point/ufp32_root_test/tests/mod.rs
+++ b/tests/src/fixed_point/ufp32_root_test/tests/mod.rs
@@ -2,7 +2,7 @@ use fuels::prelude::{abigen, launch_provider_and_get_wallet};
 
 abigen!(Script(
     name = "TestUfp32Root",
-    abi = "src/fixed_point/ufp32_root_test/out/debug/ufp32_root_test-abi.json"
+    abi = "src/fixed_point/ufp32_root_test/out/release/ufp32_root_test-abi.json"
 ),);
 
 mod success {
@@ -11,7 +11,7 @@ mod success {
 
     #[tokio::test]
     async fn runs_ufp32_root_test_script() {
-        let path_to_bin = "src/fixed_point/ufp32_root_test/out/debug/ufp32_root_test.bin";
+        let path_to_bin = "src/fixed_point/ufp32_root_test/out/release/ufp32_root_test.bin";
 
         let wallet = launch_provider_and_get_wallet().await.unwrap();
 

--- a/tests/src/fixed_point/ufp32_test/tests/mod.rs
+++ b/tests/src/fixed_point/ufp32_test/tests/mod.rs
@@ -2,7 +2,7 @@ use fuels::prelude::{abigen, launch_provider_and_get_wallet};
 
 abigen!(Script(
     name = "TestUfp32",
-    abi = "src/fixed_point/ufp32_test/out/debug/ufp32_test-abi.json"
+    abi = "src/fixed_point/ufp32_test/out/release/ufp32_test-abi.json"
 ),);
 
 mod success {
@@ -11,7 +11,7 @@ mod success {
 
     #[tokio::test]
     async fn runs_ufp32_test_script() {
-        let path_to_bin = "src/fixed_point/ufp32_test/out/debug/ufp32_test.bin";
+        let path_to_bin = "src/fixed_point/ufp32_test/out/release/ufp32_test.bin";
 
         let wallet = launch_provider_and_get_wallet().await.unwrap();
 

--- a/tests/src/fixed_point/ufp64_div_test/tests/mod.rs
+++ b/tests/src/fixed_point/ufp64_div_test/tests/mod.rs
@@ -2,7 +2,7 @@ use fuels::prelude::{abigen, launch_provider_and_get_wallet};
 
 abigen!(Script(
     name = "TestUfp64Div",
-    abi = "src/fixed_point/ufp64_div_test/out/debug/ufp64_div_test-abi.json"
+    abi = "src/fixed_point/ufp64_div_test/out/release/ufp64_div_test-abi.json"
 ),);
 
 mod success {
@@ -11,7 +11,7 @@ mod success {
 
     #[tokio::test]
     async fn runs_ufp64_div_test_script() {
-        let path_to_bin = "src/fixed_point/ufp64_div_test/out/debug/ufp64_div_test.bin";
+        let path_to_bin = "src/fixed_point/ufp64_div_test/out/release/ufp64_div_test.bin";
 
         let wallet = launch_provider_and_get_wallet().await.unwrap();
 

--- a/tests/src/fixed_point/ufp64_exp_test/tests/mod.rs
+++ b/tests/src/fixed_point/ufp64_exp_test/tests/mod.rs
@@ -2,7 +2,7 @@ use fuels::prelude::{abigen, launch_provider_and_get_wallet};
 
 abigen!(Script(
     name = "TestUfp64Exp",
-    abi = "src/fixed_point/ufp64_exp_test/out/debug/ufp64_exp_test-abi.json"
+    abi = "src/fixed_point/ufp64_exp_test/out/release/ufp64_exp_test-abi.json"
 ),);
 
 mod success {
@@ -11,7 +11,7 @@ mod success {
 
     #[tokio::test]
     async fn runs_ufp64_exp_test_script() {
-        let path_to_bin = "src/fixed_point/ufp64_exp_test/out/debug/ufp64_exp_test.bin";
+        let path_to_bin = "src/fixed_point/ufp64_exp_test/out/release/ufp64_exp_test.bin";
         let wallet = launch_provider_and_get_wallet().await.unwrap();
 
         let instance = TestUfp64Exp::new(wallet, path_to_bin);

--- a/tests/src/fixed_point/ufp64_mul_test/tests/mod.rs
+++ b/tests/src/fixed_point/ufp64_mul_test/tests/mod.rs
@@ -2,7 +2,7 @@ use fuels::prelude::{abigen, launch_provider_and_get_wallet};
 
 abigen!(Script(
     name = "TestUfp64Mul",
-    abi = "src/fixed_point/ufp64_mul_test/out/debug/ufp64_mul_test-abi.json"
+    abi = "src/fixed_point/ufp64_mul_test/out/release/ufp64_mul_test-abi.json"
 ),);
 
 mod success {
@@ -11,7 +11,7 @@ mod success {
 
     #[tokio::test]
     async fn runs_ufp64_mul_test_script() {
-        let path_to_bin = "src/fixed_point/ufp64_mul_test/out/debug/ufp64_mul_test.bin";
+        let path_to_bin = "src/fixed_point/ufp64_mul_test/out/release/ufp64_mul_test.bin";
 
         let wallet = launch_provider_and_get_wallet().await.unwrap();
 

--- a/tests/src/fixed_point/ufp64_pow_test/tests/mod.rs
+++ b/tests/src/fixed_point/ufp64_pow_test/tests/mod.rs
@@ -2,7 +2,7 @@ use fuels::prelude::{abigen, launch_provider_and_get_wallet};
 
 abigen!(Script(
     name = "TestUfp64Pow",
-    abi = "src/fixed_point/ufp64_pow_test/out/debug/ufp64_pow_test-abi.json"
+    abi = "src/fixed_point/ufp64_pow_test/out/release/ufp64_pow_test-abi.json"
 ),);
 
 mod success {
@@ -11,7 +11,7 @@ mod success {
 
     #[tokio::test]
     async fn runs_ufp64_pow_test_script() {
-        let path_to_bin = "src/fixed_point/ufp64_pow_test/out/debug/ufp64_pow_test.bin";
+        let path_to_bin = "src/fixed_point/ufp64_pow_test/out/release/ufp64_pow_test.bin";
         let wallet = launch_provider_and_get_wallet().await.unwrap();
 
         let instance = TestUfp64Pow::new(wallet, path_to_bin);

--- a/tests/src/fixed_point/ufp64_root_test/tests/mod.rs
+++ b/tests/src/fixed_point/ufp64_root_test/tests/mod.rs
@@ -2,7 +2,7 @@ use fuels::prelude::{abigen, launch_provider_and_get_wallet};
 
 abigen!(Script(
     name = "TestUfp64Root",
-    abi = "src/fixed_point/ufp64_root_test/out/debug/ufp64_root_test-abi.json"
+    abi = "src/fixed_point/ufp64_root_test/out/release/ufp64_root_test-abi.json"
 ),);
 
 mod success {
@@ -11,7 +11,7 @@ mod success {
 
     #[tokio::test]
     async fn runs_ufp64_root_test_script() {
-        let path_to_bin = "src/fixed_point/ufp64_root_test/out/debug/ufp64_root_test.bin";
+        let path_to_bin = "src/fixed_point/ufp64_root_test/out/release/ufp64_root_test.bin";
 
         let wallet = launch_provider_and_get_wallet().await.unwrap();
 

--- a/tests/src/fixed_point/ufp64_test/tests/mod.rs
+++ b/tests/src/fixed_point/ufp64_test/tests/mod.rs
@@ -2,7 +2,7 @@ use fuels::prelude::{abigen, launch_provider_and_get_wallet};
 
 abigen!(Script(
     name = "TestUfp64",
-    abi = "src/fixed_point/ufp64_test/out/debug/ufp64_test-abi.json"
+    abi = "src/fixed_point/ufp64_test/out/release/ufp64_test-abi.json"
 ),);
 
 mod success {
@@ -11,7 +11,7 @@ mod success {
 
     #[tokio::test]
     async fn runs_ufp64_test_script() {
-        let path_to_bin = "src/fixed_point/ufp64_test/out/debug/ufp64_test.bin";
+        let path_to_bin = "src/fixed_point/ufp64_test/out/release/ufp64_test.bin";
 
         let wallet = launch_provider_and_get_wallet().await.unwrap();
 

--- a/tests/src/merkle_proof/tests/utils/mod.rs
+++ b/tests/src/merkle_proof/tests/utils/mod.rs
@@ -13,7 +13,7 @@ use sha2::{Digest, Sha256};
 
 abigen!(Contract(
     name = "TestMerkleProofLib",
-    abi = "src/merkle_proof/out/debug/merkle_proof_test-abi.json"
+    abi = "src/merkle_proof/out/release/merkle_proof_test-abi.json"
 ));
 
 pub const NODE: u8 = 0x01;
@@ -246,7 +246,7 @@ pub mod test_helpers {
         let wallet = launch_provider_and_get_wallet().await.unwrap();
 
         let contract_id = Contract::load_from(
-            "./src/merkle_proof/out/debug/merkle_proof_test.bin",
+            "./src/merkle_proof/out/release/merkle_proof_test.bin",
             LoadConfiguration::default(),
         )
         .unwrap()

--- a/tests/src/native_asset/tests/utils/setup.rs
+++ b/tests/src/native_asset/tests/utils/setup.rs
@@ -11,11 +11,11 @@ use sha2::{Digest, Sha256};
 
 abigen!(Contract(
     name = "AssetLib",
-    abi = "src/native_asset/out/debug/native_asset_lib-abi.json"
+    abi = "src/native_asset/out/release/native_asset_lib-abi.json"
 ),);
 
 const NATIVE_ASSET_TEST_CONTRACT_BINARY_PATH: &str =
-    "./src/native_asset/out/debug/native_asset_lib.bin";
+    "./src/native_asset/out/release/native_asset_lib.bin";
 
 pub(crate) fn defaults(
     contract_id: ContractId,

--- a/tests/src/ownership/tests/utils/mod.rs
+++ b/tests/src/ownership/tests/utils/mod.rs
@@ -92,11 +92,14 @@ pub mod test_helpers {
         );
         let configuration =
             LoadConfiguration::default().with_storage_configuration(storage_configuration.unwrap());
-        let id = Contract::load_from("src/ownership/out/release/ownership_test.bin", configuration)
-            .unwrap()
-            .deploy(&wallet1, TxPolicies::default())
-            .await
-            .unwrap();
+        let id = Contract::load_from(
+            "src/ownership/out/release/ownership_test.bin",
+            configuration,
+        )
+        .unwrap()
+        .deploy(&wallet1, TxPolicies::default())
+        .await
+        .unwrap();
 
         let deploy_wallet = Metadata {
             contract: OwnershipLib::new(id.clone(), wallet1.clone()),

--- a/tests/src/ownership/tests/utils/mod.rs
+++ b/tests/src/ownership/tests/utils/mod.rs
@@ -10,7 +10,7 @@ use fuels::{
 // Load abi from json
 abigen!(Contract(
     name = "OwnershipLib",
-    abi = "src/ownership/out/debug/ownership_test-abi.json"
+    abi = "src/ownership/out/release/ownership_test-abi.json"
 ));
 
 pub struct Metadata {
@@ -88,11 +88,11 @@ pub mod test_helpers {
         let wallet3 = wallets.pop().unwrap();
 
         let storage_configuration = StorageConfiguration::default().add_slot_overrides_from_file(
-            "src/ownership/out/debug/ownership_test-storage_slots.json",
+            "src/ownership/out/release/ownership_test-storage_slots.json",
         );
         let configuration =
             LoadConfiguration::default().with_storage_configuration(storage_configuration.unwrap());
-        let id = Contract::load_from("src/ownership/out/debug/ownership_test.bin", configuration)
+        let id = Contract::load_from("src/ownership/out/release/ownership_test.bin", configuration)
             .unwrap()
             .deploy(&wallet1, TxPolicies::default())
             .await

--- a/tests/src/reentrancy/mod.rs
+++ b/tests/src/reentrancy/mod.rs
@@ -7,20 +7,20 @@ use fuels::{
 };
 
 abigen!(
-    Contract(name="AttackerContract", abi="src/reentrancy/reentrancy_attacker_contract/out/debug/reentrancy_attacker_contract-abi.json"),
-    Contract(name="TargetContract", abi="src/reentrancy/reentrancy_target_contract/out/debug/reentrancy_target_contract-abi.json"),
-    Contract(name="AttackHelperContract", abi="src/reentrancy/reentrancy_attack_helper_contract/out/debug/reentrancy_attack_helper_contract-abi.json"),
+    Contract(name="AttackerContract", abi="src/reentrancy/reentrancy_attacker_contract/out/release/reentrancy_attacker_contract-abi.json"),
+    Contract(name="TargetContract", abi="src/reentrancy/reentrancy_target_contract/out/release/reentrancy_target_contract-abi.json"),
+    Contract(name="AttackHelperContract", abi="src/reentrancy/reentrancy_attack_helper_contract/out/release/reentrancy_attack_helper_contract-abi.json"),
 );
 
 const REENTRANCY_ATTACKER_BIN: &str =
-    "src/reentrancy/reentrancy_attacker_contract/out/debug/reentrancy_attacker_contract.bin";
+    "src/reentrancy/reentrancy_attacker_contract/out/release/reentrancy_attacker_contract.bin";
 const REENTRANCY_ATTACK_HELPER_BIN: &str =
-    "src/reentrancy/reentrancy_attack_helper_contract/out/debug/reentrancy_attack_helper_contract.bin";
-const REENTRANCY_ATTACKER_STORAGE: &str = "src/reentrancy/reentrancy_attacker_contract/out/debug/reentrancy_attacker_contract-storage_slots.json";
+    "src/reentrancy/reentrancy_attack_helper_contract/out/release/reentrancy_attack_helper_contract.bin";
+const REENTRANCY_ATTACKER_STORAGE: &str = "src/reentrancy/reentrancy_attacker_contract/out/release/reentrancy_attacker_contract-storage_slots.json";
 
 const REENTRANCY_TARGET_BIN: &str =
-    "src/reentrancy/reentrancy_target_contract/out/debug/reentrancy_target_contract.bin";
-const REENTRANCY_TARGET_STORAGE: &str = "src/reentrancy/reentrancy_target_contract/out/debug/reentrancy_target_contract-storage_slots.json";
+    "src/reentrancy/reentrancy_target_contract/out/release/reentrancy_target_contract.bin";
+const REENTRANCY_TARGET_STORAGE: &str = "src/reentrancy/reentrancy_target_contract/out/release/reentrancy_target_contract-storage_slots.json";
 
 pub async fn get_attacker_instance(
     wallet: WalletUnlocked,

--- a/tests/src/signed_integers/signed_i128/tests/mod.rs
+++ b/tests/src/signed_integers/signed_i128/tests/mod.rs
@@ -2,7 +2,7 @@ use fuels::prelude::{abigen, launch_provider_and_get_wallet};
 
 abigen!(Script(
     name = "Testi128",
-    abi = "src/signed_integers/signed_i128/out/debug/i128_test-abi.json"
+    abi = "src/signed_integers/signed_i128/out/release/i128_test-abi.json"
 ),);
 
 mod success {
@@ -11,7 +11,7 @@ mod success {
 
     #[tokio::test]
     async fn runs_i128_test_script() {
-        let path_to_bin = "src/signed_integers/signed_i128/out/debug/i128_test.bin";
+        let path_to_bin = "src/signed_integers/signed_i128/out/release/i128_test.bin";
         let wallet = launch_provider_and_get_wallet().await.unwrap();
 
         let instance = Testi128::new(wallet, path_to_bin);

--- a/tests/src/signed_integers/signed_i128_twos_complement/tests/mod.rs
+++ b/tests/src/signed_integers/signed_i128_twos_complement/tests/mod.rs
@@ -2,7 +2,7 @@ use fuels::prelude::{abigen, launch_provider_and_get_wallet};
 
 abigen!(Script(
     name = "Testi128TwosComplement",
-    abi = "src/signed_integers/signed_i128_twos_complement/out/debug/i128_twos_complement_test-abi.json"
+    abi = "src/signed_integers/signed_i128_twos_complement/out/release/i128_twos_complement_test-abi.json"
 ),);
 
 mod success {
@@ -12,7 +12,7 @@ mod success {
     #[tokio::test]
     async fn runs_i128_twos_complement_test_script() {
         let path_to_bin =
-            "src/signed_integers/signed_i128_twos_complement/out/debug/i128_twos_complement_test.bin";
+            "src/signed_integers/signed_i128_twos_complement/out/release/i128_twos_complement_test.bin";
         let wallet = launch_provider_and_get_wallet().await;
 
         let instance = Testi128TwosComplement::new(wallet, path_to_bin);

--- a/tests/src/signed_integers/signed_i16/tests/mod.rs
+++ b/tests/src/signed_integers/signed_i16/tests/mod.rs
@@ -2,7 +2,7 @@ use fuels::prelude::{abigen, launch_provider_and_get_wallet};
 
 abigen!(Script(
     name = "Testi16",
-    abi = "src/signed_integers/signed_i16/out/debug/i16_test-abi.json"
+    abi = "src/signed_integers/signed_i16/out/release/i16_test-abi.json"
 ),);
 
 mod success {
@@ -11,7 +11,7 @@ mod success {
 
     #[tokio::test]
     async fn runs_i16_test_script() {
-        let path_to_bin = "src/signed_integers/signed_i16/out/debug/i16_test.bin";
+        let path_to_bin = "src/signed_integers/signed_i16/out/release/i16_test.bin";
         let wallet = launch_provider_and_get_wallet().await.unwrap();
 
         let instance = Testi16::new(wallet, path_to_bin);

--- a/tests/src/signed_integers/signed_i16_twos_complement/tests/mod.rs
+++ b/tests/src/signed_integers/signed_i16_twos_complement/tests/mod.rs
@@ -2,7 +2,7 @@ use fuels::prelude::{abigen, launch_provider_and_get_wallet};
 
 abigen!(Script(
     name = "Testi16TwosComplement",
-    abi = "src/signed_integers/signed_i16_twos_complement/out/debug/i16_twos_complement_test-abi.json"
+    abi = "src/signed_integers/signed_i16_twos_complement/out/release/i16_twos_complement_test-abi.json"
 ),);
 
 mod success {
@@ -12,7 +12,7 @@ mod success {
     #[tokio::test]
     async fn runs_i16_twos_complement_test_script() {
         let path_to_bin =
-            "src/signed_integers/signed_i16_twos_complement/out/debug/i16_twos_complement_test.bin";
+            "src/signed_integers/signed_i16_twos_complement/out/release/i16_twos_complement_test.bin";
         let wallet = launch_provider_and_get_wallet().await.unwrap();
 
         let instance = Testi16TwosComplement::new(wallet, path_to_bin);

--- a/tests/src/signed_integers/signed_i256/tests/mod.rs
+++ b/tests/src/signed_integers/signed_i256/tests/mod.rs
@@ -2,7 +2,7 @@ use fuels::prelude::{abigen, launch_provider_and_get_wallet};
 
 abigen!(Script(
     name = "Testi256",
-    abi = "src/signed_integers/signed_i256/out/debug/i256_test-abi.json"
+    abi = "src/signed_integers/signed_i256/out/release/i256_test-abi.json"
 ),);
 
 mod success {
@@ -11,7 +11,7 @@ mod success {
 
     #[tokio::test]
     async fn runs_i256_test_script() {
-        let path_to_bin = "src/signed_integers/signed_i256/out/debug/i256_test.bin";
+        let path_to_bin = "src/signed_integers/signed_i256/out/release/i256_test.bin";
         let wallet = launch_provider_and_get_wallet().await.unwrap();
 
         let instance = Testi256::new(wallet, path_to_bin);

--- a/tests/src/signed_integers/signed_i256_twos_complement/tests/mod.rs
+++ b/tests/src/signed_integers/signed_i256_twos_complement/tests/mod.rs
@@ -2,7 +2,7 @@ use fuels::prelude::{abigen, launch_provider_and_get_wallet};
 
 abigen!(Script(
     name = "Testi256TwosComplement",
-    abi = "src/signed_integers/signed_i256_twos_complement/out/debug/i256_twos_complement_test-abi.json"
+    abi = "src/signed_integers/signed_i256_twos_complement/out/release/i256_twos_complement_test-abi.json"
 ),);
 
 mod success {
@@ -12,7 +12,7 @@ mod success {
     #[tokio::test]
     async fn runs_i256_twos_complement_test_script() {
         let path_to_bin =
-            "src/signed_integers/signed_i256_twos_complement/out/debug/i256_twos_complement_test.bin";
+            "src/signed_integers/signed_i256_twos_complement/out/release/i256_twos_complement_test.bin";
         let wallet = launch_provider_and_get_wallet().await;
 
         let instance = Testi256TwosComplement::new(wallet, path_to_bin);

--- a/tests/src/signed_integers/signed_i32/tests/mod.rs
+++ b/tests/src/signed_integers/signed_i32/tests/mod.rs
@@ -2,7 +2,7 @@ use fuels::prelude::{abigen, launch_provider_and_get_wallet};
 
 abigen!(Script(
     name = "Testi32",
-    abi = "src/signed_integers/signed_i32/out/debug/i32_test-abi.json"
+    abi = "src/signed_integers/signed_i32/out/release/i32_test-abi.json"
 ),);
 
 mod success {
@@ -11,7 +11,7 @@ mod success {
 
     #[tokio::test]
     async fn runs_i32_test_script() {
-        let path_to_bin = "src/signed_integers/signed_i32/out/debug/i32_test.bin";
+        let path_to_bin = "src/signed_integers/signed_i32/out/release/i32_test.bin";
         let wallet = launch_provider_and_get_wallet().await.unwrap();
 
         let instance = Testi32::new(wallet, path_to_bin);

--- a/tests/src/signed_integers/signed_i32_twos_complement/tests/mod.rs
+++ b/tests/src/signed_integers/signed_i32_twos_complement/tests/mod.rs
@@ -2,7 +2,7 @@ use fuels::prelude::{abigen, launch_provider_and_get_wallet};
 
 abigen!(Script(
     name = "Testi32TwosComplement",
-    abi = "src/signed_integers/signed_i32_twos_complement/out/debug/i32_twos_complement_test-abi.json"
+    abi = "src/signed_integers/signed_i32_twos_complement/out/release/i32_twos_complement_test-abi.json"
 ),);
 
 mod success {
@@ -12,7 +12,7 @@ mod success {
     #[tokio::test]
     async fn runs_i32_twos_complement_test_script() {
         let path_to_bin =
-            "src/signed_integers/signed_i32_twos_complement/out/debug/i32_twos_complement_test.bin";
+            "src/signed_integers/signed_i32_twos_complement/out/release/i32_twos_complement_test.bin";
         let wallet = launch_provider_and_get_wallet().await.unwrap();
 
         let instance = Testi32TwosComplement::new(wallet, path_to_bin);

--- a/tests/src/signed_integers/signed_i64/tests/mod.rs
+++ b/tests/src/signed_integers/signed_i64/tests/mod.rs
@@ -2,7 +2,7 @@ use fuels::prelude::{abigen, launch_provider_and_get_wallet};
 
 abigen!(Script(
     name = "Testi64",
-    abi = "src/signed_integers/signed_i64/out/debug/i64_test-abi.json"
+    abi = "src/signed_integers/signed_i64/out/release/i64_test-abi.json"
 ),);
 
 mod success {
@@ -11,7 +11,7 @@ mod success {
 
     #[tokio::test]
     async fn runs_i64_test_script() {
-        let path_to_bin = "src/signed_integers/signed_i64/out/debug/i64_test.bin";
+        let path_to_bin = "src/signed_integers/signed_i64/out/release/i64_test.bin";
         let wallet = launch_provider_and_get_wallet().await.unwrap();
 
         let instance = Testi64::new(wallet, path_to_bin);

--- a/tests/src/signed_integers/signed_i64_twos_complement/tests/mod.rs
+++ b/tests/src/signed_integers/signed_i64_twos_complement/tests/mod.rs
@@ -2,7 +2,7 @@ use fuels::prelude::{abigen, launch_provider_and_get_wallet};
 
 abigen!(Script(
     name = "Testi64TwosComplement",
-    abi = "src/signed_integers/signed_i64_twos_complement/out/debug/i64_twos_complement_test-abi.json"
+    abi = "src/signed_integers/signed_i64_twos_complement/out/release/i64_twos_complement_test-abi.json"
 ),);
 
 mod success {
@@ -12,7 +12,7 @@ mod success {
     #[tokio::test]
     async fn runs_i64_twos_complement_test_script() {
         let path_to_bin =
-            "src/signed_integers/signed_i64_twos_complement/out/debug/i64_twos_complement_test.bin";
+            "src/signed_integers/signed_i64_twos_complement/out/release/i64_twos_complement_test.bin";
         let wallet = launch_provider_and_get_wallet().await.unwrap();
 
         let instance = Testi64TwosComplement::new(wallet, path_to_bin);

--- a/tests/src/signed_integers/signed_i8/tests/mod.rs
+++ b/tests/src/signed_integers/signed_i8/tests/mod.rs
@@ -2,7 +2,7 @@ use fuels::prelude::{abigen, launch_provider_and_get_wallet};
 
 abigen!(Script(
     name = "Testi8",
-    abi = "src/signed_integers/signed_i8/out/debug/i8_test-abi.json"
+    abi = "src/signed_integers/signed_i8/out/release/i8_test-abi.json"
 ),);
 
 mod success {
@@ -11,7 +11,7 @@ mod success {
 
     #[tokio::test]
     async fn runs_i8_test_script() {
-        let path_to_bin = "src/signed_integers/signed_i8/out/debug/i8_test.bin";
+        let path_to_bin = "src/signed_integers/signed_i8/out/release/i8_test.bin";
         let wallet = launch_provider_and_get_wallet().await.unwrap();
 
         let instance = Testi8::new(wallet, path_to_bin);

--- a/tests/src/signed_integers/signed_i8_twos_complement/tests/mod.rs
+++ b/tests/src/signed_integers/signed_i8_twos_complement/tests/mod.rs
@@ -3,7 +3,7 @@ use fuels::prelude::{abigen, launch_provider_and_get_wallet};
 abigen!(Script(
     name = "Testi8TwosComplement",
     abi =
-        "src/signed_integers/signed_i8_twos_complement/out/debug/i8_twos_complement_test-abi.json"
+        "src/signed_integers/signed_i8_twos_complement/out/release/i8_twos_complement_test-abi.json"
 ),);
 
 mod success {
@@ -13,7 +13,7 @@ mod success {
     #[tokio::test]
     async fn runs_i8_twos_complement_test_script() {
         let path_to_bin =
-            "src/signed_integers/signed_i8_twos_complement/out/debug/i8_twos_complement_test.bin";
+            "src/signed_integers/signed_i8_twos_complement/out/release/i8_twos_complement_test.bin";
         let wallet = launch_provider_and_get_wallet().await.unwrap();
 
         let instance = Testi8TwosComplement::new(wallet, path_to_bin);


### PR DESCRIPTION
## Type of change

<!--Delete points that do not apply-->

- Improvement (refactoring, restructuring repository, cleaning tech debt, ...)

## Changes

The following changes have been made:

- CI and tests now use `--release` when calling `forc build`

Closes #232 
