### PR TITLE
Bump to forc v0.56.0

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,0 @@
-# Syntax highlighting of sway files as rust
-*.sw linguist-language=Sway

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
 # Syntax highlighting of sway files as rust
-*.sw linguist-language=Rust
+*.sw linguist-language=Sway

--- a/docs/book/src/asset/metadata.md
+++ b/docs/book/src/asset/metadata.md
@@ -68,7 +68,12 @@ To use the `StorageMetadata` type, simply get the stored metadata with the assoc
 The `Metadata` type defined by the [SRC-7](https://github.com/FuelLabs/sway-standards/blob/master/SRCs/src-7.md) standard can be one of 4 states:
 
 ```sway
-{{#include ../../../../examples/asset/metadata_docs/src/main.sw:metadata_enum}}
+pub enum Metadata {
+    B256: b256,
+    Bytes: Bytes,
+    Int: u64,
+    String: String,
+}
 ```
 
 The Asset Library enables the following functionality for the `Metadata` type:

--- a/docs/book/src/reentrancy/index.md
+++ b/docs/book/src/reentrancy/index.md
@@ -35,7 +35,7 @@ Once imported, using the Reentrancy Library can be done by calling one of the tw
 Once imported, using the Reentrancy Guard Library can be used by calling the `reentrancy_guard()` in your Sway Smart Contract. The following shows a Sway Smart Contract that applies the Reentrancy Guard Library:
 
 ```sway
-{{#include ../../../../examples/reentrancy/src/main.sw:reentrancy}}
+{{#include ../../../../examples/reentrancy/src/main.sw:reentrancy_guard}}
 ```
 
 ### Checking Reentrancy Status

--- a/docs/book/src/signed_integers/index.md
+++ b/docs/book/src/signed_integers/index.md
@@ -19,7 +19,7 @@ To import the Signed Integer Number Library to your Sway Smart Contract, add the
 In order to use the any of the Signed Integer types, import them into your Sway project like so:
 
 ```sway
-{{#include ../../../../examples/signed_integers/src/main.sw:import_i8}}
+{{#include ../../../../examples/signed_integers/src/main.sw:import_8}}
 ```
 
 ## Basic Functionality

--- a/examples/admin/Forc.toml
+++ b/examples/admin/Forc.toml
@@ -5,5 +5,5 @@ license = "Apache-2.0"
 name = "admin_examples"
 
 [dependencies]
-standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.4.1" }
+standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.4.3" }
 sway_libs = { path = "../../libs" }

--- a/examples/asset/base_docs/Forc.toml
+++ b/examples/asset/base_docs/Forc.toml
@@ -5,5 +5,5 @@ license = "Apache-2.0"
 name = "base_docs"
 
 [dependencies]
-standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.4.1" }
+standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.4.3" }
 sway_libs = { path = "../../../libs" }

--- a/examples/asset/basic_src20/Forc.toml
+++ b/examples/asset/basic_src20/Forc.toml
@@ -5,5 +5,5 @@ license = "Apache-2.0"
 name = "basic_src20"
 
 [dependencies]
-standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.4.1" }
+standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.4.3" }
 sway_libs = { path = "../../../libs" }

--- a/examples/asset/basic_src3/Forc.toml
+++ b/examples/asset/basic_src3/Forc.toml
@@ -5,5 +5,5 @@ license = "Apache-2.0"
 name = "basic_src3"
 
 [dependencies]
-standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.4.1" }
+standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.4.3" }
 sway_libs = { path = "../../../libs" }

--- a/examples/asset/basic_src7/Forc.toml
+++ b/examples/asset/basic_src7/Forc.toml
@@ -5,5 +5,5 @@ license = "Apache-2.0"
 name = "basic_src7"
 
 [dependencies]
-standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.4.1" }
+standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.4.3" }
 sway_libs = { path = "../../../libs" }

--- a/examples/asset/metadata_docs/Forc.toml
+++ b/examples/asset/metadata_docs/Forc.toml
@@ -5,5 +5,5 @@ license = "Apache-2.0"
 name = "metadata_docs"
 
 [dependencies]
-standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.4.1" }
+standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.4.3" }
 sway_libs = { path = "../../../libs" }

--- a/examples/asset/metadata_docs/src/main.sw
+++ b/examples/asset/metadata_docs/src/main.sw
@@ -20,15 +20,6 @@ storage {
 }
 // ANCHOR_END: src7_storage
 
-// ANCHOR: metadata_enum
-pub enum Metadata {
-    B256: b256,
-    Bytes: Bytes,
-    Int: u64,
-    String: String,
-}
-// ANCHOR_END: metadata_enum
-
 // ANCHOR: as_b256
 fn b256_type(my_metadata: Metadata) {
     assert(my_metadata.is_b256());

--- a/examples/asset/setting_src20_attributes/Forc.toml
+++ b/examples/asset/setting_src20_attributes/Forc.toml
@@ -5,5 +5,5 @@ license = "Apache-2.0"
 name = "setting_src20_attributes"
 
 [dependencies]
-standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.4.1" }
+standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.4.3" }
 sway_libs = { path = "../../../libs" }

--- a/examples/asset/setting_src7_attributes/Forc.toml
+++ b/examples/asset/setting_src7_attributes/Forc.toml
@@ -5,5 +5,5 @@ license = "Apache-2.0"
 name = "setting_src7_attributes"
 
 [dependencies]
-standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.4.1" }
+standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.4.3" }
 sway_libs = { path = "../../../libs" }

--- a/examples/asset/supply_docs/Forc.toml
+++ b/examples/asset/supply_docs/Forc.toml
@@ -5,5 +5,5 @@ license = "Apache-2.0"
 name = "supply_docs"
 
 [dependencies]
-standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.4.1" }
+standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.4.3" }
 sway_libs = { path = "../../../libs" }

--- a/examples/ownership/Forc.toml
+++ b/examples/ownership/Forc.toml
@@ -5,5 +5,5 @@ license = "Apache-2.0"
 name = "ownership_examples"
 
 [dependencies]
-standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.4.1" }
+standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.4.3" }
 sway_libs = { path = "../../libs" }

--- a/examples/signed_integers/src/main.sw
+++ b/examples/signed_integers/src/main.sw
@@ -6,7 +6,7 @@ use sway_libs::signed_integers::*;
 
 // ANCHOR: import_8
 use sway_libs::signed_integers::i8::I8;
-// ANCHOR_END: import
+// ANCHOR_END: import_8
 
 fn initialize() {
     // ANCHOR: initialize

--- a/libs/Forc.toml
+++ b/libs/Forc.toml
@@ -5,4 +5,4 @@ license = "Apache-2.0"
 name = "sway_libs"
 
 [dependencies]
-standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.4.1" }
+standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.4.3" }

--- a/libs/src/asset/supply.sw
+++ b/libs/src/asset/supply.sw
@@ -7,10 +7,7 @@ use std::{
         burn,
         mint_to,
     },
-    call_frames::{
-        contract_id,
-        msg_asset_id,
-    },
+    call_frames::msg_asset_id,
     context::this_balance,
     hash::{
         Hash,
@@ -68,7 +65,7 @@ pub fn _mint(
     sub_id: SubId,
     amount: u64,
 ) -> AssetId {
-    let asset_id = AssetId::new(contract_id(), sub_id);
+    let asset_id = AssetId::new(ContractId::this(), sub_id);
     let supply = _total_supply(total_supply_key, asset_id);
 
     // Only increment the number of assets minted by this contract if it hasn't been minted before.
@@ -127,7 +124,7 @@ pub fn _burn(
     sub_id: SubId,
     amount: u64,
 ) {
-    let asset_id = AssetId::new(contract_id(), sub_id);
+    let asset_id = AssetId::new(ContractId::this(), sub_id);
 
     require(this_balance(asset_id) >= amount, BurnError::NotEnoughCoins);
 

--- a/libs/src/reentrancy.sw
+++ b/libs/src/reentrancy.sw
@@ -55,7 +55,7 @@ pub fn reentrancy_guard() {
 /// ```
 pub fn is_reentrant() -> bool {
     // Get our current contract ID
-    let this_id = contract_id();
+    let this_id = ContractId::this();
 
     // Reentrancy cannot occur in an external context. If not detected by the time we get to the
     // bottom of the call_frame stack, then no reentrancy has occured.

--- a/tests/src/admin/Forc.toml
+++ b/tests/src/admin/Forc.toml
@@ -5,5 +5,5 @@ license = "Apache-2.0"
 name = "admin_test"
 
 [dependencies]
-standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.4.1" }
+standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.4.3" }
 sway_libs = { path = "../../../libs" }

--- a/tests/src/native_asset/Forc.toml
+++ b/tests/src/native_asset/Forc.toml
@@ -5,5 +5,5 @@ license = "Apache-2.0"
 name = "native_asset_lib"
 
 [dependencies]
-standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.4.1" }
+standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.4.3" }
 sway_libs = { path = "../../../libs" }

--- a/tests/src/ownership/Forc.toml
+++ b/tests/src/ownership/Forc.toml
@@ -5,5 +5,5 @@ license = "Apache-2.0"
 name = "ownership_test"
 
 [dependencies]
-standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.4.1" }
+standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.4.3" }
 sway_libs = { path = "../../../libs" }

--- a/tests/src/reentrancy/reentrancy_attacker_contract/src/main.sw
+++ b/tests/src/reentrancy/reentrancy_attacker_contract/src/main.sw
@@ -1,6 +1,6 @@
 contract;
 
-use std::{auth::*, call_frames::contract_id, constants::ZERO_B256};
+use std::{auth::*, constants::ZERO_B256};
 
 use reentrancy_target_abi::Target;
 use reentrancy_attacker_abi::Attacker;
@@ -46,17 +46,17 @@ impl Attacker for Contract {
     }
 
     fn evil_callback_1() {
-        assert(abi(Attacker, contract_id().bits()).launch_attack(get_msg_sender_id_or_panic()));
+        assert(abi(Attacker, ContractId::this().bits()).launch_attack(get_msg_sender_id_or_panic()));
     }
 
     fn evil_callback_2() {
-        abi(Attacker, contract_id()
+        abi(Attacker, ContractId::this()
             .bits())
             .launch_thwarted_attack_1(get_msg_sender_id_or_panic());
     }
 
     fn evil_callback_3() {
-        abi(Attacker, contract_id()
+        abi(Attacker, ContractId::this()
             .bits())
             .launch_thwarted_attack_2(get_msg_sender_id_or_panic());
     }

--- a/tests/src/reentrancy/reentrancy_target_contract/src/main.sw
+++ b/tests/src/reentrancy/reentrancy_target_contract/src/main.sw
@@ -1,6 +1,6 @@
 contract;
 
-use std::{auth::*, call_frames::contract_id};
+use std::auth::*;
 use sway_libs::reentrancy::*;
 
 use reentrancy_attacker_abi::Attacker;
@@ -48,7 +48,7 @@ impl Target for Contract {
     }
 
     fn intra_contract_call() {
-        abi(Target, contract_id()
+        abi(Target, ContractId::this()
             .bits())
             .cross_function_reentrance_denied();
     }


### PR DESCRIPTION
## Type of change

<!--Delete points that do not apply-->

- Improvement (refactoring, restructuring repository, cleaning tech debt, ...)

## Changes

The following changes have been made:

- Updates CI to forc v0.56.0 and fuel-core v0.24.2
- Updates libs to forc v0.56.0
- Updates examples to forc v0.56.0
- Updates tests to forc v0.56.0

## Notes

- Dependent on https://github.com/FuelLabs/sway-standards/pull/83
