### PR TITLE
Hotfix: Fix CI to forc v0.56.0 and tests to fuels v0.57.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,8 @@ env:
   CARGO_TERM_COLOR: always
   REGISTRY: ghcr.io
   RUST_VERSION: 1.75.0
-  FORC_VERSION: 0.53.0
-  CORE_VERSION: 0.23.0
+  FORC_VERSION: 0.56.0
+  CORE_VERSION: 0.24.2
 
 jobs:
   build-sway-lib:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   REGISTRY: ghcr.io
-  RUST_VERSION: 1.75.0
+  RUST_VERSION: 1.77.0
   FORC_VERSION: 0.56.0
   CORE_VERSION: 0.24.2
 

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -8,7 +8,7 @@ on:
       - v*
 
 env:
-  RUST_VERSION: 1.75.0
+  RUST_VERSION: 1.77.0
   FORC_VERSION: 0.56.0
   CORE_VERSION: 0.24.2
 

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -9,8 +9,8 @@ on:
 
 env:
   RUST_VERSION: 1.75.0
-  FORC_VERSION: 0.53.0
-  CORE_VERSION: 0.23.0
+  FORC_VERSION: 0.56.0
+  CORE_VERSION: 0.24.2
 
 jobs:
   deploy-contributing:

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 [dependencies]
 fuel-merkle = { version = "0.33.0" }
 sha2 = { version = "0.10" }
-fuels = { version = "0.53.0", features = ["fuel-core-lib"] }
+fuels = { version = "0.58.0", features = ["fuel-core-lib"] }
 tokio = { version = "1.12", features = ["rt", "macros"] }
 
 [[test]]

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -7,8 +7,7 @@ license = "Apache-2.0"
 
 [dependencies]
 fuel-merkle = { version = "0.33.0" }
-fuels = { version = "0.53.0", features = ["fuel-core-lib"] }
-fuels-core = { version = "0.53.0" }
+fuels = { version = "0.58.0", features = ["fuel-core-lib"] }
 sha2 = { version = "0.10" }
 tokio = { version = "1.12", features = ["rt", "macros"] }
 rand = { version = "0.8.5", default-features = false, features = ["std_rng", "getrandom"] }

--- a/tests/src/bytecode/tests/utils/mod.rs
+++ b/tests/src/bytecode/tests/utils/mod.rs
@@ -278,7 +278,7 @@ pub mod abi_calls {
 }
 
 pub mod test_helpers {
-    
+
     use super::*;
 
     pub fn defaults() -> (u64, u64, u8) {
@@ -373,7 +373,9 @@ pub mod test_helpers {
         wallet: WalletUnlocked,
         config_value: u64,
     ) -> (SimpleContract<WalletUnlocked>, ContractId) {
-        let configurables = SimpleContractConfigurables::default().with_VALUE(config_value).unwrap();
+        let configurables = SimpleContractConfigurables::default()
+            .with_VALUE(config_value)
+            .unwrap();
 
         let id = Contract::load_from(
             SIMPLE_CONTRACT_BYTECODE_PATH,
@@ -406,7 +408,9 @@ pub mod test_helpers {
         let configurables = SimpleContractConfigurables::new(EncoderConfig {
             max_tokens: 10_000_000,
             ..Default::default()
-        }).with_VALUE(config_value).unwrap();
+        })
+        .with_VALUE(config_value)
+        .unwrap();
 
         // Fetch the bytecode root
         let root = Contract::load_from(
@@ -457,15 +461,15 @@ pub mod test_helpers {
         config_enum: SimpleEnum,
     ) -> (ComplexContract<WalletUnlocked>, ContractId) {
         let configurables = ComplexContractConfigurables::new(EncoderConfig {
-                max_tokens: 10_000_000,
-                ..Default::default()
-            })
-            .with_VALUE(config_value)
-            .unwrap()
-            .with_STRUCT(config_struct)
-            .unwrap()
-            .with_ENUM(config_enum)
-            .unwrap();
+            max_tokens: 10_000_000,
+            ..Default::default()
+        })
+        .with_VALUE(config_value)
+        .unwrap()
+        .with_STRUCT(config_struct)
+        .unwrap()
+        .with_ENUM(config_enum)
+        .unwrap();
 
         let id = Contract::load_from(
             COMPLEX_CONTRACT_BYTECODE_PATH,
@@ -499,15 +503,15 @@ pub mod test_helpers {
         config_enum: SimpleEnum,
     ) -> Bits256 {
         let configurables = ComplexContractConfigurables::new(EncoderConfig {
-                max_tokens: 10_000_000,
-                ..Default::default()
-            })
-            .with_VALUE(config_value)
-            .unwrap()
-            .with_STRUCT(config_struct)
-            .unwrap()
-            .with_ENUM(config_enum)
-            .unwrap();
+            max_tokens: 10_000_000,
+            ..Default::default()
+        })
+        .with_VALUE(config_value)
+        .unwrap()
+        .with_STRUCT(config_struct)
+        .unwrap()
+        .with_ENUM(config_enum)
+        .unwrap();
 
         // Fetch the bytecode root
         let root = Contract::load_from(
@@ -526,7 +530,9 @@ pub mod test_helpers {
         config_value: u64,
     ) -> Predicate {
         let provider = wallet.try_provider().unwrap();
-        let predicate_data = SimplePredicateEncoder::default().encode_data(config_value).unwrap();
+        let predicate_data = SimplePredicateEncoder::default()
+            .encode_data(config_value)
+            .unwrap();
         let result_instance = Predicate::from_code(bytecode)
             .with_provider(provider.clone())
             .with_data(predicate_data);
@@ -582,8 +588,12 @@ pub mod test_helpers {
         config_value: u64,
     ) -> Predicate {
         let provider = wallet.try_provider().unwrap();
-        let predicate_data = SimplePredicateEncoder::default().encode_data(config_value).unwrap();
-        let configurables = SimplePredicateConfigurables::default().with_VALUE(config_value).unwrap();
+        let predicate_data = SimplePredicateEncoder::default()
+            .encode_data(config_value)
+            .unwrap();
+        let configurables = SimplePredicateConfigurables::default()
+            .with_VALUE(config_value)
+            .unwrap();
         let result_instance = Predicate::load_from(PREDICATE_BYTECODE_PATH)
             .unwrap()
             .with_provider(provider.clone())
@@ -627,8 +637,12 @@ pub mod test_helpers {
         let predicate_bytecode = predicate_bytecode();
 
         let provider = wallet.try_provider().unwrap();
-        let predicate_data = SimplePredicateEncoder::default().encode_data(config_value).unwrap();
-        let configurables = SimplePredicateConfigurables::default().with_VALUE(config_value).unwrap();
+        let predicate_data = SimplePredicateEncoder::default()
+            .encode_data(config_value)
+            .unwrap();
+        let configurables = SimplePredicateConfigurables::default()
+            .with_VALUE(config_value)
+            .unwrap();
         let result_instance = Predicate::from_code(predicate_bytecode)
             .with_configurables(configurables)
             .with_provider(provider.clone())
@@ -639,7 +653,12 @@ pub mod test_helpers {
 
     pub async fn spend_predicate(predicate_instance: Predicate, wallet: WalletUnlocked) {
         predicate_instance
-            .transfer(wallet.address(), 1, *wallet.provider().unwrap().base_asset_id(), TxPolicies::default())
+            .transfer(
+                wallet.address(),
+                1,
+                *wallet.provider().unwrap().base_asset_id(),
+                TxPolicies::default(),
+            )
             .await
             .unwrap();
     }

--- a/tests/src/bytecode/tests/utils/mod.rs
+++ b/tests/src/bytecode/tests/utils/mod.rs
@@ -1,11 +1,11 @@
 use fuels::{
     accounts::predicate::Predicate,
+    core::codec::{DecoderConfig, EncoderConfig},
     prelude::*,
     programs::call_response::FuelCallResponse,
-    tx::{Bytes32, StorageSlot},
-    types::Bits256,
+    tx::StorageSlot,
+    types::{Bits256, Bytes32},
 };
-use fuels_core::codec::DecoderConfig;
 use rand::prelude::{Rng, SeedableRng, StdRng};
 use std::{fs, str::FromStr};
 
@@ -40,11 +40,11 @@ const DEFAULT_PREDICATE_BALANCE: u64 = 512;
 const HEX_STR_1: &str = "0xacbe4bfc77e55c071db31f2e37c824d75794867d88499107dc8318cb22aceea5";
 const HEX_STR_2: &str = "0x0b1af92ac5a3e8cfeafede9586a1f853a9e0258e7cdccae5e5181edac081f2c1b";
 const HEX_STR_3: &str = "0x0345c74edfb0ce0820409176d0cbc2c44eac1e5e4c7382ee7e7c38d611d9ba767";
-const SIMPLE_PREDICATE_OFFSET: u64 = 100;
-const SIMPLE_CONTRACT_OFFSET: u64 = 68;
-const COMPLEX_CONTRACT_OFFSET_1: u64 = 18268;
-const COMPLEX_CONTRACT_OFFSET_2: u64 = 18276;
-const COMPLEX_CONTRACT_OFFSET_3: u64 = 18316;
+const SIMPLE_PREDICATE_OFFSET: u64 = 116;
+const SIMPLE_CONTRACT_OFFSET: u64 = 936;
+const COMPLEX_CONTRACT_OFFSET_1: u64 = 28008;
+const COMPLEX_CONTRACT_OFFSET_2: u64 = 28016;
+const COMPLEX_CONTRACT_OFFSET_3: u64 = 28056;
 
 pub mod abi_calls {
 
@@ -95,6 +95,12 @@ pub mod abi_calls {
         bytecode: Vec<u8>,
     ) -> Bits256 {
         contract
+            .clone()
+            .with_encoder_config(EncoderConfig {
+                max_depth: 10,
+                max_tokens: 100_000,
+                max_total_enum_width: 10_000,
+            })
             .methods()
             .compute_bytecode_root(bytecode)
             .call()
@@ -109,6 +115,12 @@ pub mod abi_calls {
         configurables: Vec<(u64, Vec<u8>)>,
     ) -> Bits256 {
         contract
+            .clone()
+            .with_encoder_config(EncoderConfig {
+                max_depth: 10,
+                max_tokens: 100_000,
+                max_total_enum_width: 10_000,
+            })
             .methods()
             .compute_bytecode_root_with_configurables(bytecode, configurables)
             .call()
@@ -135,10 +147,16 @@ pub mod abi_calls {
         configurables: Vec<(u64, Vec<u8>)>,
     ) -> Vec<u8> {
         contract
+            .clone()
+            .with_encoder_config(EncoderConfig {
+                max_depth: 10,
+                max_tokens: 100_000,
+                max_total_enum_width: 10_000,
+            })
             .methods()
             .swap_configurables(bytecode, configurables)
             .with_decoder_config(DecoderConfig {
-                max_tokens: 1_000_000,
+                max_tokens: 10_000_000,
                 ..Default::default()
             })
             .call()
@@ -179,6 +197,12 @@ pub mod abi_calls {
         complex_contract_instance: ComplexContract<WalletUnlocked>,
     ) -> FuelCallResponse<()> {
         contract
+            .clone()
+            .with_encoder_config(EncoderConfig {
+                max_depth: 10,
+                max_tokens: 100_000,
+                max_total_enum_width: 10_000,
+            })
             .methods()
             .verify_contract_bytecode(contract_id, bytecode)
             .with_contracts(&[&complex_contract_instance])
@@ -211,6 +235,12 @@ pub mod abi_calls {
         complex_contract_instance: ComplexContract<WalletUnlocked>,
     ) -> FuelCallResponse<()> {
         contract
+            .clone()
+            .with_encoder_config(EncoderConfig {
+                max_depth: 10,
+                max_tokens: 100_000,
+                max_total_enum_width: 10_000,
+            })
             .methods()
             .verify_contract_bytecode_with_configurables(contract_id, bytecode, configurables)
             .with_contracts(&[&complex_contract_instance])
@@ -248,7 +278,7 @@ pub mod abi_calls {
 }
 
 pub mod test_helpers {
-
+    
     use super::*;
 
     pub fn defaults() -> (u64, u64, u8) {
@@ -343,11 +373,11 @@ pub mod test_helpers {
         wallet: WalletUnlocked,
         config_value: u64,
     ) -> (SimpleContract<WalletUnlocked>, ContractId) {
-        let configurables = SimpleContractConfigurables::new().with_VALUE(config_value);
+        let configurables = SimpleContractConfigurables::default().with_VALUE(config_value).unwrap();
 
         let id = Contract::load_from(
             SIMPLE_CONTRACT_BYTECODE_PATH,
-            LoadConfiguration::default().with_configurables(configurables.clone()),
+            LoadConfiguration::default().with_configurables(configurables),
         )
         .unwrap()
         .deploy(&wallet, TxPolicies::default())
@@ -373,7 +403,10 @@ pub mod test_helpers {
     pub async fn simple_contract_bytecode_root_with_configurables_from_file(
         config_value: u64,
     ) -> Bits256 {
-        let configurables = SimpleContractConfigurables::new().with_VALUE(config_value);
+        let configurables = SimpleContractConfigurables::new(EncoderConfig {
+            max_tokens: 10_000_000,
+            ..Default::default()
+        }).with_VALUE(config_value).unwrap();
 
         // Fetch the bytecode root
         let root = Contract::load_from(
@@ -423,10 +456,16 @@ pub mod test_helpers {
         config_struct: SimpleStruct,
         config_enum: SimpleEnum,
     ) -> (ComplexContract<WalletUnlocked>, ContractId) {
-        let configurables = ComplexContractConfigurables::new()
+        let configurables = ComplexContractConfigurables::new(EncoderConfig {
+                max_tokens: 10_000_000,
+                ..Default::default()
+            })
             .with_VALUE(config_value)
+            .unwrap()
             .with_STRUCT(config_struct)
-            .with_ENUM(config_enum);
+            .unwrap()
+            .with_ENUM(config_enum)
+            .unwrap();
 
         let id = Contract::load_from(
             COMPLEX_CONTRACT_BYTECODE_PATH,
@@ -459,10 +498,16 @@ pub mod test_helpers {
         config_struct: SimpleStruct,
         config_enum: SimpleEnum,
     ) -> Bits256 {
-        let configurables = ComplexContractConfigurables::new()
+        let configurables = ComplexContractConfigurables::new(EncoderConfig {
+                max_tokens: 10_000_000,
+                ..Default::default()
+            })
             .with_VALUE(config_value)
+            .unwrap()
             .with_STRUCT(config_struct)
-            .with_ENUM(config_enum);
+            .unwrap()
+            .with_ENUM(config_enum)
+            .unwrap();
 
         // Fetch the bytecode root
         let root = Contract::load_from(
@@ -481,7 +526,7 @@ pub mod test_helpers {
         config_value: u64,
     ) -> Predicate {
         let provider = wallet.try_provider().unwrap();
-        let predicate_data = SimplePredicateEncoder::encode_data(config_value);
+        let predicate_data = SimplePredicateEncoder::default().encode_data(config_value).unwrap();
         let result_instance = Predicate::from_code(bytecode)
             .with_provider(provider.clone())
             .with_data(predicate_data);
@@ -491,14 +536,14 @@ pub mod test_helpers {
             .transfer(
                 result_instance.address(),
                 DEFAULT_PREDICATE_BALANCE,
-                BASE_ASSET_ID,
+                *wallet.provider().unwrap().base_asset_id(),
                 TxPolicies::default(),
             )
             .await
             .unwrap();
 
         let predicate_balance = result_instance
-            .get_asset_balance(&BASE_ASSET_ID)
+            .get_asset_balance(&wallet.provider().unwrap().base_asset_id())
             .await
             .unwrap();
         assert_eq!(predicate_balance, DEFAULT_PREDICATE_BALANCE);
@@ -517,14 +562,14 @@ pub mod test_helpers {
             .transfer(
                 result_instance.address(),
                 DEFAULT_PREDICATE_BALANCE,
-                BASE_ASSET_ID,
+                *wallet.provider().unwrap().base_asset_id(),
                 TxPolicies::default(),
             )
             .await
             .unwrap();
 
         let predicate_balance = result_instance
-            .get_asset_balance(&BASE_ASSET_ID)
+            .get_asset_balance(&wallet.provider().unwrap().base_asset_id())
             .await
             .unwrap();
         assert_eq!(predicate_balance, DEFAULT_PREDICATE_BALANCE);
@@ -537,8 +582,8 @@ pub mod test_helpers {
         config_value: u64,
     ) -> Predicate {
         let provider = wallet.try_provider().unwrap();
-        let predicate_data = SimplePredicateEncoder::encode_data(config_value);
-        let configurables = SimplePredicateConfigurables::new().with_VALUE(config_value);
+        let predicate_data = SimplePredicateEncoder::default().encode_data(config_value).unwrap();
+        let configurables = SimplePredicateConfigurables::default().with_VALUE(config_value).unwrap();
         let result_instance = Predicate::load_from(PREDICATE_BYTECODE_PATH)
             .unwrap()
             .with_provider(provider.clone())
@@ -550,14 +595,14 @@ pub mod test_helpers {
             .transfer(
                 result_instance.address(),
                 DEFAULT_PREDICATE_BALANCE,
-                BASE_ASSET_ID,
+                *wallet.provider().unwrap().base_asset_id(),
                 TxPolicies::default(),
             )
             .await
             .unwrap();
 
         let predicate_balance = result_instance
-            .get_asset_balance(&BASE_ASSET_ID)
+            .get_asset_balance(&wallet.provider().unwrap().base_asset_id())
             .await
             .unwrap();
         assert_eq!(predicate_balance, DEFAULT_PREDICATE_BALANCE);
@@ -582,8 +627,8 @@ pub mod test_helpers {
         let predicate_bytecode = predicate_bytecode();
 
         let provider = wallet.try_provider().unwrap();
-        let predicate_data = SimplePredicateEncoder::encode_data(config_value);
-        let configurables = SimplePredicateConfigurables::new().with_VALUE(config_value);
+        let predicate_data = SimplePredicateEncoder::default().encode_data(config_value).unwrap();
+        let configurables = SimplePredicateConfigurables::default().with_VALUE(config_value).unwrap();
         let result_instance = Predicate::from_code(predicate_bytecode)
             .with_configurables(configurables)
             .with_provider(provider.clone())
@@ -594,7 +639,7 @@ pub mod test_helpers {
 
     pub async fn spend_predicate(predicate_instance: Predicate, wallet: WalletUnlocked) {
         predicate_instance
-            .transfer(wallet.address(), 1, BASE_ASSET_ID, TxPolicies::default())
+            .transfer(wallet.address(), 1, *wallet.provider().unwrap().base_asset_id(), TxPolicies::default())
             .await
             .unwrap();
     }

--- a/tests/src/native_asset/tests/functions/burn.rs
+++ b/tests/src/native_asset/tests/functions/burn.rs
@@ -93,7 +93,7 @@ mod success {
 mod revert {
 
     use super::*;
-    use fuels::prelude::{CallParameters, TxPolicies, BASE_ASSET_ID};
+    use fuels::{prelude::{CallParameters, TxPolicies}, types::AssetId};
 
     #[tokio::test]
     #[should_panic(expected = "NotEnoughCoins")]
@@ -146,7 +146,7 @@ mod revert {
 
         mint(&instance_1, identity2, sub_id_1, 100).await;
 
-        let call_params = CallParameters::new(50, BASE_ASSET_ID, 1_000_000);
+        let call_params = CallParameters::new(50, AssetId::zeroed(), 1_000_000);
         instance_2
             .methods()
             .burn(sub_id_1, 50)

--- a/tests/src/native_asset/tests/functions/burn.rs
+++ b/tests/src/native_asset/tests/functions/burn.rs
@@ -93,7 +93,10 @@ mod success {
 mod revert {
 
     use super::*;
-    use fuels::{prelude::{CallParameters, TxPolicies}, types::AssetId};
+    use fuels::{
+        prelude::{CallParameters, TxPolicies},
+        types::AssetId,
+    };
 
     #[tokio::test]
     #[should_panic(expected = "NotEnoughCoins")]

--- a/tests/src/native_asset/tests/functions/decimals.rs
+++ b/tests/src/native_asset/tests/functions/decimals.rs
@@ -2,7 +2,7 @@ use crate::native_asset::tests::utils::{
     interface::{decimals, set_decimals},
     setup::{defaults, get_asset_id, setup},
 };
-use fuels::tx::Bytes32;
+use fuels::types::Bytes32;
 
 mod success {
 

--- a/tests/src/native_asset/tests/functions/metadata.rs
+++ b/tests/src/native_asset/tests/functions/metadata.rs
@@ -2,7 +2,7 @@ use crate::native_asset::tests::utils::{
     interface::{metadata, set_metadata},
     setup::{defaults, get_asset_id, setup, Metadata},
 };
-use fuels::{tx::Bytes32, types::Bytes};
+use fuels::types::{Bytes, Bytes32};
 
 mod success {
 

--- a/tests/src/native_asset/tests/functions/name.rs
+++ b/tests/src/native_asset/tests/functions/name.rs
@@ -2,7 +2,7 @@ use crate::native_asset::tests::utils::{
     interface::{name, set_name},
     setup::{defaults, get_asset_id, setup},
 };
-use fuels::tx::Bytes32;
+use fuels::types::Bytes32;
 
 mod success {
 

--- a/tests/src/native_asset/tests/functions/set_decimals.rs
+++ b/tests/src/native_asset/tests/functions/set_decimals.rs
@@ -2,7 +2,7 @@ use crate::native_asset::tests::utils::{
     interface::{decimals, set_decimals},
     setup::{defaults, get_asset_id, setup},
 };
-use fuels::tx::Bytes32;
+use fuels::types::Bytes32;
 
 mod success {
 

--- a/tests/src/native_asset/tests/functions/set_metadata.rs
+++ b/tests/src/native_asset/tests/functions/set_metadata.rs
@@ -2,7 +2,7 @@ use crate::native_asset::tests::utils::{
     interface::{metadata, set_metadata},
     setup::{defaults, get_asset_id, setup, Metadata},
 };
-use fuels::{tx::Bytes32, types::Bytes};
+use fuels::types::{Bytes, Bytes32};
 
 mod success {
 

--- a/tests/src/native_asset/tests/functions/set_name.rs
+++ b/tests/src/native_asset/tests/functions/set_name.rs
@@ -2,7 +2,7 @@ use crate::native_asset::tests::utils::{
     interface::{name, set_name},
     setup::{defaults, get_asset_id, setup},
 };
-use fuels::tx::Bytes32;
+use fuels::types::Bytes32;
 
 mod success {
 

--- a/tests/src/native_asset/tests/functions/set_symbol.rs
+++ b/tests/src/native_asset/tests/functions/set_symbol.rs
@@ -2,7 +2,7 @@ use crate::native_asset::tests::utils::{
     interface::{set_symbol, symbol},
     setup::{defaults, get_asset_id, setup},
 };
-use fuels::tx::Bytes32;
+use fuels::types::Bytes32;
 
 mod success {
 

--- a/tests/src/native_asset/tests/functions/symbol.rs
+++ b/tests/src/native_asset/tests/functions/symbol.rs
@@ -2,7 +2,7 @@ use crate::native_asset::tests::utils::{
     interface::{set_symbol, symbol},
     setup::{defaults, get_asset_id, setup},
 };
-use fuels::tx::Bytes32;
+use fuels::types::Bytes32;
 
 mod success {
 

--- a/tests/src/native_asset/tests/functions/total_supply.rs
+++ b/tests/src/native_asset/tests/functions/total_supply.rs
@@ -2,7 +2,7 @@ use crate::native_asset::tests::utils::{
     interface::{burn, mint, total_supply},
     setup::{defaults, get_asset_id, setup},
 };
-use fuels::{tx::Bytes32, types::Bits256};
+use fuels::types::{Bits256, Bytes32};
 
 mod success {
 

--- a/tests/src/native_asset/tests/utils/setup.rs
+++ b/tests/src/native_asset/tests/utils/setup.rs
@@ -2,10 +2,9 @@ use fuels::{
     accounts::ViewOnlyAccount,
     prelude::{
         abigen, launch_custom_provider_and_get_wallets, AssetConfig, Contract, ContractId,
-        LoadConfiguration, TxPolicies, WalletUnlocked, WalletsConfig, BASE_ASSET_ID,
+        LoadConfiguration, TxPolicies, WalletUnlocked, WalletsConfig,
     },
-    tx::Bytes32,
-    types::{Address, AssetId, Bits256, Identity},
+    types::{Address, AssetId, Bits256, Bytes32, Identity},
 };
 use sha2::{Digest, Sha256};
 
@@ -51,12 +50,12 @@ pub(crate) async fn setup() -> (
     let coin_amount = 100_000_000;
     let number_of_wallets = 2;
 
-    let base_asset = AssetConfig {
-        id: BASE_ASSET_ID,
+    let asset_config = AssetConfig {
+        id: AssetId::zeroed(),
         num_coins: number_of_coins,
         coin_amount,
     };
-    let assets = vec![base_asset];
+    let assets = vec![asset_config];
 
     let wallet_config = WalletsConfig::new_multiple_assets(number_of_wallets, assets);
     let mut wallets = launch_custom_provider_and_get_wallets(wallet_config, None, None)

--- a/tests/src/reentrancy/reentrancy_attacker_abi/src/main.sw
+++ b/tests/src/reentrancy/reentrancy_attacker_abi/src/main.sw
@@ -7,7 +7,7 @@ abi Attacker {
     #[storage(write)]
     fn launch_thwarted_attack_3(target: ContractId, helper: ContractId);
     fn innocent_call(target: ContractId);
-    fn evil_callback_1();
+    fn evil_callback_1() -> bool;
     fn evil_callback_2();
     fn evil_callback_3();
     #[storage(read)]

--- a/tests/src/reentrancy/reentrancy_attacker_contract/src/main.sw
+++ b/tests/src/reentrancy/reentrancy_attacker_contract/src/main.sw
@@ -45,8 +45,8 @@ impl Attacker for Contract {
         abi(Target, target.bits()).guarded_function_is_callable();
     }
 
-    fn evil_callback_1() {
-        assert(abi(Attacker, ContractId::this().bits()).launch_attack(get_msg_sender_id_or_panic()));
+    fn evil_callback_1() -> bool {
+        abi(Attacker, ContractId::this().bits()).launch_attack(get_msg_sender_id_or_panic())
     }
 
     fn evil_callback_2() {

--- a/tests/src/reentrancy/reentrancy_target_contract/src/main.sw
+++ b/tests/src/reentrancy/reentrancy_target_contract/src/main.sw
@@ -22,8 +22,7 @@ impl Target for Contract {
             // this call transfers control to the attacker contract, allowing it to execute arbitrary code.
             abi(Attacker, get_msg_sender_id_or_panic()
                 .bits())
-                .evil_callback_1();
-            false
+                .evil_callback_1()
         }
     }
 


### PR DESCRIPTION
## Type of change

<!--Delete points that do not apply-->

- Improvement (refactoring, restructuring repository, cleaning tech debt, ...)

## Changes

The following changes have been made:

- Updated CI to correct forc v0.56.0 and fuel-core v0.24.2 versions
- Updated tests to fuels v0.57.0

## Notes

- It is unclear what happened in https://github.com/FuelLabs/sway-libs/pull/239 and where these changes went. I redid the updates. Any breaking changes to the sway libraries themselves occurred in https://github.com/FuelLabs/sway-libs/pull/239 so these are just updates to tests.
