### PR TITLE
Create Examples and Integrate Into Docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,3 +136,37 @@ jobs:
       - name: Build sway-libs docs
         run: |
           forc doc --manifest-path libs
+
+  build-examples:
+      runs-on: ubuntu-latest
+      steps:
+        - name: Checkout repository
+          uses: actions/checkout@v3
+
+        - name: Install Rust toolchain
+          uses: dtolnay/rust-toolchain@master
+          with:
+            toolchain: ${{ env.RUST_VERSION }}
+            components: rustfmt
+
+        - name: Init cache
+          uses: Swatinem/rust-cache@v2
+
+        - name: Install Fuel toolchain
+          uses: FuelLabs/action-fuel-toolchain@v0.6.0
+          with:
+            name: my-toolchain
+            components: forc@${{ env.FORC_VERSION }}, fuel-core@${{ env.CORE_VERSION }}
+
+        - name: Check Sway formatting
+          run: forc fmt --path examples --check
+
+        - name: Check Rust formatting
+          run: cargo fmt --manifest-path examples/Cargo.toml --verbose --check
+
+        - name: Build All Examples
+          run: forc build --path examples --release
+
+        - name: Cargo Test Examples
+          run: |
+            cargo test --manifest-path examples/Cargo.toml

--- a/docs/book/src/admin/index.md
+++ b/docs/book/src/admin/index.md
@@ -13,7 +13,7 @@ In order to use the Admin Library, Sway Libs must be added to the `Forc.toml` fi
 To import the Admin Library, be sure to include both the Admin and Ownership Libraries in your import statements.
 
 ```sway
-use sway_libs::{admin::*, ownership::*};
+{{#include ../../../../examples/admin/src/main.sw:import}}
 ```
 
 ## Integrating the Admin Library into the Ownership Library
@@ -21,18 +21,7 @@ use sway_libs::{admin::*, ownership::*};
 To use the Admin library, be sure to set a contract owner for your contract. The following demonstrates setting a contract owner using the [Ownership Library](../ownership/).
 
 ```sway
-use sway_libs::{admin::add_admin, ownership::initialize_ownership};
-
-#[storage(read, write)]
-fn my_constructor(new_owner: Identity) {
-    initialize_ownership(new_owner);
-}
-
-#[storage(read, write)]
-fn add_a_admin(new_admin: Identity) {
-    // Can only be called by contract's owner set in the constructor above.
-    add_admin(new_admin);
-}
+{{#include ../../../../examples/admin/src/owner_integration.sw:ownership_integration}}
 ```
 
 ## Basic Functionality
@@ -42,25 +31,17 @@ fn add_a_admin(new_admin: Identity) {
 To add a new admin to a contract, call the `add_admin()` function.
 
 ```sway
-#[storage(read, write)]
-fn add_a_admin(new_admin: Identity) {
-    // Can only be called by contract's owner.
-    add_admin(new_admin);
-}
+{{#include ../../../../examples/admin/src/main.sw:add_admin}}
 ```
 
 > **NOTE** Only the contract's owner may call this function. Please see the example above to set a contract owner.
 
 ### Removing an Admin
 
-To remove an admin from a contract, call the `remove_admin()` function.
+To remove an admin from a contract, call the `revoke_admin()` function.
 
 ```sway
-#[storage(read, write)]
-fn remove_a_admin(old_admin: Identity) {
-    // Can only be called by contract's owner.
-    remove_admin(old_admin);
-}
+{{#include ../../../../examples/admin/src/main.sw:remove_admin}}
 ```
 
 > **NOTE** Only the contract's owner may call this function. Please see the example above to set a contract owner.
@@ -70,11 +51,7 @@ fn remove_a_admin(old_admin: Identity) {
 To restrict a function to only an admin, call the `only_admin()` function.
 
 ```sway
-#[storage(read)]
-fn only_owner_may call() {
-    only_admin();
-    // Only an admin may reach this line.
-}
+{{#include ../../../../examples/admin/src/main.sw:only_admin}}
 ```
 
 > **NOTE:** Admins and the contract's owner are independent of one another. `only_admin()` will revert if called by the contract's owner.
@@ -82,11 +59,7 @@ fn only_owner_may call() {
 To restrict a function to only an admin or the contract's owner, call the `only_owner_or_admin()` function.
 
 ```sway
-#[storage(read)]
-fn both_owner_or_admin_may_call() {
-    only_owner_or_admin();
-    // Only an admin may reach this line.
-}
+{{#include ../../../../examples/admin/src/main.sw:both_admin}}
 ```
 
 ### Checking Admin Status
@@ -94,9 +67,5 @@ fn both_owner_or_admin_may_call() {
 To check the administrative privileges of a user, call the `is_admin()` function.
 
 ```sway
-#[storage(read)]
-fn check_if_admin(admin: Identity) {
-    let status = is_admin(admin);
-    assert(status);
-}
+{{#include ../../../../examples/admin/src/main.sw:check_admin}}
 ```

--- a/docs/book/src/asset/base.md
+++ b/docs/book/src/asset/base.md
@@ -9,8 +9,7 @@ In order to use the Asset Library, Sway Libs and [Sway Standards](https://github
 To import the Asset Library Base Functionality and [SRC-20](https://github.com/FuelLabs/sway-standards/blob/master/SRCs/src-20.md) Standard to your Sway Smart Contract, add the following to your Sway file:
 
 ```sway
-use sway_libs::asset::base::*;
-use standards::src20::*;
+{{#include ../../../../examples/asset/base_docs/src/main.sw:import}}
 ```
 
 ## Integration with the SRC-20 Standard
@@ -18,18 +17,7 @@ use standards::src20::*;
 The [SRC-20](https://github.com/FuelLabs/sway-standards/blob/master/SRCs/src-20.md) definition states that the following abi implementation is required for any Native Asset on Fuel:
 
 ```sway
-abi SRC20 {
-    #[storage(read)]
-    fn total_assets() -> u64;
-    #[storage(read)]
-    fn total_supply(asset: AssetId) -> Option<u64>;
-    #[storage(read)]
-    fn name(asset: AssetId) -> Option<String>;
-    #[storage(read)]
-    fn symbol(asset: AssetId) -> Option<String>;
-    #[storage(read)]
-    fn decimals(asset: AssetId) -> Option<u8>;
-}
+{{#include ../../../../examples/asset/base_docs/src/main.sw:src20_abi}}
 ```
 
 The Asset Library has the following complimentary functions for each function in the `SRC20` abi:
@@ -43,14 +31,7 @@ The Asset Library has the following complimentary functions for each function in
 The following ABI and functions are also provided to set your [SRC-20](https://github.com/FuelLabs/sway-standards/blob/master/SRCs/src-20.md) standard storage values:
 
 ```sway
-abi SetAssetAttributes {
-    #[storage(write)]
-    fn set_name(asset: AssetId, name: String);
-    #[storage(write)]
-    fn set_symbol(asset: AssetId, symbol: String);
-    #[storage(write)]
-    fn set_decimals(asset: AssetId, decimals: u8);
-}
+{{#include ../../../../examples/asset/base_docs/src/main.sw:set_attributes}}
 ```
 
 - `_set_name()`
@@ -64,13 +45,7 @@ abi SetAssetAttributes {
 Once imported, the Asset Library's base functionality should be available. To use them, be sure to add the storage block bellow to your contract which enables the [SRC-20](https://github.com/FuelLabs/sway-standards/blob/master/SRCs/src-20.md) standard.
 
 ```sway
-storage {
-    total_assets: u64 = 0,
-    total_supply: StorageMap<AssetId, u64> = StorageMap {},
-    name: StorageMap<AssetId, StorageString> = StorageMap {},
-    symbol: StorageMap<AssetId, StorageString> = StorageMap {},
-    decimals: StorageMap<AssetId, u8> = StorageMap {},
-}
+{{#include ../../../../examples/asset/base_docs/src/main.sw:src20_storage}}
 ```
 
 ## Implementing the SRC-20 Standard with the Asset Library
@@ -78,57 +53,7 @@ storage {
 To use the Asset Library's base functionly, simply pass the `StorageKey` from the prescribed storage block. The example below shows the implementation of the [SRC-20](https://github.com/FuelLabs/sway-standards/blob/master/SRCs/src-20.md) standard in combination with the Asset Library with no user defined restrictions or custom functionality.
 
 ```sway
-use sway_libs::asset::base::{
-    _total_assets, 
-    _total_supply,
-    _name,
-    _symbol,
-    _decimals
-};
-use standards::src20::SRC20;
-use std::{string::String, storage::storage_string::*};
-
-// The SRC-20 storage block
-storage {
-    total_assets: u64 = 0,
-    total_supply: StorageMap<AssetId, u64> = StorageMap {},
-    name: StorageMap<AssetId, StorageString> = StorageMap {},
-    symbol: StorageMap<AssetId, StorageString> = StorageMap {},
-    decimals: StorageMap<AssetId, u8> = StorageMap {},
-}
-
-// Implement the SRC-20 Standard for this contract
-impl SRC20 for Contract {
-    #[storage(read)]
-    fn total_assets() -> u64 {
-        // Pass the `total_assets` StorageKey to `_total_assets()` from the Asset Library.
-        _total_assets(storage.total_assets)
-    }
-
-    #[storage(read)]
-    fn total_supply(asset: AssetId) -> Option<u64> {
-        // Pass the `total_supply` StorageKey to `_total_supply()` from the Asset Library.
-        _total_supply(storage.total_supply, asset)
-    }
-
-    #[storage(read)]
-    fn name(asset: AssetId) -> Option<String> {
-        // Pass the `name` StorageKey to `_name_()` from the Asset Library.
-        _name(storage.name, asset)
-    }
-
-    #[storage(read)]
-    fn symbol(asset: AssetId) -> Option<String> {
-        // Pass the `symbol` StorageKey to `_symbol_()` function from the Asset Library.
-        _symbol(storage.symbol, asset)
-    }
-
-    #[storage(read)]
-    fn decimals(asset: AssetId) -> Option<u8> {
-        // Pass the `decimals` StorageKey to `_decimals_()` function from the Asset Library.
-        _decimals(storage.decimals, asset)
-    }
-}
+{{#include ../../../../examples/asset/basic_src20/src/main.sw:basic_src20}}
 ```
 
 ## Setting an Asset's SRC-20 Attributes
@@ -136,31 +61,7 @@ impl SRC20 for Contract {
 To set some the asset attributes for an Asset, use the `SetAssetAttributes` ABI provided by the Asset Library. The example below shows the implementation of the `SetAssetAttributes` ABI with no user defined restrictions or custom functionality. It is recommended that the [Ownership Library](../ownership/index.md) is used in conjunction with the `SetAssetAttributes` ABI to ensure only a single user has permissions to set an Asset's attributes.
 
 ```sway
-use sway_libs::asset::base::*;
-use std::{string::String, storage::storage_string::*};
-
-storage {
-    name: StorageMap<AssetId, StorageString> = StorageMap {},
-    symbol: StorageMap<AssetId, StorageString> = StorageMap {},
-    decimals: StorageMap<AssetId, u8> = StorageMap {},
-}
-
-impl SetAssetAttributes for Contract {
-    #[storage(write)]
-    fn set_name(asset: AssetId, name: String) {
-        _set_name(storage.name, asset, name);
-    }
-
-    #[storage(write)]
-    fn set_symbol(asset: AssetId, symbol: String) {
-        _set_symbol(storage.symbol, asset, symbol);
-    }
-
-    #[storage(write)]
-    fn set_decimals(asset: AssetId, decimals: u8) {
-        _set_decimals(storage.decimals, asset, decimals);
-    }
-}
+{{#include ../../../../examples/asset/setting_src20_attributes/src/main.sw:setting_src20_attributes}}
 ```
 
 > **NOTE** The `_set_name()`, `_set_symbol()`, and `_set_decimals()` functions will set the attributes of an asset *unconditionally*. External checks should be applied to restrict the setting of attributes.

--- a/docs/book/src/asset/metadata.md
+++ b/docs/book/src/asset/metadata.md
@@ -9,8 +9,7 @@ In order to use the Asset Library, Sway Libs and [Sway Standards](https://github
 To import the Asset Library Base Functionality and [SRC-7](https://github.com/FuelLabs/sway-standards/blob/master/SRCs/src-7.md) Standard to your Sway Smart Contract, add the following to your Sway file:
 
 ```sway
-use sway_libs::asset::metadata::*;
-use standards::src7::*;
+{{#include ../../../../examples/asset/metadata_docs/src/main.sw:import}}
 ```
 
 ## Integration with the SRC-7 Standard
@@ -18,10 +17,7 @@ use standards::src7::*;
 The [SRC-7](https://github.com/FuelLabs/sway-standards/blob/master/SRCs/src-7.md) definition states that the following abi implementation is required for any Native Asset on Fuel:
 
 ```sway
-abi SRC7 {
-    #[storage(read)]
-    fn metadata(asset: AssetId, key: String) -> Option<Metadata>;
-}
+{{#include ../../../../examples/asset/metadata_docs/src/main.sw:src7_abi}}
 ```
 
 The Asset Library has the following complimentary data type for the [SRC-7](https://github.com/FuelLabs/sway-standards/blob/master/SRCs/src-7.md) standard:
@@ -44,9 +40,7 @@ The following additional functionality for the [SRC-7](https://github.com/FuelLa
 Once imported, the Asset Library's metadata functionality should be available. To use them, be sure to add the storage block bellow to your contract which enables the [SRC-7](https://github.com/FuelLabs/sway-standards/blob/master/SRCs/src-7.md) standard.
 
 ```sway
-storage {
-    metadata: StorageMetadata = StorageMetadata {},
-}
+{{#include ../../../../examples/asset/metadata_docs/src/main.sw:src7_storage}}
 ```
 
 ## Using the `StorageMetadata` Type
@@ -56,18 +50,7 @@ storage {
 To set some metadata for an Asset, use the `SetAssetMetadata` ABI provided by the Asset Library. Be sure to follow the [SRC-9](https://github.com/FuelLabs/sway-standards/blob/master/SRCs/src-9.md) standard for your `key`. It is recommended that the [Ownership Library](../ownership/index.md) is used in conjunction with the `SetAssetMetadata` ABI to ensure only a single user has permissions to set an Asset's metadata.
 
 ```sway
-use sway_libs::asset::metadata::*;
-
-storage {
-    metadata: StorageMetadata = StorageMetadata {},
-}
-
-impl SetAssetMetadata for Contract {
-    #[storage(read, write)]
-    fn set_metadata(asset: AssetId, key: String, metadata: Metadata) {
-        _set_metadata(storage.metadata, asset, key, metadata);
-    }
-}
+{{#include ../../../../examples/asset/setting_src7_attributes/src/main.sw:setting_src7_attributes}}
 ```
 
 > **NOTE** The `_set_metadata()` function will set the metadata of an asset *unconditionally*. External checks should be applied to restrict the setting of metadata.
@@ -77,21 +60,7 @@ impl SetAssetMetadata for Contract {
 To use the `StorageMetadata` type, simply get the stored metadata with the associated `key` and `AssetId`. The example below shows the implementation of the [SRC-7](https://github.com/FuelLabs/sway-standards/blob/master/SRCs/src-7.md) standard in combination with the Asset Library's `StorageMetadata` type with no user defined restrictions or custom functionality.
 
 ```sway
-use sway_libs::asset::metadata::*;
-use standards::src7::SRC7;
-
-storage {
-    metadata: StorageMetadata = StorageMetadata {},
-}
-
-// Implement the SRC-7 Standard for this contract
-impl SRC7 for Contract {
-    #[storage(read)]
-    fn metadata(asset: AssetId, key: String) -> Option<Metadata> {
-        // Return the stored metadata
-        storage.metadata.get(asset, key)
-    }
-}
+{{#include ../../../../examples/asset/basic_src7/src/main.sw:basic_src7}}
 ```
 
 ## Using the `Metadata` Extensions
@@ -99,12 +68,7 @@ impl SRC7 for Contract {
 The `Metadata` type defined by the [SRC-7](https://github.com/FuelLabs/sway-standards/blob/master/SRCs/src-7.md) standard can be one of 4 states:
 
 ```sway
-pub enum Metadata {
-    B256: b256,
-    Bytes: Bytes,
-    Int: u64,
-    String: String,
-}
+{{#include ../../../../examples/asset/metadata_docs/src/main.sw:metadata_enum}}
 ```
 
 The Asset Library enables the following functionality for the `Metadata` type:
@@ -115,11 +79,7 @@ The `is_b256()` check enables checking whether the `Metadata` type is a `b256`.
 The `as_b256()` returns the `b256` of the `Metadata` type.
 
 ```sway
-fn b256_type(my_metadata: Metadata) {
-    assert(my_metadata.is_b256());
-
-    let my_b256: b256 = my_metadata.as_b256();
-}
+{{#include ../../../../examples/asset/metadata_docs/src/main.sw:as_b256}}
 ```
 
 ### `is_bytes()` and `as_bytes()`
@@ -128,11 +88,7 @@ The `is_bytes()` check enables checking whether the `Metadata` type is a `Bytes`
 The `as_bytes()` returns the `Bytes` of the `Metadata` type.
 
 ```sway
-fn bytes_type(my_metadata: Metadata) {
-    assert(my_metadata.is_bytes());
-
-    let my_bytes: Bytes = my_metadata.as_bytes();
-}
+{{#include ../../../../examples/asset/metadata_docs/src/main.sw:as_bytes}}
 ```
 
 ### `is_u64()` and `as_u64()`
@@ -141,11 +97,7 @@ The `is_u64()` check enables checking whether the `Metadata` type is a `u64`.
 The `as_u64()` returns the `u64` of the `Metadata` type.
 
 ```sway
-fn u64_type(my_metadata: Metadata) {
-    assert(my_metadata.is_u64());
-
-    let my_u64: u64 = my_metadata.as_u64();
-}
+{{#include ../../../../examples/asset/metadata_docs/src/main.sw:as_u64}}
 ```
 
 ### `is_string()` and `as_string()`
@@ -154,9 +106,5 @@ The `is_string()` check enables checking whether the `Metadata` type is a `Strin
 The `as_string()` returns the `String` of the `Metadata` type.
 
 ```sway
-fn string_type(my_metadata: Metadata) {
-    assert(my_metadata.is_string());
-
-    let my_string: String = my_metadata.as_string();
-}
+{{#include ../../../../examples/asset/metadata_docs/src/main.sw:as_string}}
 ```

--- a/docs/book/src/asset/supply.md
+++ b/docs/book/src/asset/supply.md
@@ -9,8 +9,7 @@ In order to use the Asset Library, Sway Libs and [Sway Standards](https://github
 To import the Asset Library Supply Functionality and [SRC-3](https://github.com/FuelLabs/sway-standards/blob/master/SRCs/src-3.md) Standard to your Sway Smart Contract, add the following to your Sway file:
 
 ```sway
-use sway_libs::asset::supply::*;
-use standards::src3::*;
+{{#include ../../../../examples/asset/supply_docs/src/main.sw:import}}
 ```
 
 ## Integration with the SRC-3 Standard
@@ -18,12 +17,7 @@ use standards::src3::*;
 The [SRC-3](https://github.com/FuelLabs/sway-standards/blob/master/SRCs/src-3.md) definition states that the following abi implementation is required for any Native Asset on Fuel which mints and burns tokens:
 
 ```sway
-abi SRC3 {
-    #[storage(read, write)]
-    fn mint(recipient: Identity, vault_sub_id: SubId, amount: u64);
-    #[storage(read, write)]
-    fn burn(vault_sub_id: SubId, amount: u64);
-}
+{{#include ../../../../examples/asset/supply_docs/src/main.sw:src3_abi}}
 ```
 
 The Asset Library has the following complimentary functions for each function in the `SRC3` abi:
@@ -38,10 +32,7 @@ The Asset Library has the following complimentary functions for each function in
 Once imported, the Asset Library's supply functionality should be available. To use them, be sure to add the storage block bellow to your contract which enables the [SRC-3](https://github.com/FuelLabs/sway-standards/blob/master/SRCs/src-3.md) standard.
 
 ```sway
-storage {
-    total_assets: u64 = 0,
-    total_supply: StorageMap<AssetId, u64> = StorageMap {},
-}
+{{#include ../../../../examples/asset/supply_docs/src/main.sw:src3_storage}}
 ```
 
 ## Implementing the SRC-3 Standard with the Asset Library
@@ -49,34 +40,7 @@ storage {
 To use a base function, simply pass the `StorageKey` from the prescribed storage block. The example below shows the implementation of the [SRC-3](https://github.com/FuelLabs/sway-standards/blob/master/SRCs/src-3.md) standard in combination with the Asset Library with no user defined restrictions or custom functionality. It is recommended that the [Ownership Library](../ownership/index.md) is used in conjunction with the Asset Library;s supply functionality to ensure only a single user has permissions to mint an Asset.
 
 ```sway
-use sway_libs::asset::supply::{_mint, _burn};
-use standards::src3::SRC3;
-
-storage {
-    total_assets: u64 = 0,
-    total_supply: StorageMap<AssetId, u64> = StorageMap {},
-}
-
-// Implement the SRC-3 Standard for this contract
-impl SRC3 for Contract {
-    #[storage(read, write)]
-    fn mint(recipient: Identity, sub_id: SubId, amount: u64) {
-        // Pass the StorageKeys to the `_mint()` function from the Asset Library.
-        _mint(
-            storage.total_assets,
-            storage.total_supply,
-            recipient,
-            sub_id,
-            amount,
-        );
-    }
-
-    // Pass the StorageKeys to the `_burn_()` function from the Asset Library.
-    #[storage(read, write)]
-    fn burn(sub_id: SubId, amount: u64) {
-        _burn(storage.total_supply, sub_id, amount);
-    }
-}
+{{#include ../../../../examples/asset/basic_src3/src/main.sw:basic_src3}}
 ```
 
 > **NOTE** The `_mint()` and `_burn()` functions will mint and burn assets *unconditionally*. External checks should be applied to restrict the minting and burning of assets.

--- a/docs/book/src/asset/supply.md
+++ b/docs/book/src/asset/supply.md
@@ -1,6 +1,6 @@
 # Supply Functionality
 
-For implementation details on the Asset Library supply functionality please see the [Sway Libs Docs](https://fuellabs.github.io/sway-libs/master/sway_libs/asset/mint/index.html).
+For implementation details on the Asset Library supply functionality please see the [Sway Libs Docs](https://fuellabs.github.io/sway-libs/master/sway_libs/asset/supply/index.html).
 
 ## Importing the Asset Library Supply Functionality
 

--- a/docs/book/src/bytecode/index.md
+++ b/docs/book/src/bytecode/index.md
@@ -13,7 +13,7 @@ In order to use the Bytecode Library, Sway Libs must be added to the `Forc.toml`
 To import the Bytecode Library to your Sway Smart Contract, add the following to your Sway file:
 
 ```sway
-use sway_libs::bytecode::*;
+{{#include ../../../../examples/bytecode/src/main.sw:import}}
 ```
 
 ## Using the Bytecode Library In Sway
@@ -36,15 +36,7 @@ Once imported, using the Bytecode Library is as simple as calling the desired fu
 Please note that if you are passing the bytecode from the SDK and are including configurable values, the `Vec<u8>` bytecode provided must be copied to be mutable. The following can be added to make your bytecode mutable:
 
 ```sway
-fn foo(not_mutable_bytecode: Vec<u8>) {
-    // Copy the bytecode to a newly allocated memory to avoid memory ownership error.
-    let mut bytecode_slice = raw_slice::from_parts::<u8>(alloc_bytes(not_mutable_bytecode.len()), not_mutable_bytecode.len());
-    not_mutable_bytecode
-        .ptr()
-        .copy_bytes_to(bytecode_slice.ptr(), not_mutable_bytecode.len());
-    let mut bytecode_vec = Vec::from(bytecode_slice);
-    // You may now use `bytecode_vec` in your computation and verification function calls
-}
+{{#include ../../../../examples/bytecode/src/main.sw:known_issue}}
 ```
 
 ## Basic Functionality
@@ -56,10 +48,7 @@ The examples below are intended for internal contract calls. If you are passing 
 Given some bytecode, you may swap the configurables of both Contracts and Predicates by calling the `swap_configurables()` function.
 
 ```sway
-fn foo(my_bytecode: Vec<u8>, my_configurables: Vec<(u64, Vec<u8>)>) {
-    let mut my_bytecode = my_bytecode;
-    let resulting_bytecode: Vec<u8> = swap_configurables(my_bytecode, my_configurables);
-}
+{{#include ../../../../examples/bytecode/src/main.sw:swap_configurables}}
 ```
 
 ## Contracts
@@ -69,14 +58,7 @@ fn foo(my_bytecode: Vec<u8>, my_configurables: Vec<(u64, Vec<u8>)>) {
 To compute a contract's bytecode root you may call the `compute_bytecode_root()` or `compute_bytecode_root_with_configurables()` functions.
 
 ```sway
-fn foo(my_bytecode: Vec<u8>) {
-    let root: b256 = compute_bytecode_root(my_bytecode);
-}
-
-fn bar(my_bytecode: Vec<u8>, my_configurables: Vec<(u64, Vec<u8>)>) {
-    let mut my_bytecode = my_bytecode;
-    let root: b256 = compute_bytecode_root_with_configurables(my_bytecode, my_configurables);
-}
+{{#include ../../../../examples/bytecode/src/main.sw:compute_bytecode_root}}
 ```
 
 ### Verifying a Contract's Bytecode Root
@@ -84,16 +66,7 @@ fn bar(my_bytecode: Vec<u8>, my_configurables: Vec<(u64, Vec<u8>)>) {
 To verify a contract's bytecode root you may call `verify_bytecode_root()` or `verify_contract_bytecode_with_configurables()` functions.
 
 ```sway
-fn foo(my_contract: ContractId, my_bytecode: Vec<u8>) {
-    verify_contract_bytecode(my_contract, my_bytecode);
-    // By reaching this line the contract has been verified to match the bytecode provided.
-}
-
-fn bar(my_contract: ContractId, my_bytecode: Vec<u8>, my_configurables: Vec<(u64, Vec<u8>)>) {
-    let mut my_bytecode = my_bytecode;
-    verify_contract_bytecode_with_configurables(my_contract, my_bytecode, my_configurables);
-    // By reaching this line the contract has been verified to match the bytecode provided.
-}
+{{#include ../../../../examples/bytecode/src/main.sw:verify_contract_bytecode}}
 ```
 
 ## Predicates
@@ -103,14 +76,7 @@ fn bar(my_contract: ContractId, my_bytecode: Vec<u8>, my_configurables: Vec<(u64
 To compute a predicates's address you may call the `compute_predicate_address()` or `compute_predicate_address_with_configurables()` functions.
 
 ```sway
-fn foo(my_bytecode: Vec<u8>) {
-    let address: Address = compute_predicate_address(my_bytecode);
-}
-
-fn bar(my_bytecode: Vec<u8>, my_configurables: Vec<(u64, Vec<u8>)>) {
-    let mut my_bytecode = my_bytecode;
-    let address: Address = compute_predicate_address_with_configurables(my_bytecode, my_configurables);
-}
+{{#include ../../../../examples/bytecode/src/main.sw:compute_predicate_address}}
 ```
 
 ### Computing the Address from a Root
@@ -118,9 +84,7 @@ fn bar(my_bytecode: Vec<u8>, my_configurables: Vec<(u64, Vec<u8>)>) {
 If you have the root of a predicate, you may compute it's corresponding predicate address by calling the `predicate_address_from_root()` function.
 
 ```sway
-fn foo(my_root: b256) {
-    let address: Address = predicate_address_from_root(my_root);
-}
+{{#include ../../../../examples/bytecode/src/main.sw:predicate_address_from_root}}
 ```
 
 ### Verifying the Address
@@ -128,14 +92,5 @@ fn foo(my_root: b256) {
 To verify a predicates's address you may call `verify_predicate_address()` or `verify_predicate_address_with_configurables()` functions.
 
 ```sway
-fn foo(my_predicate: Address, my_bytecode: Vec<u8>) {
-    verify_predicate_address(my_predicate, my_bytecode);
-    // By reaching this line the predicate bytecode matches the address provided.
-}
-
-fn bar(my_predicate: Address, my_bytecode: Vec<u8>, my_configurables: Vec<(u64, Vec<u8>)>) {
-    let mut my_bytecode = my_bytecode;
-    verify_predicate_bytecode_with_configurables(my_predicate, my_bytecode, my_configurables);
-    // By reaching this line the predicate bytecode matches the address provided.
-}
+{{#include ../../../../examples/bytecode/src/main.sw:verify_predicate_address}}
 ```

--- a/docs/book/src/fixed_point/index.md
+++ b/docs/book/src/fixed_point/index.md
@@ -13,7 +13,7 @@ In order to use the Fixed Point Number Library, Sway Libs must be added to the `
 To import the Fixed Point Number Library to your Sway Smart Contract, add the following to your Sway file:
 
 ```sway
-use sway_libs::fixed_point::*;
+{{#include ../../../../examples/fixed_point/src/main.sw:import}}
 ```
 
 ## Supported Fixed Point Numbers
@@ -29,11 +29,7 @@ We currently support the following signed Fixed Point numbers:
 In order to use the `IFP64`, `IFP128` or `IFP256` types, import them into your Sway project like so:
 
 ```sway
-use sway_libs::fixed_point::{
-    ifp64::IFP64,
-    ifp128::IFP128,
-    ifp256::IFP256,
-};
+{{#include ../../../../examples/fixed_point/src/main.sw:import_ifp}}
 ```
 
 ### Unsigned Fixed Point Numbers
@@ -47,11 +43,7 @@ We currently support the following unsigned Fixed Point numbers:
 In order to use the `UFP32`, `UFP64` or `UFP128` types, import them into your Sway project like so:
 
 ```sway
-use sway_libs::fixed_point::{
-    ufp32::UFP32,
-    ufp64::UFP64,
-    ufp128::UFP128,
-};
+{{#include ../../../../examples/fixed_point/src/main.sw:import_ufp}}
 ```
 
 ## Basic Functionality
@@ -61,9 +53,7 @@ use sway_libs::fixed_point::{
 Once imported, any signed or unsigned Fixed Point number type can be instantiated by defining a new variable and calling the `from` function.
 
 ```sway
-let mut ufp32_value = UFP32::from(0);
-let mut ufp64_value = UFP64::from(0);
-let mut ufp128_value = UFP128::from(0);
+{{#include ../../../../examples/fixed_point/src/main.sw:instantiating_ufp}}
 ```
 
 ### Basic mathematical Functions
@@ -71,21 +61,7 @@ let mut ufp128_value = UFP128::from(0);
 Basic arithmetic operations are working as usual.
 
 ```sway
-fn add_ufp(val1: UFP64, val2: UFP64) {
-    let result: UFP64 = val1 + val2;
-}
-
-fn subtract_ufp(val1: UFP64, val2: UFP64) {
-    let result: UFP64 = val1 - val2;
-}
-
-fn multiply_ufp(val1: UFP64, val2: UFP64) {
-    let result: UFP64 = val1 * val2;
-}
-
-fn divide_ufp(val1: UFP64, val2: UFP64) {
-    let result: UFP64 = val1 / val2;
-}
+{{#include ../../../../examples/fixed_point/src/main.sw:mathematical_ops}}
 ```
 
 ### Advanced mathematical Functions Supported
@@ -95,21 +71,17 @@ We currently support the following advanced mathematical functions:
 #### Exponential
 
 ```sway
-let ten = UFP64::from_uint(10);
-let res = UFP64::exp(ten);
+{{#include ../../../../examples/fixed_point/src/main.sw:exponential}}
 ```
 
 #### Square Root
 
 ```sway
-let ufp64_169 = UFP64::from_uint(169);
-let res = UFP64::sqrt(ufp64_169);
+{{#include ../../../../examples/fixed_point/src/main.sw:square_root}}
 ```
 
 #### Power
 
 ```sway
-let three = UFP64::from_uint(3);
-let five = UFP64::from_uint(5);
-let res = five.pow(three);
+{{#include ../../../../examples/fixed_point/src/main.sw:power}}
 ```

--- a/docs/book/src/merkle/index.md
+++ b/docs/book/src/merkle/index.md
@@ -11,7 +11,7 @@ In order to use the Merkle Library, Sway Libs must be added to the `Forc.toml` f
 To import the Merkle Library to your Sway Smart Contract, add the following to your Sway file:
 
 ```sway
-use sway_libs::merkle::binary_proof::*;
+{{#include ../../../../examples/merkle/src/main.sw:import}}
 ```
 
 ## Using the Merkle Proof Library In Sway
@@ -32,17 +32,13 @@ The Binary Proof currently allows for you to compute leaves and nodes of a merkl
 To compute a leaf use the `leaf_digest()` function:
 
 ```sway
-fn foo(hashed_data: b256) {
-    let leaf: b256 = leaf_digest(hashed_data);
-}
+{{#include ../../../../examples/merkle/src/main.sw:leaf_digest}}
 ```
 
 To compute a node given two leaves, use the `node_digest()` function:
 
 ```sway
-fn foo(leaf_a: b256, leaf_b: b256) {
-    let node: b256 = node_digest(leaf_a, leaf_b);
-}
+{{#include ../../../../examples/merkle/src/main.sw:node_digest}}
 ```
 
 > **NOTE** Order matters when computing a node.
@@ -52,9 +48,7 @@ fn foo(leaf_a: b256, leaf_b: b256) {
 To compute a Merkle root given a proof, use the `process_proof()` function.
 
 ```sway
-fn foo(key: u64, leaf: b256, num_leaves: u64, proof: Vec<b256>) {
-    let merkle_root: b256 = process_proof(key, leaf, num_leaves, proof);
-}
+{{#include ../../../../examples/merkle/src/main.sw:process_proof}}
 ```
 
 ### Verifying a Proof
@@ -62,9 +56,7 @@ fn foo(key: u64, leaf: b256, num_leaves: u64, proof: Vec<b256>) {
 To verify a proof against a merkle root, use the `verify_proof()` function.
 
 ```sway
-fn foo(merkle_roof: b256, key: u64, leaf: b256, num_leaves: u64, proof: Vec<b256>) {
-    assert(verify_proof(key, leaf, merkle_root, num_leaves, proof));
-}
+{{#include ../../../../examples/merkle/src/main.sw:verify_proof}}
 ```
 
 ## Using the Merkle Proof Library with Fuels-rs
@@ -75,19 +67,16 @@ To generate a Merkle Tree and corresponding proof for your Sway Smart Contract, 
 
 The import the Fuel-Merkle crate, the following should be added to the project's `Cargo.toml` file under `[dependencies]`:
 
-```rust
-fuel-merkle = { version = "0.33.0" }
+```sway
+{{#include ../../../../examples/Cargo.toml:dependencies}}
 ```
 
 ### Importing Into Your Rust File
 
 The following should be added to your Rust file to use the Fuel-Merkle crate.
 
-```rust
-use fuel_merkle::{
-    binary::in_memory::MerkleTree,
-    common::Bytes32,
-};
+```sway
+{{#include ../../../../examples/merkle/mod.rs:import}}
 ```
 
 ### Using Fuel-Merkle
@@ -96,30 +85,20 @@ use fuel_merkle::{
 
 To create a merkle tree using Fuel-Merkle is as simple as pushing your leaves in increasing order.
 
-```rust
-let mut tree = MerkleTree::new();
-let leaves = ["A".as_bytes(), "B".as_bytes(), "C".as_bytes()].to_vec();
-for datum in leaves.iter() {
-    let mut hasher = Sha256::new();
-    hasher.update(&datum);
-    let hash: Bytes32 = hasher.finalize().try_into().unwrap();
-    tree.push(hash);
-}
+```sway
+{{#include ../../../../examples/merkle/mod.rs:generating_a_tree}}
 ```
 
 #### Generating And Verifying A Proof
 
 To generate a proof for a specific leaf, you must have the index or key of the leaf. Simply call the prove function:
 
-```rust
-let mut proof = tree.prove(key).unwrap();
+```sway
+{{#include ../../../../examples/merkle/mod.rs:generating_proof}}
 ```
 
 Once the proof has been generated, you may call the Sway Smart Contract's `verify_proof` function:
 
-```rust
-let merkle_root = proof.0;
-let merkle_leaf = proof.1[0];
-proof.1.remove(0);
-contract_instance.verify_proof(key, merkle_leaf, merkle_root, num_leaves, proof.1).call().await;
+```sway
+{{#include ../../../../examples/merkle/mod.rs:verify_proof}}
 ```

--- a/docs/book/src/merkle/index.md
+++ b/docs/book/src/merkle/index.md
@@ -68,8 +68,10 @@ To generate a Merkle Tree and corresponding proof for your Sway Smart Contract, 
 The import the Fuel-Merkle crate, the following should be added to the project's `Cargo.toml` file under `[dependencies]`:
 
 ```sway
-{{#include ../../../../examples/Cargo.toml:dependencies}}
+fuel-merkle = { version = "0.33.0" }
 ```
+
+> **NOTE** Make sure to use the latest version of the [fuel-merkle](https://crates.io/crates/fuel-merkle) crate.
 
 ### Importing Into Your Rust File
 

--- a/docs/book/src/ownership/index.md
+++ b/docs/book/src/ownership/index.md
@@ -11,8 +11,7 @@ In order to use the Ownership library, Sway Libs and [Sway Standards](https://gi
 To import the Ownership Library and [SRC-5](https://github.com/FuelLabs/sway-standards/blob/master/SRCs/src-5.md) Standard to your Sway Smart Contract, add the following to your Sway file:
 
 ```sway
-use sway_libs::ownership::*;
-use standards::src5::*;
+{{#include ../../../../examples/ownership/src/main.sw:import}}
 ```
 
 ## Integrating the Ownership Library into the SRC-5 Standard
@@ -20,15 +19,7 @@ use standards::src5::*;
 To implement the [SRC-5](https://github.com/FuelLabs/sway-standards/blob/master/SRCs/src-5.md) standard with the Ownership library, be sure to add the Sway Standards dependency to your contract. The following demonstrates the integration of the Ownership library with the SRC-5 standard.
 
 ```sway
-use sway_libs::ownership::_owner;
-use standards::src_5::{State, SRC5};
-
-impl SRC5 for Contract {
-    #[storage(read)]
-    fn owner() -> State {
-        _owner()
-    }
-}
+{{#include ../../../../examples/ownership/src/main.sw:integrate_with_src5}}
 ```
 
 > **NOTE** A constructor method must be implemented to initialize the owner.
@@ -40,10 +31,7 @@ impl SRC5 for Contract {
 Once imported, the Ownership Library's functions will be available. To use them initialize the owner for your contract by calling the `initialize_ownership()` function in your own constructor method.
 
 ```sway
-#[storage(read, write)]
-fn my_constructor(new_owner: Identity) {
-    initialize_ownership(new_owner);
-}
+{{#include ../../../../examples/ownership/src/main.sw:initialize}}
 ```
 
 ### Applying Restrictions
@@ -51,11 +39,7 @@ fn my_constructor(new_owner: Identity) {
 To restrict a function to only the owner, call the `only_owner()` function.
 
 ```sway
-#[storage(read)]
-fn only_owner_may_call() {
-    only_owner();
-    // Only the contract's owner may reach this line.
-}
+{{#include ../../../../examples/ownership/src/main.sw:only_owner}}
 ```
 
 ### Checking the Ownership Status
@@ -63,8 +47,5 @@ fn only_owner_may_call() {
 To return the ownership state from storage, call the `_owner()` function.
 
 ```sway
-#[storage(read)]
-fn get_owner_state() {
-    let owner: State = _owner();
-}
+{{#include ../../../../examples/ownership/src/main.sw:state}}
 ```

--- a/docs/book/src/pausable/index.md
+++ b/docs/book/src/pausable/index.md
@@ -13,7 +13,7 @@ In order to use the Pausable library, Sway Libs must be added to the `Forc.toml`
 To import the Pausable Library to your Sway Smart Contract, add the following to your Sway file:
 
 ```sway
-use sway_libs::pausable::*;
+{{#include ../../../../examples/pausable/pausable/src/main.sw:import}}
 ```
 
 ## Basic Functionality
@@ -28,24 +28,7 @@ The Pausable Library has two states:
 By default, your contract will start in the `Unpaused` state. To pause your contract, you may call the `_pause()` function. The example below provides a basic pausable contract using the Pausable Library's `Pausable` abi without any restrictions such as an administrator.
 
 ```sway
-use sway_libs::pausable::{_is_paused, _pause, _unpause, Pausable};
-
-impl Pausable for Contract {
-    #[storage(write)]
-    fn pause() {
-        _pause();
-    }
-
-    #[storage(write)]
-    fn unpause() {
-        _unpause();
-    }
-
-    #[storage(read)]
-    fn is_paused() -> bool {
-        _is_paused()
-    }
-}
+{{#include ../../../../examples/pausable/pausable/src/main.sw:pausable_impl}}
 ```
 
 ## Applying Paused Restrictions
@@ -53,23 +36,11 @@ impl Pausable for Contract {
 When developing a contract, you may want to lock functions down to a specific state. To do this, you may call either of the `require_paused()` or `require_not_paused()` functions. The example below shows these functions in use.
 
 ```sway
-use sway_libs::pausable::require_paused;
-
-#[storage(read)]
-fn require_paused_state() {
-    require_paused();
-    // This comment will only ever be reached if the contract is in the paused state
-}
+{{#include ../../../../examples/pausable/pausable/src/main.sw:require_paused}}
 ```
 
 ```sway
-use sway_libs::pausable::require_not_paused;
-
-#[storage(read)]
-fn require_not_paused_state() {
-    require_not_paused();
-    // This comment will only ever be reached if the contract is in the unpaused state
-}
+{{#include ../../../../examples/pausable/pausable/src/main.sw:require_not_paused}}
 ```
 
 ## Using the Ownership Library with the Pausable Library
@@ -79,41 +50,5 @@ It is highly recommended to integrate the [Ownership Library](../ownership/index
 The follow example implements the `Pausable` abi and applies restrictions to it's pause/unpause functions. The owner of the contract must be set in an constructor defined by `MyConstructor` in this example.
 
 ```sway
-use sway_libs::{
-    pausable::{_is_paused, _pause, _unpause, Pausable}, 
-    ownership::{initialize_ownership, only_owner}
-};
-
-abi MyConstructor {
-    #[storage(read, write)]
-    fn my_constructor(new_owner: Identity);
-}
-
-impl MyConstructor for Contract {
-    #[storage(read, write)]
-    fn my_constructor(new_owner: Identity) {
-        initialize_ownership(new_owner);
-    }
-}
-
-impl Pausable for Contract {
-    #[storage(write)]
-    fn pause() {
-        // Add the `only_owner()` check to ensure only the owner may unpause this contract.
-        only_owner(); 
-        _pause();
-    }
-
-    #[storage(write)]
-    fn unpause() {
-        // Add the `only_owner()` check to ensure only the owner may unpause this contract.
-        only_owner();
-        _unpause();
-    }
-
-    #[storage(read)]
-    fn is_paused() -> bool {
-        _is_paused()
-    }
-}
+{{#include ../../../../examples/pausable/pausable_with_ownership/src/main.sw:impl_with_ownership}}
 ```

--- a/docs/book/src/queue/index.md
+++ b/docs/book/src/queue/index.md
@@ -11,7 +11,7 @@ In order to use the Queue Library, Sway Libs must be added to the `Forc.toml` fi
 To import the Queue Library to your Sway Smart Contract, add the following to your Sway file:
 
 ```sway
-use sway_libs::queue::*;
+{{#include ../../../../examples/queue/src/main.sw:import}}
 ```
 
 ## Basic Functionality
@@ -21,7 +21,7 @@ use sway_libs::queue::*;
 Once the `Queue` has been imported, you can create a new queue instance by calling the `new` function.
 
 ```sway
-let mut queue = Queue::new();
+{{#include ../../../../examples/queue/src/main.sw:instantiate}}
 ```
 
 ## Enqueuing elements
@@ -29,8 +29,7 @@ let mut queue = Queue::new();
 Adding elements to the `Queue` can be done using the `enqueue` function.
 
 ```sway
-// Enqueue an element to the queue
-queue.enqueue(10u8);
+{{#include ../../../../examples/queue/src/main.sw:enqueue}}
 ```
 
 ### Dequeuing Elements
@@ -38,8 +37,7 @@ queue.enqueue(10u8);
 To remove elements from the `Queue`, the `dequeue` function is used. This function follows the FIFO principle.
 
 ```sway
-// Dequeue the first element and unwrap the value
-let first_item = queue.dequeue().unwrap();
+{{#include ../../../../examples/queue/src/main.sw:dequeue}}
 ```
 
 ### Fetching the Head Element
@@ -47,8 +45,7 @@ let first_item = queue.dequeue().unwrap();
 To retrieve the element at the head of the `Queue` without removing it, you can use the `peek` function.
 
 ```sway
-// Peek at the head of the queue
-let head_item = queue.peek();
+{{#include ../../../../examples/queue/src/main.sw:peek}}
 ```
 
 ### Checking the Queue's Length
@@ -56,9 +53,5 @@ let head_item = queue.peek();
 The `is_empty` and `len` functions can be used to check if the queue is empty and to get the number of elements in the queue respectively.
 
 ```sway
-// Checks if queue is empty (returns True or False)
-let is_queue_empty = queue.is_empty();
-
-// Returns length of queue
-let queue_length = queue.len();
+{{#include ../../../../examples/queue/src/main.sw:length}}
 ```

--- a/docs/book/src/reentrancy/index.md
+++ b/docs/book/src/reentrancy/index.md
@@ -20,7 +20,7 @@ In order to use the Reentrancy Guard library, Sway Libs must be added to the `Fo
 To import the Reentrancy Guard Library to your Sway Smart Contract, add the following to your Sway file:
 
 ```sway
-use sway_libs::reentrancy::*;
+{{#include ../../../../examples/reentrancy/src/main.sw:import}}
 ```
 
 ## Basic Functionality
@@ -35,19 +35,7 @@ Once imported, using the Reentrancy Library can be done by calling one of the tw
 Once imported, using the Reentrancy Guard Library can be used by calling the `reentrancy_guard()` in your Sway Smart Contract. The following shows a Sway Smart Contract that applies the Reentrancy Guard Library:
 
 ```sway
-use sway_libs::reentrancy::reentrancy_guard;
-
-abi MyContract {
-    fn my_non_reentrant_function();
-}
-
-impl MyContract for Contract {
-    fn my_non_reentrant_function() {
-        reentrancy_guard();
-
-        // my code here
-    }
-}
+{{#include ../../../../examples/reentrancy/src/main.sw:reentrancy}}
 ```
 
 ### Checking Reentrancy Status
@@ -55,9 +43,5 @@ impl MyContract for Contract {
 To check if the current caller is a reentrant, you may call the `is_reentrant()` function.
 
 ```sway
-use sway_libs::reentrancy::is_reentrant;
-
-fn check_if_reentrant() {
-    assert(!is_reentrant());
-}
+{{#include ../../../../examples/reentrancy/src/main.sw:is_reentrant}}
 ```

--- a/docs/book/src/signed_integers/index.md
+++ b/docs/book/src/signed_integers/index.md
@@ -13,13 +13,13 @@ In order to use the Signed Integer Number Library, Sway Libs must be added to th
 To import the Signed Integer Number Library to your Sway Smart Contract, add the following to your Sway file:
 
 ```sway
-use sway_libs::signed_integer::*;
+{{#include ../../../../examples/signed_integers/src/main.sw:import}}
 ```
 
 In order to use the any of the Signed Integer types, import them into your Sway project like so:
 
 ```sway
-use sway_libs::signed_integers::i8::I8;
+{{#include ../../../../examples/signed_integers/src/main.sw:import_i8}}
 ```
 
 ## Basic Functionality
@@ -29,29 +29,15 @@ use sway_libs::signed_integers::i8::I8;
 Once imported, a `Signed Integer` type can be instantiated defining a new variable and calling the `new` function.
 
 ```sway
-let mut i8_value = I8::new();
+{{#include ../../../../examples/signed_integers/src/main.sw:initialize}}
 ```
 
-### Basic mathematical Functions
+### Basic Mathematical Functions
 
 Basic arithmetic operations are working as usual.
 
 ```sway
-fn add_signed_int(val1: i8, val2: i8) {
-    let result: i8 = val1 + val2;
-}
-
-fn subtract_signed_int(val1: i8, val2: i8) {
-    let result: i8 = val1 - val2;
-}
-
-fn multiply_signed_int(val1: i8, val2: i8) {
-    let result: i8 = val1 * val2;
-}
-
-fn divide_signed_int(val1: i8, val2: i8) {
-    let result: i8 = val1 / val2;
-}
+{{#include ../../../../examples/signed_integers/src/main.sw:mathematical_ops}}
 ```
 
 ## Known Issues

--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -1,0 +1,2 @@
+out
+target

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -6,11 +6,10 @@ edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]
-# ANCHOR: dependencies
 fuel-merkle = { version = "0.33.0" }
-# ANCHOR_END: dependencies
 sha2 = { version = "0.10" }
 fuels = { version = "0.53.0", features = ["fuel-core-lib"] }
+tokio = { version = "1.12", features = ["rt", "macros"] }
 
 [[test]]
 harness = true

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,0 +1,18 @@
+[project]
+name = "sdk-examples"
+version = "0.0.0"
+authors = ["Fuel Labs <contact@fuel.sh>"]
+edition = "2021"
+license = "Apache-2.0"
+
+[dependencies]
+# ANCHOR: dependencies
+fuel-merkle = { version = "0.33.0" }
+# ANCHOR_END: dependencies
+sha2 = { version = "0.10" }
+fuels = { version = "0.53.0", features = ["fuel-core-lib"] }
+
+[[test]]
+harness = true
+name = "sdk-examples"
+path = "harness.rs"

--- a/examples/Forc.toml
+++ b/examples/Forc.toml
@@ -1,0 +1,21 @@
+[workspace]
+members = [
+  "./admin",
+  "./asset/base_docs",
+  "./asset/basic_src3",
+  "./asset/basic_src7",
+  "./asset/basic_src20",
+  "./asset/metadata_docs",
+  "./asset/setting_src7_attributes",
+  "./asset/setting_src20_attributes",
+  "./asset/supply_docs",
+  "./bytecode",
+  "./fixed_point",
+  "./merkle",
+  "./ownership",
+  "./pausable/pausable",
+  "./pausable/pausable_with_ownership",
+  "./queue",
+  "./reentrancy",
+  "./signed_integers",
+]

--- a/examples/admin/Forc.toml
+++ b/examples/admin/Forc.toml
@@ -1,0 +1,9 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "admin_examples"
+
+[dependencies]
+standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.4.1" }
+sway_libs = { path = "../../libs" }

--- a/examples/admin/src/main.sw
+++ b/examples/admin/src/main.sw
@@ -1,0 +1,47 @@
+library;
+
+mod owner_integration;
+
+// ANCHOR: import
+use sway_libs::{admin::*, ownership::*};
+// ANCHOR_END: import
+
+// ANCHOR: add_admin
+#[storage(read, write)]
+fn add_a_admin(new_admin: Identity) {
+    // Can only be called by contract's owner.
+    add_admin(new_admin);
+}
+// ANCHOR_END: add_admin
+
+// ANCHOR: remove_admin
+#[storage(read, write)]
+fn remove_an_admin(old_admin: Identity) {
+    // Can only be called by contract's owner.
+    revoke_admin(old_admin);
+}
+// ANCHOR_END: remove_admin
+
+// ANCHOR: only_admin
+#[storage(read)]
+fn only_owner_may_call() {
+    only_admin();
+    // Only an admin may reach this line.
+}
+// ANCHOR_END: only_admin
+
+// ANCHOR: both_admin
+#[storage(read)]
+fn both_owner_or_admin_may_call() {
+    only_owner_or_admin();
+    // Only an admin may reach this line.
+}
+// ANCHOR_END: both_admin
+
+// ANCHOR: check_admin
+#[storage(read)]
+fn check_if_admin(admin: Identity) {
+    let status = is_admin(admin);
+    assert(status);
+}
+// ANCHOR_END: check_admin

--- a/examples/admin/src/owner_integration.sw
+++ b/examples/admin/src/owner_integration.sw
@@ -1,0 +1,16 @@
+library;
+
+// ANCHOR: ownership_integration
+use sway_libs::{admin::add_admin, ownership::initialize_ownership};
+
+#[storage(read, write)]
+fn my_constructor(new_owner: Identity) {
+    initialize_ownership(new_owner);
+}
+
+#[storage(read, write)]
+fn add_a_admin(new_admin: Identity) {
+    // Can only be called by contract's owner set in the constructor above.
+    add_admin(new_admin);
+}
+// ANCHOR_END: ownership_integration

--- a/examples/asset/base_docs/Forc.toml
+++ b/examples/asset/base_docs/Forc.toml
@@ -1,0 +1,9 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "base_docs"
+
+[dependencies]
+standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.4.1" }
+sway_libs = { path = "../../../libs" }

--- a/examples/asset/base_docs/src/main.sw
+++ b/examples/asset/base_docs/src/main.sw
@@ -1,0 +1,44 @@
+contract;
+
+use std::{hash::*, storage::storage_string::*, string::String};
+
+// ANCHOR: import
+use sway_libs::asset::base::*;
+use standards::src20::*;
+// ANCHOR_END: import
+
+// ANCHOR: src20_abi
+abi SRC20 {
+    #[storage(read)]
+    fn total_assets() -> u64;
+    #[storage(read)]
+    fn total_supply(asset: AssetId) -> Option<u64>;
+    #[storage(read)]
+    fn name(asset: AssetId) -> Option<String>;
+    #[storage(read)]
+    fn symbol(asset: AssetId) -> Option<String>;
+    #[storage(read)]
+    fn decimals(asset: AssetId) -> Option<u8>;
+}
+// ANCHOR_END: src20_abi
+
+// ANCHOR: set_attributes
+abi SetAssetAttributes {
+    #[storage(write)]
+    fn set_name(asset: AssetId, name: String);
+    #[storage(write)]
+    fn set_symbol(asset: AssetId, symbol: String);
+    #[storage(write)]
+    fn set_decimals(asset: AssetId, decimals: u8);
+}
+// ANCHOR_END: set_attributes
+
+// ANCHOR: src20_storage
+storage {
+    total_assets: u64 = 0,
+    total_supply: StorageMap<AssetId, u64> = StorageMap {},
+    name: StorageMap<AssetId, StorageString> = StorageMap {},
+    symbol: StorageMap<AssetId, StorageString> = StorageMap {},
+    decimals: StorageMap<AssetId, u8> = StorageMap {},
+}
+// ANCHOR_END: src20_storage

--- a/examples/asset/basic_src20/Forc.toml
+++ b/examples/asset/basic_src20/Forc.toml
@@ -1,0 +1,9 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "basic_src20"
+
+[dependencies]
+standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.4.1" }
+sway_libs = { path = "../../../libs" }

--- a/examples/asset/basic_src20/src/main.sw
+++ b/examples/asset/basic_src20/src/main.sw
@@ -1,0 +1,49 @@
+contract;
+
+// ANCHOR: basic_src20
+use sway_libs::asset::base::{_decimals, _name, _symbol, _total_assets, _total_supply};
+use standards::src20::SRC20;
+use std::{hash::Hash, storage::storage_string::*, string::String};
+
+// The SRC-20 storage block
+storage {
+    total_assets: u64 = 0,
+    total_supply: StorageMap<AssetId, u64> = StorageMap {},
+    name: StorageMap<AssetId, StorageString> = StorageMap {},
+    symbol: StorageMap<AssetId, StorageString> = StorageMap {},
+    decimals: StorageMap<AssetId, u8> = StorageMap {},
+}
+
+// Implement the SRC-20 Standard for this contract
+impl SRC20 for Contract {
+    #[storage(read)]
+    fn total_assets() -> u64 {
+        // Pass the `total_assets` StorageKey to `_total_assets()` from the Asset Library.
+        _total_assets(storage.total_assets)
+    }
+
+    #[storage(read)]
+    fn total_supply(asset: AssetId) -> Option<u64> {
+        // Pass the `total_supply` StorageKey to `_total_supply()` from the Asset Library.
+        _total_supply(storage.total_supply, asset)
+    }
+
+    #[storage(read)]
+    fn name(asset: AssetId) -> Option<String> {
+        // Pass the `name` StorageKey to `_name_()` from the Asset Library.
+        _name(storage.name, asset)
+    }
+
+    #[storage(read)]
+    fn symbol(asset: AssetId) -> Option<String> {
+        // Pass the `symbol` StorageKey to `_symbol_()` function from the Asset Library.
+        _symbol(storage.symbol, asset)
+    }
+
+    #[storage(read)]
+    fn decimals(asset: AssetId) -> Option<u8> {
+        // Pass the `decimals` StorageKey to `_decimals_()` function from the Asset Library.
+        _decimals(storage.decimals, asset)
+    }
+}
+// ANCHOR_END: basic_src20

--- a/examples/asset/basic_src3/Forc.toml
+++ b/examples/asset/basic_src3/Forc.toml
@@ -1,0 +1,9 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "basic_src3"
+
+[dependencies]
+standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.4.1" }
+sway_libs = { path = "../../../libs" }

--- a/examples/asset/basic_src3/src/main.sw
+++ b/examples/asset/basic_src3/src/main.sw
@@ -1,0 +1,37 @@
+contract;
+
+use std::hash::*;
+
+// ANCHOR: basic_src3
+use sway_libs::asset::supply::{_burn, _mint};
+use standards::src3::SRC3;
+
+storage {
+    total_assets: u64 = 0,
+    total_supply: StorageMap<AssetId, u64> = StorageMap {},
+}
+
+// Implement the SRC-3 Standard for this contract
+impl SRC3 for Contract {
+    #[storage(read, write)]
+    fn mint(recipient: Identity, sub_id: SubId, amount: u64) {
+        // Pass the StorageKeys to the `_mint()` function from the Asset Library.
+        _mint(
+            storage
+                .total_assets,
+            storage
+                .total_supply,
+            recipient,
+            sub_id,
+            amount,
+        );
+    }
+
+    // Pass the StorageKeys to the `_burn_()` function from the Asset Library.
+    #[payable]
+    #[storage(read, write)]
+    fn burn(sub_id: SubId, amount: u64) {
+        _burn(storage.total_supply, sub_id, amount);
+    }
+}
+// ANCHOR_END: basic_src3

--- a/examples/asset/basic_src7/Forc.toml
+++ b/examples/asset/basic_src7/Forc.toml
@@ -1,0 +1,9 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "basic_src7"
+
+[dependencies]
+standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.4.1" }
+sway_libs = { path = "../../../libs" }

--- a/examples/asset/basic_src7/src/main.sw
+++ b/examples/asset/basic_src7/src/main.sw
@@ -1,0 +1,21 @@
+contract;
+
+use std::string::String;
+
+// ANCHOR: basic_src7
+use sway_libs::asset::metadata::*;
+use standards::src7::{Metadata, SRC7};
+
+storage {
+    metadata: StorageMetadata = StorageMetadata {},
+}
+
+// Implement the SRC-7 Standard for this contract
+impl SRC7 for Contract {
+    #[storage(read)]
+    fn metadata(asset: AssetId, key: String) -> Option<Metadata> {
+        // Return the stored metadata
+        storage.metadata.get(asset, key)
+    }
+}
+// ANCHOR_END: basic_src7

--- a/examples/asset/metadata_docs/Forc.toml
+++ b/examples/asset/metadata_docs/Forc.toml
@@ -1,0 +1,9 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "metadata_docs"
+
+[dependencies]
+standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.4.1" }
+sway_libs = { path = "../../../libs" }

--- a/examples/asset/metadata_docs/src/main.sw
+++ b/examples/asset/metadata_docs/src/main.sw
@@ -1,0 +1,62 @@
+contract;
+
+use std::{bytes::Bytes, string::String};
+
+// ANCHOR: import
+use sway_libs::asset::metadata::*;
+use standards::src7::*;
+// ANCHOR_END: import
+
+// ANCHOR: src7_abi
+abi SRC7 {
+    #[storage(read)]
+    fn metadata(asset: AssetId, key: String) -> Option<Metadata>;
+}
+// ANCHOR_END: src7_abi
+
+// ANCHOR: src7_storage
+storage {
+    metadata: StorageMetadata = StorageMetadata {},
+}
+// ANCHOR_END: src7_storage
+
+// ANCHOR: metadata_enum
+pub enum Metadata {
+    B256: b256,
+    Bytes: Bytes,
+    Int: u64,
+    String: String,
+}
+// ANCHOR_END: metadata_enum
+
+// ANCHOR: as_b256
+fn b256_type(my_metadata: Metadata) {
+    assert(my_metadata.is_b256());
+
+    let my_b256: b256 = my_metadata.as_b256().unwrap();
+}
+// ANCHOR_END: as_b256
+
+// ANCHOR: as_bytes
+fn bytes_type(my_metadata: Metadata) {
+    assert(my_metadata.is_bytes());
+
+    let my_bytes: Bytes = my_metadata.as_bytes().unwrap();
+}
+// ANCHOR_END: as_bytes
+
+// ANCHOR: as_u64
+fn u64_type(my_metadata: Metadata) {
+    assert(my_metadata.is_u64());
+
+    let my_u64: u64 = my_metadata.as_u64().unwrap();
+}
+// ANCHOR_END: as_u64
+
+// ANCHOR: as_string
+fn string_type(my_metadata: Metadata) {
+    assert(my_metadata.is_string());
+
+    let my_string: String = my_metadata.as_string().unwrap();
+}
+// ANCHOR_END: as_string

--- a/examples/asset/setting_src20_attributes/Forc.toml
+++ b/examples/asset/setting_src20_attributes/Forc.toml
@@ -1,0 +1,9 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "setting_src20_attributes"
+
+[dependencies]
+standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.4.1" }
+sway_libs = { path = "../../../libs" }

--- a/examples/asset/setting_src20_attributes/src/main.sw
+++ b/examples/asset/setting_src20_attributes/src/main.sw
@@ -1,0 +1,29 @@
+contract;
+
+// ANCHOR: setting_src20_attributes
+use sway_libs::asset::base::*;
+use std::{hash::Hash, storage::storage_string::*, string::String};
+
+storage {
+    name: StorageMap<AssetId, StorageString> = StorageMap {},
+    symbol: StorageMap<AssetId, StorageString> = StorageMap {},
+    decimals: StorageMap<AssetId, u8> = StorageMap {},
+}
+
+impl SetAssetAttributes for Contract {
+    #[storage(write)]
+    fn set_name(asset: AssetId, name: String) {
+        _set_name(storage.name, asset, name);
+    }
+
+    #[storage(write)]
+    fn set_symbol(asset: AssetId, symbol: String) {
+        _set_symbol(storage.symbol, asset, symbol);
+    }
+
+    #[storage(write)]
+    fn set_decimals(asset: AssetId, decimals: u8) {
+        _set_decimals(storage.decimals, asset, decimals);
+    }
+}
+// ANCHOR_END: setting_src20_attributes

--- a/examples/asset/setting_src7_attributes/Forc.toml
+++ b/examples/asset/setting_src7_attributes/Forc.toml
@@ -1,0 +1,9 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "setting_src7_attributes"
+
+[dependencies]
+standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.4.1" }
+sway_libs = { path = "../../../libs" }

--- a/examples/asset/setting_src7_attributes/src/main.sw
+++ b/examples/asset/setting_src7_attributes/src/main.sw
@@ -1,0 +1,19 @@
+contract;
+
+use std::string::String;
+
+// ANCHOR: setting_src7_attributes
+use sway_libs::asset::metadata::*;
+use standards::src7::Metadata;
+
+storage {
+    metadata: StorageMetadata = StorageMetadata {},
+}
+
+impl SetAssetMetadata for Contract {
+    #[storage(read, write)]
+    fn set_metadata(asset: AssetId, key: String, metadata: Metadata) {
+        _set_metadata(storage.metadata, asset, key, metadata);
+    }
+}
+// ANCHOR_END: setting_src7_attributes

--- a/examples/asset/supply_docs/Forc.toml
+++ b/examples/asset/supply_docs/Forc.toml
@@ -1,0 +1,9 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "supply_docs"
+
+[dependencies]
+standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.4.1" }
+sway_libs = { path = "../../../libs" }

--- a/examples/asset/supply_docs/src/main.sw
+++ b/examples/asset/supply_docs/src/main.sw
@@ -1,0 +1,25 @@
+contract;
+
+use std::hash::Hash;
+
+// ANCHOR: import
+use sway_libs::asset::supply::*;
+use standards::src3::*;
+// ANCHOR_END: import
+
+// ANCHOR: src3_abi
+abi SRC3 {
+    #[storage(read, write)]
+    fn mint(recipient: Identity, vault_sub_id: SubId, amount: u64);
+    #[payable]
+    #[storage(read, write)]
+    fn burn(vault_sub_id: SubId, amount: u64);
+}
+// ANCHOR_END: src3_abi
+
+// ANCHOR: src3_storage
+storage {
+    total_assets: u64 = 0,
+    total_supply: StorageMap<AssetId, u64> = StorageMap {},
+}
+// ANCHOR_END: src3_storage

--- a/examples/bytecode/Forc.toml
+++ b/examples/bytecode/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "bytecode_examples"
+
+[dependencies]
+sway_libs = { path = "../../libs" }

--- a/examples/bytecode/src/main.sw
+++ b/examples/bytecode/src/main.sw
@@ -1,0 +1,92 @@
+library;
+
+use std::alloc::alloc_bytes;
+
+// ANCHOR: import
+use sway_libs::bytecode::*;
+// ANCHOR_END: import
+
+// ANCHOR: known_issue
+fn make_mutable(not_mutable_bytecode: Vec<u8>) {
+    // Copy the bytecode to a newly allocated memory to avoid memory ownership error.
+    let mut bytecode_slice = raw_slice::from_parts::<u8>(
+        alloc_bytes(not_mutable_bytecode.len()),
+        not_mutable_bytecode
+            .len(),
+    );
+    not_mutable_bytecode
+        .ptr()
+        .copy_bytes_to(bytecode_slice.ptr(), not_mutable_bytecode.len());
+    let mut bytecode_vec = Vec::from(bytecode_slice);
+    // You may now use `bytecode_vec` in your computation and verification function calls
+}
+// ANCHOR_END: known_issue
+
+// ANCHOR: swap_configurables
+fn swap(my_bytecode: Vec<u8>, my_configurables: Vec<(u64, Vec<u8>)>) {
+    let mut my_bytecode = my_bytecode;
+    let resulting_bytecode: Vec<u8> = swap_configurables(my_bytecode, my_configurables);
+}
+// ANCHOR_END: swap_configurables
+
+// ANCHOR: compute_bytecode_root
+fn compute_bytecode(my_bytecode: Vec<u8>) {
+    let root: b256 = compute_bytecode_root(my_bytecode);
+}
+
+fn compute_bytecode_configurables(my_bytecode: Vec<u8>, my_configurables: Vec<(u64, Vec<u8>)>) {
+    let mut my_bytecode = my_bytecode;
+    let root: b256 = compute_bytecode_root_with_configurables(my_bytecode, my_configurables);
+}
+// ANCHOR_END: compute_bytecode_root
+
+// ANCHOR: verify_contract_bytecode
+fn verify_contract(my_contract: ContractId, my_bytecode: Vec<u8>) {
+    verify_contract_bytecode(my_contract, my_bytecode);
+    // By reaching this line the contract has been verified to match the bytecode provided.
+}
+
+fn verify_contract_configurables(
+    my_contract: ContractId,
+    my_bytecode: Vec<u8>,
+    my_configurables: Vec<(u64, Vec<u8>)>,
+) {
+    let mut my_bytecode = my_bytecode;
+    verify_contract_bytecode_with_configurables(my_contract, my_bytecode, my_configurables);
+    // By reaching this line the contract has been verified to match the bytecode provided.
+}
+// ANCHOR_END: verify_contract_bytecode
+
+// ANCHOR: compute_predicate_address
+fn compute_predicate(my_bytecode: Vec<u8>) {
+    let address: Address = compute_predicate_address(my_bytecode);
+}
+
+fn compute_predicate_configurables(my_bytecode: Vec<u8>, my_configurables: Vec<(u64, Vec<u8>)>) {
+    let mut my_bytecode = my_bytecode;
+    let address: Address = compute_predicate_address_with_configurables(my_bytecode, my_configurables);
+}
+// ANCHOR_END: compute_predicate_address
+
+// ANCHOR: predicate_address_from_root
+fn predicate_address(my_root: b256) {
+    let address: Address = predicate_address_from_root(my_root);
+}
+// ANCHOR_END: predicate_address_from_root
+
+// ANCHOR: verify_predicate_address
+fn verify_predicate(my_predicate: Address, my_bytecode: Vec<u8>) {
+    verify_predicate_address(my_predicate, my_bytecode);
+    // By reaching this line the predicate bytecode matches the address provided.
+}
+
+fn verify_predicate_configurables(
+    my_predicate: Address,
+    my_bytecode: Vec<u8>,
+    my_configurables: Vec<(u64, Vec<u8>)>,
+) {
+    let mut my_bytecode = my_bytecode;
+    verify_predicate_address_with_configurables(my_predicate, my_bytecode, my_configurables);
+    // By reaching this line the predicate bytecode matches the address provided.
+}
+// ANCHOR_END: verify_predicate_address

--- a/examples/fixed_point/Forc.toml
+++ b/examples/fixed_point/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "fixed_point_examples"
+
+[dependencies]
+sway_libs = { path = "../../libs" }

--- a/examples/fixed_point/src/main.sw
+++ b/examples/fixed_point/src/main.sw
@@ -1,0 +1,60 @@
+library;
+
+// ANCHOR: import
+use sway_libs::fixed_point::*;
+// ANCHOR_END: import
+
+// ANCHOR: import_ifp
+use sway_libs::fixed_point::{ifp128::IFP128, ifp256::IFP256, ifp64::IFP64,};
+// ANCHOR_END: import_ifp
+
+// ANCHOR: import_ufp
+use sway_libs::fixed_point::{ufp128::UFP128, ufp32::UFP32, ufp64::UFP64,};
+// ANCHOR_END: import_ufp
+
+fn instantiating_ufp() {
+    // ANCHOR: instantiating_ufp
+    let mut ufp32_value = UFP32::from(0u32);
+    let mut ufp64_value = UFP64::from(0u64);
+    let mut ufp128_value = UFP128::from((0u64, 0u64));
+    // ANCHOR_END: instantiating_ufp
+}
+
+// ANCHOR: mathematical_ops
+fn add_ufp(val1: UFP64, val2: UFP64) {
+    let result: UFP64 = val1 + val2;
+}
+
+fn subtract_ufp(val1: UFP64, val2: UFP64) {
+    let result: UFP64 = val1 - val2;
+}
+
+fn multiply_ufp(val1: UFP64, val2: UFP64) {
+    let result: UFP64 = val1 * val2;
+}
+
+fn divide_ufp(val1: UFP64, val2: UFP64) {
+    let result: UFP64 = val1 / val2;
+}
+// ANCHOR_END: mathematical_ops
+
+fn exponential() {
+    // ANCHOR: exponential
+    let ten = UFP64::from_uint(10);
+    let res = UFP64::exp(ten);
+    // ANCHOR_END: exponential
+}
+
+fn square_root() {
+    // ANCHOR: square_root
+    let ufp64_169 = UFP64::from_uint(169);
+    let res = UFP64::sqrt(ufp64_169);
+    // ANCHOR_END: square_root
+}
+
+fn power() {
+    // ANCHOR: power
+    let five = UFP64::from_uint(5);
+    let res = five.pow(3u32);
+    // ANCHOR_END: power
+}

--- a/examples/harness.rs
+++ b/examples/harness.rs
@@ -1,0 +1,1 @@
+mod merkle;

--- a/examples/merkle/Forc.toml
+++ b/examples/merkle/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "merkle_examples"
+
+[dependencies]
+sway_libs = { path = "../../libs" }

--- a/examples/merkle/mod.rs
+++ b/examples/merkle/mod.rs
@@ -72,7 +72,13 @@ async fn rust_setup_example() {
 
     let result: bool = contract_instance
         .methods()
-        .verify(Bits256(merkle_root), key, Bits256(merkle_leaf), num_leaves, bits256_proof)
+        .verify(
+            Bits256(merkle_root),
+            key,
+            Bits256(merkle_leaf),
+            num_leaves,
+            bits256_proof,
+        )
         .call()
         .await
         .unwrap()

--- a/examples/merkle/mod.rs
+++ b/examples/merkle/mod.rs
@@ -1,0 +1,72 @@
+// ANCHOR: import
+use fuel_merkle::{binary::in_memory::MerkleTree, common::Bytes32};
+// ANCHOR_END: import
+use fuels::prelude::*;
+use sha2::{Digest, Sha256};
+
+// Load abi from json
+abigen!(Contract(
+    name = "MerkleExample",
+    abi = "out/release/merkle_proof_test-abi.json"
+));
+
+async fn get_contract_instance() -> (MerkleExample<WalletUnlocked>, WalletUnlocked) {
+    // Launch a local network and deploy the contract
+    let mut wallets = launch_custom_provider_and_get_wallets(
+        WalletsConfig::new(
+            Some(1),             /* Single wallet */
+            Some(1),             /* Single coin (UTXO) */
+            Some(1_000_000_000), /* Amount per coin */
+        ),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+    let wallet = wallets.pop().unwrap();
+
+    let id = Contract::load_from(
+        "./out/release/merkle_proof_test.bin",
+        LoadConfiguration::default(),
+    )
+    .unwrap()
+    .deploy(&wallet, TxPolicies::default())
+    .await
+    .unwrap();
+
+    let instance = MerkleExample::new(id.clone(), wallet.clone());
+
+    (instance, wallet)
+}
+
+fn rust_setup_example() {
+    let (contract_instance, _id) = get_contract_instance().await;
+
+    // ANCHOR: generating_a_tree
+    let mut tree = MerkleTree::new();
+    let leaves = ["A".as_bytes(), "B".as_bytes(), "C".as_bytes()].to_vec();
+    for datum in leaves.iter() {
+        let mut hasher = Sha256::new();
+        hasher.update(&datum);
+        let hash: Bytes32 = hasher.finalize().try_into().unwrap();
+        tree.push(&hash);
+    }
+    // ANCHOR_END: generating_a_tree
+
+    let key = 0;
+    let num_leaves = 3;
+
+    // ANCHOR: generating_proof
+    let mut proof = tree.prove(key).unwrap();
+    // ANCHOR_END: generating_proof
+
+    // ANCHOR: verify_proof
+    let merkle_root = proof.0;
+    let merkle_leaf = proof.1[0];
+    proof.1.remove(0);
+    contract_instance
+        .verify(key, merkle_leaf, merkle_root, num_leaves, proof.1)
+        .call()
+        .await;
+    // ANCHOR_END: verify_proof
+}

--- a/examples/merkle/src/main.sw
+++ b/examples/merkle/src/main.sw
@@ -1,8 +1,19 @@
-library;
+contract;
 
 // ANCHOR: import
 use sway_libs::merkle::binary_proof::*;
 // ANCHOR_END: import
+
+abi MerkleExample {
+    fn verify(merkle_root: b256, key: u64, leaf: b256, num_leaves: u64, proof: Vec<b256>) -> bool;
+}
+
+impl MerkleExample for Contract {
+    fn verify(merkle_root: b256, key: u64, leaf: b256, num_leaves: u64, proof: Vec<b256>) -> bool {
+        verify_proof(key, leaf, merkle_root, num_leaves, proof)
+    }
+}
+
 
 // ANCHOR: leaf_digest
 fn compute_leaf(hashed_data: b256) {

--- a/examples/merkle/src/main.sw
+++ b/examples/merkle/src/main.sw
@@ -1,0 +1,35 @@
+library;
+
+// ANCHOR: import
+use sway_libs::merkle::binary_proof::*;
+// ANCHOR_END: import
+
+// ANCHOR: leaf_digest
+fn compute_leaf(hashed_data: b256) {
+    let leaf: b256 = leaf_digest(hashed_data);
+}
+// ANCHOR_END: leaf_digest
+
+// ANCHOR: node_digest
+fn compute_node(leaf_a: b256, leaf_b: b256) {
+    let node: b256 = node_digest(leaf_a, leaf_b);
+}
+// ANCHOR_END: node_digest
+
+// ANCHOR: process_proof
+fn process(key: u64, leaf: b256, num_leaves: u64, proof: Vec<b256>) {
+    let merkle_root: b256 = process_proof(key, leaf, num_leaves, proof);
+}
+// ANCHOR_END: process_proof
+
+// ANCHOR: verify_proof
+fn verify(
+    merkle_root: b256,
+    key: u64,
+    leaf: b256,
+    num_leaves: u64,
+    proof: Vec<b256>,
+) {
+    assert(verify_proof(key, leaf, merkle_root, num_leaves, proof));
+}
+// ANCHOR_END: verify_proof

--- a/examples/merkle/src/main.sw
+++ b/examples/merkle/src/main.sw
@@ -5,15 +5,26 @@ use sway_libs::merkle::binary_proof::*;
 // ANCHOR_END: import
 
 abi MerkleExample {
-    fn verify(merkle_root: b256, key: u64, leaf: b256, num_leaves: u64, proof: Vec<b256>) -> bool;
+    fn verify(
+        merkle_root: b256,
+        key: u64,
+        leaf: b256,
+        num_leaves: u64,
+        proof: Vec<b256>,
+    ) -> bool;
 }
 
 impl MerkleExample for Contract {
-    fn verify(merkle_root: b256, key: u64, leaf: b256, num_leaves: u64, proof: Vec<b256>) -> bool {
+    fn verify(
+        merkle_root: b256,
+        key: u64,
+        leaf: b256,
+        num_leaves: u64,
+        proof: Vec<b256>,
+    ) -> bool {
         verify_proof(key, leaf, merkle_root, num_leaves, proof)
     }
 }
-
 
 // ANCHOR: leaf_digest
 fn compute_leaf(hashed_data: b256) {

--- a/examples/ownership/Forc.toml
+++ b/examples/ownership/Forc.toml
@@ -1,0 +1,9 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "ownership_examples"
+
+[dependencies]
+standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.4.1" }
+sway_libs = { path = "../../libs" }

--- a/examples/ownership/src/main.sw
+++ b/examples/ownership/src/main.sw
@@ -1,0 +1,40 @@
+library;
+
+// ANCHOR: import
+use sway_libs::ownership::*;
+use standards::src5::*;
+// ANCHOR_END: import
+
+// ANCHOR: integrate_with_src5
+use sway_libs::ownership::_owner;
+use standards::src5::{SRC5, State};
+
+impl SRC5 for Contract {
+    #[storage(read)]
+    fn owner() -> State {
+        _owner()
+    }
+}
+// ANCHOR_END: integrate_with_src5
+
+// ANCHOR: initialize
+#[storage(read, write)]
+fn my_constructor(new_owner: Identity) {
+    initialize_ownership(new_owner);
+}
+// ANCHOR_END: initialize
+
+// ANCHOR: only_owner
+#[storage(read)]
+fn only_owner_may_call() {
+    only_owner();
+    // Only the contract's owner may reach this line.
+}
+// ANCHOR_END: only_owner
+
+// ANCHOR: state
+#[storage(read)]
+fn get_owner_state() {
+    let owner: State = _owner();
+}
+// ANCHOR_END: state

--- a/examples/pausable/pausable/Forc.toml
+++ b/examples/pausable/pausable/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "pausable_example"
+
+[dependencies]
+sway_libs = { path = "../../../libs" }

--- a/examples/pausable/pausable/src/main.sw
+++ b/examples/pausable/pausable/src/main.sw
@@ -1,0 +1,46 @@
+contract;
+
+// ANCHOR: import
+use sway_libs::pausable::*;
+// ANCHOR_END: import
+
+// ANCHOR: pausable_impl
+use sway_libs::pausable::{_is_paused, _pause, _unpause, Pausable};
+
+impl Pausable for Contract {
+    #[storage(write)]
+    fn pause() {
+        _pause();
+    }
+
+    #[storage(write)]
+    fn unpause() {
+        _unpause();
+    }
+
+    #[storage(read)]
+    fn is_paused() -> bool {
+        _is_paused()
+    }
+}
+// ANCHOR_END: pausable_impl
+
+// ANCHOR: require_paused
+use sway_libs::pausable::require_paused;
+
+#[storage(read)]
+fn require_paused_state() {
+    require_paused();
+    // This comment will only ever be reached if the contract is in the paused state
+}
+// ANCHOR_END: require_paused
+
+// ANCHOR: require_not_paused
+use sway_libs::pausable::require_not_paused;
+
+#[storage(read)]
+fn require_not_paused_state() {
+    require_not_paused();
+    // This comment will only ever be reached if the contract is in the unpaused state
+}
+// ANCHOR_END: require_not_paused

--- a/examples/pausable/pausable_with_ownership/Forc.toml
+++ b/examples/pausable/pausable_with_ownership/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "pausable_with_ownership_example"
+
+[dependencies]
+sway_libs = { path = "../../../libs" }

--- a/examples/pausable/pausable_with_ownership/src/main.sw
+++ b/examples/pausable/pausable_with_ownership/src/main.sw
@@ -1,0 +1,49 @@
+contract;
+
+// ANCHOR: impl_with_ownership
+use sway_libs::{
+    ownership::{
+        initialize_ownership,
+        only_owner,
+    },
+    pausable::{
+        _is_paused,
+        _pause,
+        _unpause,
+        Pausable,
+    },
+};
+
+abi MyConstructor {
+    #[storage(read, write)]
+    fn my_constructor(new_owner: Identity);
+}
+
+impl MyConstructor for Contract {
+    #[storage(read, write)]
+    fn my_constructor(new_owner: Identity) {
+        initialize_ownership(new_owner);
+    }
+}
+
+impl Pausable for Contract {
+    #[storage(write)]
+    fn pause() {
+        // Add the `only_owner()` check to ensure only the owner may unpause this contract.
+        only_owner();
+        _pause();
+    }
+
+    #[storage(write)]
+    fn unpause() {
+        // Add the `only_owner()` check to ensure only the owner may unpause this contract.
+        only_owner();
+        _unpause();
+    }
+
+    #[storage(read)]
+    fn is_paused() -> bool {
+        _is_paused()
+    }
+}
+// ANCHOR_END: impl_with_ownership

--- a/examples/queue/Forc.toml
+++ b/examples/queue/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "queue_examples"
+
+[dependencies]
+sway_libs = { path = "../../libs" }

--- a/examples/queue/src/main.sw
+++ b/examples/queue/src/main.sw
@@ -1,0 +1,51 @@
+library;
+
+// ANCHOR: import
+use sway_libs::queue::*;
+// ANCHOR_END: import
+
+fn instantiate() {
+    // ANCHOR: instantiate
+    let mut queue = Queue::new();
+    // ANCHOR_END: instantiate
+}
+
+fn enqueue() {
+    let mut queue = Queue::new();
+
+    // ANCHOR: enqueue
+    // Enqueue an element to the queue
+    queue.enqueue(10u8);
+    // ANCHOR_END: enqueue
+}
+
+fn dequeue() {
+    let mut queue = Queue::new();
+    queue.enqueue(10u8);
+
+    // ANCHOR: dequeue
+    // Dequeue the first element and unwrap the value
+    let first_item = queue.dequeue().unwrap();
+    // ANCHOR_END: dequeue
+}
+
+fn peek() {
+    let mut queue = Queue::new();
+    queue.enqueue(10u8);
+
+    // ANCHOR: peek
+    // Peek at the head of the queue
+    let head_item = queue.peek();
+    // ANCHOR_END: peek
+}
+
+fn length() {
+    let mut queue = Queue::new();
+    // ANCHOR: length
+    // Checks if queue is empty (returns True or False)
+    let is_queue_empty = queue.is_empty();
+
+    // Returns length of queue
+    let queue_length = queue.len();
+    // ANCHOR_END: length
+}

--- a/examples/reentrancy/Forc.toml
+++ b/examples/reentrancy/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "reentrancy_examples"
+
+[dependencies]
+sway_libs = { path = "../../libs" }

--- a/examples/reentrancy/src/main.sw
+++ b/examples/reentrancy/src/main.sw
@@ -1,0 +1,29 @@
+contract;
+
+// ANCHOR: import
+use sway_libs::reentrancy::*;
+// ANCHOR_END: import
+
+// ANCHOR: reentrancy_guard
+use sway_libs::reentrancy::reentrancy_guard;
+
+abi MyContract {
+    fn my_non_reentrant_function();
+}
+
+impl MyContract for Contract {
+    fn my_non_reentrant_function() {
+        reentrancy_guard();
+
+        // my code here
+    }
+}
+// ANCHOR_END: reentrancy_guard
+
+// ANCHOR: is_reentrant
+use sway_libs::reentrancy::is_reentrant;
+
+fn check_if_reentrant() {
+    assert(!is_reentrant());
+}
+// ANCHOR_END: is_reentrant

--- a/examples/signed_integers/Forc.toml
+++ b/examples/signed_integers/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "signed_integers_examples"
+
+[dependencies]
+sway_libs = { path = "../../libs" }

--- a/examples/signed_integers/src/main.sw
+++ b/examples/signed_integers/src/main.sw
@@ -1,0 +1,33 @@
+library;
+
+// ANCHOR: import
+use sway_libs::signed_integers::*;
+// ANCHOR_END: import
+
+// ANCHOR: import_8
+use sway_libs::signed_integers::i8::I8;
+// ANCHOR_END: import
+
+fn initialize() {
+    // ANCHOR: initialize
+    let mut i8_value = I8::new();
+    // ANCHOR_END: initialize
+}
+
+// ANCHOR: mathematical_ops
+fn add_signed_int(val1: I8, val2: I8) {
+    let result: I8 = val1 + val2;
+}
+
+fn subtract_signed_int(val1: I8, val2: I8) {
+    let result: I8 = val1 - val2;
+}
+
+fn multiply_signed_int(val1: I8, val2: I8) {
+    let result: I8 = val1 * val2;
+}
+
+fn divide_signed_int(val1: I8, val2: I8) {
+    let result: I8 = val1 / val2;
+}
+// ANCHOR_END: mathematical_ops


### PR DESCRIPTION
## Type of change

<!--Delete points that do not apply-->

- Improvement (refactoring, restructuring repository, cleaning tech debt, ...)
- Documentation

## Changes

The following changes have been made:

- Creates example projects for each library in an `examples/` folder
- Updates Sway-Libs book to use example projects over inline docs
- Adds examples to CI

## Related Issues

<!--Delete everything after the "#" symbol and replace it with a number. No spaces between hash and number-->

Closes #228 
