### PR TITLE
Update to forc v0.60.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ env:
   REGISTRY: ghcr.io
   RUST_VERSION: 1.77.0
   FORC_VERSION: 0.60.0
-  CORE_VERSION: 0.26.20
+  CORE_VERSION: 0.26.0
 
 jobs:
   build-sway-lib:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,8 @@ env:
   CARGO_TERM_COLOR: always
   REGISTRY: ghcr.io
   RUST_VERSION: 1.77.0
-  FORC_VERSION: 0.56.0
-  CORE_VERSION: 0.24.2
+  FORC_VERSION: 0.60.0
+  CORE_VERSION: 0.26.20
 
 jobs:
   build-sway-lib:

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -9,8 +9,8 @@ on:
 
 env:
   RUST_VERSION: 1.77.0
-  FORC_VERSION: 0.56.0
-  CORE_VERSION: 0.24.2
+  FORC_VERSION: 0.60.0
+  CORE_VERSION: 0.26.0
 
 jobs:
   deploy-contributing:

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ forc test && cargo test
 Any instructions related to using a specific library should be found within the README.md of that library.
 
 > **NOTE:**
-> All projects currently use `forc v0.60.0`, `fuels-rs v0.58.0` and `fuel-core 0.26.0`.
+> All projects currently use `forc v0.60.0`, `fuels-rs v0.62.0` and `fuel-core 0.26.0`.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
     <a href="https://github.com/FuelLabs/sway-libs/actions/workflows/ci.yml" alt="CI">
         <img src="https://github.com/FuelLabs/sway-libs/actions/workflows/ci.yml/badge.svg" />
     </a>
-    <a href="https://crates.io/crates/forc/0.49.1" alt="forc">
-        <img src="https://img.shields.io/badge/forc-v0.49.1-orange" />
+    <a href="https://crates.io/crates/forc/0.60.0" alt="forc">
+        <img src="https://img.shields.io/badge/forc-v0.60.0-orange" />
     </a>
     <a href="./LICENSE" alt="forc">
         <img src="https://img.shields.io/github/license/FuelLabs/sway-libs" />
@@ -115,7 +115,7 @@ forc test && cargo test
 Any instructions related to using a specific library should be found within the README.md of that library.
 
 > **NOTE:**
-> All projects currently use `forc v0.53.0`, `fuels-rs v0.53.0` and `fuel-core 0.23.0`.
+> All projects currently use `forc v0.60.0`, `fuels-rs v0.58.0` and `fuel-core 0.26.0`.
 
 ## Contributing
 

--- a/docs/book/src/getting_started/index.md
+++ b/docs/book/src/getting_started/index.md
@@ -38,7 +38,7 @@ use sway_libs::ownership::only_owner;
 ```
 
 > **NOTE:**
-> All projects currently use `forc v0.50.0`, `fuels-rs v0.53.0` and `fuel-core 0.22.0`.
+> All projects currently use `forc v0.60.0`, `fuels-rs v0.62.0` and `fuel-core 0.26.0`.
 
 ## Using Sway Libs
 

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 [dependencies]
 fuel-merkle = { version = "0.49.0" }
 sha2 = { version = "0.10" }
-fuels = { version = "0.58.0", features = ["fuel-core-lib"] }
+fuels = { version = "0.62.0", features = ["fuel-core-lib"] }
 tokio = { version = "1.12", features = ["rt", "macros"] }
 
 [[test]]

--- a/examples/admin/Forc.toml
+++ b/examples/admin/Forc.toml
@@ -5,5 +5,5 @@ license = "Apache-2.0"
 name = "admin_examples"
 
 [dependencies]
-standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.4.3" }
+standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.5.0" }
 sway_libs = { path = "../../libs" }

--- a/examples/asset/base_docs/Forc.toml
+++ b/examples/asset/base_docs/Forc.toml
@@ -5,5 +5,5 @@ license = "Apache-2.0"
 name = "base_docs"
 
 [dependencies]
-standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.4.3" }
+standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.5.0" }
 sway_libs = { path = "../../../libs" }

--- a/examples/asset/basic_src20/Forc.toml
+++ b/examples/asset/basic_src20/Forc.toml
@@ -5,5 +5,5 @@ license = "Apache-2.0"
 name = "basic_src20"
 
 [dependencies]
-standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.4.3" }
+standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.5.0" }
 sway_libs = { path = "../../../libs" }

--- a/examples/asset/basic_src3/Forc.toml
+++ b/examples/asset/basic_src3/Forc.toml
@@ -5,5 +5,5 @@ license = "Apache-2.0"
 name = "basic_src3"
 
 [dependencies]
-standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.4.3" }
+standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.5.0" }
 sway_libs = { path = "../../../libs" }

--- a/examples/asset/basic_src7/Forc.toml
+++ b/examples/asset/basic_src7/Forc.toml
@@ -5,5 +5,5 @@ license = "Apache-2.0"
 name = "basic_src7"
 
 [dependencies]
-standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.4.3" }
+standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.5.0" }
 sway_libs = { path = "../../../libs" }

--- a/examples/asset/metadata_docs/Forc.toml
+++ b/examples/asset/metadata_docs/Forc.toml
@@ -5,5 +5,5 @@ license = "Apache-2.0"
 name = "metadata_docs"
 
 [dependencies]
-standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.4.3" }
+standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.5.0" }
 sway_libs = { path = "../../../libs" }

--- a/examples/asset/setting_src20_attributes/Forc.toml
+++ b/examples/asset/setting_src20_attributes/Forc.toml
@@ -5,5 +5,5 @@ license = "Apache-2.0"
 name = "setting_src20_attributes"
 
 [dependencies]
-standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.4.3" }
+standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.5.0" }
 sway_libs = { path = "../../../libs" }

--- a/examples/asset/setting_src7_attributes/Forc.toml
+++ b/examples/asset/setting_src7_attributes/Forc.toml
@@ -5,5 +5,5 @@ license = "Apache-2.0"
 name = "setting_src7_attributes"
 
 [dependencies]
-standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.4.3" }
+standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.5.0" }
 sway_libs = { path = "../../../libs" }

--- a/examples/asset/supply_docs/Forc.toml
+++ b/examples/asset/supply_docs/Forc.toml
@@ -5,5 +5,5 @@ license = "Apache-2.0"
 name = "supply_docs"
 
 [dependencies]
-standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.4.3" }
+standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.5.0" }
 sway_libs = { path = "../../../libs" }

--- a/examples/merkle/mod.rs
+++ b/examples/merkle/mod.rs
@@ -1,5 +1,5 @@
 // ANCHOR: import
-use fuel_merkle::{binary::in_memory::MerkleTree, common::Bytes32};
+use fuel_merkle::binary::in_memory::MerkleTree;
 // ANCHOR_END: import
 use fuels::{prelude::*, types::Bits256};
 use sha2::{Digest, Sha256};

--- a/examples/ownership/Forc.toml
+++ b/examples/ownership/Forc.toml
@@ -5,5 +5,5 @@ license = "Apache-2.0"
 name = "ownership_examples"
 
 [dependencies]
-standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.4.3" }
+standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.5.0" }
 sway_libs = { path = "../../libs" }

--- a/libs/Forc.toml
+++ b/libs/Forc.toml
@@ -5,4 +5,4 @@ license = "Apache-2.0"
 name = "sway_libs"
 
 [dependencies]
-standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.4.3" }
+standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.5.0" }

--- a/libs/src/asset/metadata.sw
+++ b/libs/src/asset/metadata.sw
@@ -349,7 +349,7 @@ impl Metadata {
     /// # Examples
     ///
     /// ```sway
-    /// use std::{constants::ZERO_B256, string::String};
+    /// use std::string::String;
     /// use sway_libs::asset::metadata::*;
     /// use standards::src7::{SRC7, Metadata};
     ///
@@ -358,7 +358,7 @@ impl Metadata {
     ///     let metadata = metadata_abi.metadata(asset, key);
     ///
     ///     let val = metadata.unwrap().as_b256();
-    ///     assert(val != ZERO_B256);
+    ///     assert(val != b256::zero());
     /// }
     /// ```
     pub fn as_b256(self) -> Option<b256> {

--- a/libs/src/asset/supply.sw
+++ b/libs/src/asset/supply.sw
@@ -44,7 +44,7 @@ use std::{
 ///
 /// ```sway
 /// use sway_libs::asset::supply::_mint;
-/// use std::{constants::ZERO_B256, context::balance_of};
+/// use std::context::balance_of;
 ///
 /// storage {
 ///     total_assets: u64 = 0,
@@ -52,8 +52,8 @@ use std::{
 /// }
 ///
 /// fn foo(recipient: Identity) {
-///     let recipient = Identity::ContractId(ContractId::from(ZERO_B256));
-///     let asset_id = _mint(storage.total_assets, storage.total_supply, recipient, ZERO_B256, 100);
+///     let recipient = Identity::ContractId(ContractId::zero());
+///     let asset_id = _mint(storage.total_assets, storage.total_supply, recipient, SubId::zero(), 100);
 ///     assert(balance_of(recipient.as_contract_id(), asset_id), 100);
 /// }
 /// ```
@@ -106,7 +106,7 @@ pub fn _mint(
 ///
 /// ```sway
 /// use sway_libs::asset::supply::_burn;
-/// use std::{call_frames::contract_id, constants::ZERO_B256, context::balance_of};
+/// use std::{call_frames::contract_id, context::balance_of};
 ///
 /// storage {
 ///     total_supply: StorageMap<AssetId, u64> = StorageMap {},
@@ -114,7 +114,7 @@ pub fn _mint(
 ///
 /// fn foo(asset_id: AssetId) {
 ///     assert(balance_of(contract_id(), asset_id) == 100);
-///     _burn(storage.total_supply, ZERO_B256, 100);
+///     _burn(storage.total_supply, SubId::zero(), 100);
 ///     assert(balance_of(contract_id(), asset_id) == 0);
 /// }
 /// ```

--- a/libs/src/bytecode.sw
+++ b/libs/src/bytecode.sw
@@ -19,12 +19,11 @@ use ::bytecode::utils::{_compute_bytecode_root, _predicate_address_from_root, _s
 /// # Examples
 ///
 /// ```sway
-/// use std::constants::ZERO_B256;
 /// use sway_libs::bytecode::compute_bytecode_root;
 ///
 /// fn foo(my_bytecode: Vec<u8>) {
 ///     let bytecode_root = compute_bytecode_root(my_bytecode);
-///     assert(bytecode_root != ZERO_B256);
+///     assert(bytecode_root != b256::zero());
 /// }
 /// ```
 pub fn compute_bytecode_root(bytecode: Vec<u8>) -> b256 {
@@ -45,13 +44,12 @@ pub fn compute_bytecode_root(bytecode: Vec<u8>) -> b256 {
 /// # Examples
 ///
 /// ```sway
-/// use std::constants::ZERO_B256;
 /// use sway_libs::bytecode::compute_bytecode_root_with_configurables;
 ///
 /// fn foo(my_bytecode: Vec<u8>, my_configurables: Vec<(u64, Vec<u8>)>) {
 ///     let mut my_bytecode = my_bytecode;
 ///     let bytecode_root = compute_bytecode_root_with_configurables(my_bytecode, my_configurables);
-///     assert(bytecode_root != ZERO_B256);
+///     assert(bytecode_root != b256::zero());
 /// }
 /// ```
 pub fn compute_bytecode_root_with_configurables(
@@ -76,12 +74,11 @@ pub fn compute_bytecode_root_with_configurables(
 /// # Examples
 ///
 /// ```sway
-/// use std::constants::ZERO_B256;
 /// use sway_libs::bytecode::compute_predicate_address;
 ///
 /// fn foo(my_bytecode: Vec<u8>) {
 ///     let predicate_address = compute_predicate_address(my_bytecode);
-///     assert(predicate_address != Address::from(ZERO_B256));
+///     assert(predicate_address != Address::zero());
 /// }
 /// ```
 pub fn compute_predicate_address(bytecode: Vec<u8>) -> Address {
@@ -103,13 +100,12 @@ pub fn compute_predicate_address(bytecode: Vec<u8>) -> Address {
 /// # Examples
 ///
 /// ```sway
-/// use std::constants::ZERO_B256;
 /// use sway_libs::bytecode::compute_predicate_address;
 ///
 /// fn foo(my_bytecode: Vec<u8>, my_configurables: Vec<(u64, Vec<u8>)>) {
 ///     let mut my_bytecode = my_bytecode;
 ///     let predicate_address = compute_predicate_address(my_bytecode, my_configurables);
-///     assert(predicate_address != Address::from(ZERO_B256));
+///     assert(predicate_address != Address::zero());
 /// }
 /// ```
 pub fn compute_predicate_address_with_configurables(
@@ -135,12 +131,11 @@ pub fn compute_predicate_address_with_configurables(
 /// # Examples
 ///
 /// ```sway
-/// use std::constants::ZERO_B256;
 /// use sway_libs::bytecode::predicate_address_from_root;
 ///
 /// fn foo(predicate_bytecode_root: b256) {
 ///     let predicate_address = predicate_address_from_root(predicate_bytecode_root);
-///     assert(predicate_address != Address::from(ZERO_B256));
+///     assert(predicate_address != Address::zero());
 /// }
 /// ```
 pub fn predicate_address_from_root(bytecode_root: b256) -> Address {

--- a/libs/src/fixed_point/ifp128.sw
+++ b/libs/src/fixed_point/ifp128.sw
@@ -10,9 +10,9 @@ use ::fixed_point::ufp64::UFP64;
 /// Represented by an underlying `UFP64` number and a boolean.
 pub struct IFP128 {
     /// The underlying value representing the `IFP128` type.
-    pub underlying: UFP64,
+    underlying: UFP64,
     /// The underlying boolean representing a negative value for the `IFP128` type.
-    pub non_negative: bool,
+    non_negative: bool,
 }
 
 impl From<UFP64> for IFP128 {
@@ -59,7 +59,7 @@ impl IFP128 {
     ///
     /// fn foo() {
     ///     let ifp128 = IFP128::max();
-    ///     assert(ifp128.underlying == UFP64::max());
+    ///     assert(ifp128.underlying() == UFP64::max());
     /// }
     /// ```
     pub fn max() -> Self {
@@ -79,7 +79,7 @@ impl IFP128 {
     ///
     /// fn foo() {
     ///     let ifp128 = IFP128::min();
-    ///     assert(ifp128.underlying == UFP64::min());
+    ///     assert(ifp128.underlying() == UFP64::min());
     /// }
     /// ```
     pub fn min() -> Self {
@@ -102,7 +102,7 @@ impl IFP128 {
     ///
     /// fn foo() {
     ///     let ifp128 = IFP128::zero();
-    ///     assert(ifp128.underlying == UFP64::zero());
+    ///     assert(ifp128.underlying() == UFP64::zero());
     /// }
     /// ```
     pub fn zero() -> Self {
@@ -122,9 +122,9 @@ impl IFP128 {
     ///
     /// fn foo() {
     ///     let ifp128 = IFP128::zero();
-    ///     assert(ifp128.non_negative);
+    ///     assert(ifp128.non_negative());
     ///     let reverse = ifp128.sign_inverse();
-    ///     assert(!reverse.non_negative);
+    ///     assert(!reverse.non_negative());
     /// }
     /// ```
     pub fn sign_reverse(self) -> Self {
@@ -132,6 +132,66 @@ impl IFP128 {
             underlying: self.underlying,
             non_negative: !self.non_negative,
         }
+    }
+
+    /// Returns whether a `IFP128` is set to zero.
+    ///
+    /// # Returns
+    ///
+    /// * [bool] -> True if the `IFP128` is zero, otherwise false.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use sway_libs::fixed_point::ifp128::IFP128;
+    ///
+    /// fn foo() {
+    ///     let ifp128 = IFP128::zero();
+    ///     assert(ifp128.is_zero());
+    /// }
+    /// ```
+    pub fn is_zero(self) -> bool {
+        self.underlying == UFP64::zero()
+    }
+
+    /// Returns the underlying `UFP64` representing the `IFP128`.
+    ///
+    /// # Returns
+    ///
+    /// * [UFP64] - The `UFP64` representing the `IFP128`.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use sway_libs::fixed_point::{ifp128::IFP128, ufp64::UFP64};
+    ///
+    /// fn foo() {
+    ///     let ifp128 = IFP128::zero();
+    ///     assert(ifp128.underlying() == UFP64::zero());
+    /// }
+    /// ```
+    pub fn underlying(self) -> UFP64 {
+        self.underlying
+    }
+
+    /// Returns the underlying bool representing the postive or negative state of the IFP128.
+    ///
+    /// # Returns
+    ///
+    /// * [bool] - The `bool` representing whether the `IFP128` is non-negative or not.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use sway_libs::fixed_point::ifp128::IFP128;
+    ///
+    /// fn foo() {
+    ///     let ifp128 = IFP128::zero();
+    ///     assert(ifp128.non_negative() == false);
+    /// }
+    /// ```
+    pub fn non_negative(self) -> bool {
+        self.non_negative
     }
 }
 
@@ -263,7 +323,7 @@ impl IFP128 {
     ///
     /// fn foo() {
     ///     let ifp128 = IFP128::from_uint(1);
-    ///     assert(ifp128.underlying == UFP64::from_uint(1));
+    ///     assert(ifp128.underlying() == UFP64::from_uint(1));
     /// }
     /// ```
     pub fn from_uint(uint: u64) -> Self {
@@ -290,7 +350,7 @@ impl IFP128 {
     /// fn foo() {
     ///     let ifp128 = IFP128::from_uint(128);
     ///     let recip = IFP128::recip(ifp128);
-    ///     assert(recip.underlying == UFP64::recip(UFP64::from(128)));
+    ///     assert(recip.underlying() == UFP64::recip(UFP64::from(128)));
     /// }
     /// ```
     pub fn recip(number: IFP128) -> Self {
@@ -318,7 +378,7 @@ impl IFP128 {
     /// fn foo() {
     ///     let ifp128 = IFP128::from_uint(128);
     ///     let trunc = ifp128.trunc();
-    ///     assert(trunc.underlying == UFP64::from(128).trunc());
+    ///     assert(trunc.underlying() == UFP64::from(128).trunc());
     /// }
     /// ```
     pub fn trunc(self) -> Self {
@@ -374,7 +434,7 @@ impl IFP128 {
     /// fn foo() {
     ///     let ifp128 = IFP128::from_uint(128);
     ///     let fract = ifp128.fract();
-    ///     assert(fract.underlying == UFP64::from(128).fract());
+    ///     assert(fract.underlying() == UFP64::from(128).fract());
     /// }
     /// ```
     pub fn fract(self) -> Self {
@@ -442,7 +502,7 @@ impl IFP128 {
     /// fn foo() {
     ///     let ifp128 = IFP128::from_uint(128);
     ///     let round = ifp128.round();
-    ///     assert(round.underlying == UFP64::from(128).round());
+    ///     assert(round.underlying() == UFP64::from(128).round());
     /// }
     /// ```
     pub fn round(self) -> Self {

--- a/libs/src/fixed_point/ifp256.sw
+++ b/libs/src/fixed_point/ifp256.sw
@@ -10,9 +10,9 @@ use ::fixed_point::ufp128::UFP128;
 /// Represented by an underlying `UFP128` number and a boolean.
 pub struct IFP256 {
     /// The underlying value representing the `IFP256` type.
-    pub underlying: UFP128,
+    underlying: UFP128,
     /// The underlying boolean representing a negative value for the `IFP256` type.
-    pub non_negative: bool,
+    non_negative: bool,
 }
 
 impl From<UFP128> for IFP256 {
@@ -59,7 +59,7 @@ impl IFP256 {
     ///
     /// fn foo() {
     ///     let ifp256 = IFP256::max();
-    ///     assert(ifp256.underlying == UFP128::max());
+    ///     assert(ifp256.underlying() == UFP128::max());
     /// }
     /// ```
     pub fn max() -> Self {
@@ -79,7 +79,7 @@ impl IFP256 {
     ///
     /// fn foo() {
     ///     let ifp256 = IFP256::min();
-    ///     assert(ifp256.underlying == UFP128::min());
+    ///     assert(ifp256.underlying() == UFP128::min());
     /// }
     /// ```
     pub fn min() -> Self {
@@ -102,7 +102,7 @@ impl IFP256 {
     ///
     /// fn foo() {
     ///     let ifp256 = IFP256::zero();
-    ///     assert(ifp256.underlying == UFP128::zero());
+    ///     assert(ifp256.underlying() == UFP128::zero());
     /// }
     /// ```
     pub fn zero() -> Self {
@@ -122,9 +122,9 @@ impl IFP256 {
     ///
     /// fn foo() {
     ///     let ifp256 = IFP256::zero();
-    ///     assert(ifp256.non_negative);
+    ///     assert(ifp256.non_negative());
     ///     let reverse = ifp256.sign_inverse();
-    ///     assert(!reverse.non_negative);
+    ///     assert(!reverse.non_negative());
     /// }
     /// ```
     pub fn sign_reverse(self) -> Self {
@@ -132,6 +132,66 @@ impl IFP256 {
             underlying: self.underlying,
             non_negative: !self.non_negative,
         }
+    }
+
+    /// Returns whether a `IFP256` is set to zero.
+    ///
+    /// # Returns
+    ///
+    /// * [bool] -> True if the `IFP256` is zero, otherwise false.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use sway_libs::fixed_point::ifp256::IFP256;
+    ///
+    /// fn foo() {
+    ///     let ifp256 = IFP256::zero();
+    ///     assert(ifp256.is_zero());
+    /// }
+    /// ```
+    pub fn is_zero(self) -> bool {
+        self.underlying == UFP128::zero()
+    }
+
+    /// Returns the underlying `UFP128` representing the `IFP256`.
+    ///
+    /// # Returns
+    ///
+    /// * [UFP128] - The `UFP128` representing the `IFP256`.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use sway_libs::fixed_point::{ifp256::IFP256, ufp128::UFP128};
+    ///
+    /// fn foo() {
+    ///     let ifp256 = IFP256::zero();
+    ///     assert(ifp256.underlying() == UFP128::zero());
+    /// }
+    /// ```
+    pub fn underlying(self) -> UFP128 {
+        self.underlying
+    }
+
+    /// Returns the underlying bool representing the postive or negative state of the IFP256.
+    ///
+    /// # Returns
+    ///
+    /// * [bool] - The `bool` representing whether the `IFP256` is non-negative or not.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use sway_libs::fixed_point::ifp256::IFP256;
+    ///
+    /// fn foo() {
+    ///     let ifp256 = IFP256::zero();
+    ///     assert(ifp256.non_negative() == false);
+    /// }
+    /// ```
+    pub fn non_negative(self) -> bool {
+        self.non_negative
     }
 }
 
@@ -263,7 +323,7 @@ impl IFP256 {
     ///
     /// fn foo() {
     ///     let ifp256 = IFP256::from_uint(1);
-    ///     assert(ifp256.underlying == UFP128::from_uint(1));
+    ///     assert(ifp256.underlying() == UFP128::from_uint(1));
     /// }
     /// ```
     pub fn from_uint(uint: u64) -> Self {
@@ -290,7 +350,7 @@ impl IFP256 {
     /// fn foo() {
     ///     let ifp256 = IFP256::from_uint(128);
     ///     let recip = IFP256::recip(ifp256);
-    ///     assert(recip.underlying == UFP128::recip(UFP128::from(128)));
+    ///     assert(recip.underlying() == UFP128::recip(UFP128::from(128)));
     /// }
     /// ```
     pub fn recip(number: IFP256) -> Self {
@@ -318,7 +378,7 @@ impl IFP256 {
     /// fn foo() {
     ///     let ifp256 = IFP256::from_uint(128);
     ///     let trunc = ifp256.trunc();
-    ///     assert(trunc.underlying == UFP128::from(128).trunc());
+    ///     assert(trunc.underlying() == UFP128::from(128).trunc());
     /// }
     /// ```
     pub fn trunc(self) -> Self {
@@ -344,7 +404,7 @@ impl IFP256 {
     /// fn foo() {
     ///     let ifp256 = IFP256::from_uint(128);
     ///     let floor = ifp256.floor();
-    ///     assert(floor.underlying == UFP128::from(128).floor());
+    ///     assert(floor.underlying() == UFP128::from(128).floor());
     /// }
     /// ```
     pub fn floor(self) -> Self {
@@ -374,7 +434,7 @@ impl IFP256 {
     /// fn foo() {
     ///     let ifp256 = IFP256::from_uint(128);
     ///     let fract = ifp256.fract();
-    ///     assert(fract.underlying == UFP128::from(128).fract());
+    ///     assert(fract.underlying() == UFP128::from(128).fract());
     /// }
     /// ```
     pub fn fract(self) -> Self {
@@ -400,7 +460,7 @@ impl IFP256 {
     /// fn foo() {
     ///     let ifp256 = IFP256::from_uint(128);
     ///     let ceil = ifp256.ceil();
-    ///     assert(ceil.underlying = UFP128::from(128).ceil().underlying);
+    ///     assert(ceil.underlying() = UFP128::from(128).ceil().underlying());
     /// }
     /// ```
     pub fn ceil(self) -> Self {
@@ -442,7 +502,7 @@ impl IFP256 {
     /// fn foo() {
     ///     let ifp256 = IFP256::from_uint(128);
     ///     let round = ifp256.round();
-    ///     assert(round.underlying == UFP128::from(128).round().underlying);
+    ///     assert(round.underlying() == UFP128::from(128).round().underlying());
     /// }
     /// ```
     pub fn round(self) -> Self {

--- a/libs/src/fixed_point/ifp64.sw
+++ b/libs/src/fixed_point/ifp64.sw
@@ -10,9 +10,9 @@ use ::fixed_point::ufp32::UFP32;
 /// Represented by an underlying `UFP32` number and a boolean.
 pub struct IFP64 {
     /// The underlying value representing the `IFP64` type.
-    pub underlying: UFP32,
+    underlying: UFP32,
     /// The underlying boolean representing a negative value for the `IFP64` type.
-    pub non_negative: bool,
+    non_negative: bool,
 }
 
 impl From<UFP32> for IFP64 {
@@ -59,7 +59,7 @@ impl IFP64 {
     ///
     /// fn foo() {
     ///     let ifp64 = IFP64::max();
-    ///     assert(ifp64.underlying == UFP32::max());
+    ///     assert(ifp64.underlying() == UFP32::max());
     /// }
     /// ```
     pub fn max() -> Self {
@@ -79,7 +79,7 @@ impl IFP64 {
     ///
     /// fn foo() {
     ///     let ifp64 = IFP64::min();
-    ///     assert(ifp64.underlying == UFP32::min());
+    ///     assert(ifp64.underlying() == UFP32::min());
     /// }
     /// ```
     pub fn min() -> Self {
@@ -102,11 +102,31 @@ impl IFP64 {
     ///
     /// fn foo() {
     ///     let ifp64 = IFP64::zero();
-    ///     assert(ifp64.underlying == UFP32::zero());
+    ///     assert(ifp64.underlying() == UFP32::zero());
     /// }
     /// ```
     pub fn zero() -> Self {
         Self::from(UFP32::zero())
+    }
+
+    /// Returns whether a `IFP64` is set to zero.
+    ///
+    /// # Returns
+    ///
+    /// * [bool] -> True if the `IFP64` is zero, otherwise false.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use sway_libs::fixed_point::ifp64::IFP64;
+    ///
+    /// fn foo() {
+    ///     let ifp64 = IFP64::zero();
+    ///     assert(ifp64.is_zero());
+    /// }
+    /// ```
+    pub fn is_zero(self) -> bool {
+        self.underlying == UFP32::zero()
     }
 
     /// Inverts the sign for this type.
@@ -122,9 +142,9 @@ impl IFP64 {
     ///
     /// fn foo() {
     ///     let ifp64 = IFP64::zero();
-    ///     assert(ifp64.non_negative);
+    ///     assert(ifp64.non_negative());
     ///     let reverse = ifp64.sign_inverse();
-    ///     assert(!reverse.non_negative);
+    ///     assert(!reverse.non_negative());
     /// }
     /// ```
     fn sign_reverse(self) -> Self {
@@ -132,6 +152,46 @@ impl IFP64 {
             underlying: self.underlying,
             non_negative: !self.non_negative,
         }
+    }
+
+    /// Returns the underlying `UFP32` representing the `IFP64`.
+    ///
+    /// # Returns
+    ///
+    /// * [UFP32] - The `UFP32` representing the `IFP64`.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use sway_libs::fixed_point::{ifp64::IFP64, ufp32::UFP32};
+    ///
+    /// fn foo() {
+    ///     let ifp64 = IFP64::zero();
+    ///     assert(ifp64.underlying() == UFP32::zero());
+    /// }
+    /// ```
+    pub fn underlying(self) -> UFP32 {
+        self.underlying
+    }
+
+    /// Returns the underlying bool representing the postive or negative state of the IFP64.
+    ///
+    /// # Returns
+    ///
+    /// * [bool] - The `bool` representing whether the `IFP64` is non-negative or not.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use sway_libs::fixed_point::ifp64::IFP64;
+    ///
+    /// fn foo() {
+    ///     let ifp64 = IFP64::zero();
+    ///     assert(ifp64.non_negative() == false);
+    /// }
+    /// ```
+    pub fn non_negative(self) -> bool {
+        self.non_negative
     }
 }
 
@@ -263,7 +323,7 @@ impl IFP64 {
     ///
     /// fn foo() {
     ///     let ifp64 = IFP64::from_uint(1u32);
-    ///     assert(ifp64.underlying == UFP32::from_uint(1u32));
+    ///     assert(ifp64.underlying() == UFP32::from_uint(1u32));
     /// }
     /// ```
     pub fn from_uint(uint: u32) -> Self {
@@ -290,7 +350,7 @@ impl IFP64 {
     /// fn foo() {
     ///     let ifp64 = IFP64::from_uint(128u32);
     ///     let recip = IFP64::recip(ifp64);
-    ///     assert(recip.underlying == UFP32::recip(UFP32::from(128u32)));
+    ///     assert(recip.underlying() == UFP32::recip(UFP32::from(128u32)));
     /// }
     /// ```
     pub fn recip(number: IFP64) -> Self {
@@ -318,7 +378,7 @@ impl IFP64 {
     /// fn foo() {
     ///     let ifp64 = IFP64::from_uint(128u32);
     ///     let trunc = ifp64.trunc();
-    ///     assert(trunc.underlying == UFP32::from(128u32).trunc());
+    ///     assert(trunc.underlying() == UFP32::from(128u32).trunc());
     /// }
     /// ```
     pub fn trunc(self) -> Self {
@@ -344,7 +404,7 @@ impl IFP64 {
     /// fn foo() {
     ///     let ifp64 = IFP64::from_uint(128u32);
     ///     let floor = ifp64.floor();
-    ///     assert(floor.underlying == UFP32::from(128u32).trunc().underlying);
+    ///     assert(floor.underlying() == UFP32::from(128u32).trunc().underlying());
     /// }
     /// ```
     pub fn floor(self) -> Self {
@@ -374,7 +434,7 @@ impl IFP64 {
     /// fn foo() {
     ///     let ifp64 = IFP64::from_uint(128u32);
     ///     let fract = ifp64.fract();
-    ///     assert(fract.underlying == UFP32::from(128u32).fract());
+    ///     assert(fract.underlying() == UFP32::from(128u32).fract());
     /// }
     /// ```
     pub fn fract(self) -> Self {
@@ -400,7 +460,7 @@ impl IFP64 {
     /// fn foo() {
     ///     let ifp64 = IFP64::from_uint(128u32);
     ///     let ceil = ifp64.ceil();
-    ///     assert(ceil.underlying = UFP32::from(128u32).ceil());
+    ///     assert(ceil.underlying() = UFP32::from(128u32).ceil());
     /// }
     /// ```
     pub fn ceil(self) -> Self {
@@ -442,7 +502,7 @@ impl IFP64 {
     /// fn foo() {
     ///     let ifp64 = IFP64::from_uint(128_u32);
     ///     let round = ifp64.round();
-    ///     assert(round.underlying == UFP32::from(128u32).round());
+    ///     assert(round.underlying() == UFP32::from(128u32).round());
     /// }
     /// ```
     pub fn round(self) -> Self {

--- a/libs/src/fixed_point/ufp32.sw
+++ b/libs/src/fixed_point/ufp32.sw
@@ -121,7 +121,9 @@ impl UFP32 {
     /// }
     /// ```
     pub fn zero() -> Self {
-        Self { underlying: 0u32 }
+        Self {
+            underlying: 0u32,
+        }
     }
 
     /// Returns whether a `UFP32` is set to zero.

--- a/libs/src/merkle/binary_proof.sw
+++ b/libs/src/merkle/binary_proof.sw
@@ -29,10 +29,9 @@ pub const NODE = 1u8;
 ///
 /// ```sway
 /// use sway_libs::merkle::binary_proof::leaf_digest;
-/// use std::contants::ZERO_B256;
 ///
 /// fn foo() {
-///     let data = ZERO_B256;
+///     let data = b256::zero();
 ///     let digest = leaf_digest(data);
 ///     assert(digest == 0x54f05a87f5b881780cdc40e3fddfebf72e3ba7e5f65405ab121c7f22d9849ab4);
 /// }
@@ -60,11 +59,10 @@ pub fn leaf_digest(data: b256) -> b256 {
 ///
 /// ```sway
 /// use sway_libs::merkle::binary_proof::node_digest;
-/// use std::contants::ZERO_B256;
 ///
 /// fn foo() {
-///     let leaf_1 = ZERO_B256;
-///     let leaf_2 = ZERO_B256;
+///     let leaf_1 = b256::zero();
+///     let leaf_2 = b256::zero();
 ///     let digest = node_digest(leaf_1, leaf_2);
 ///     assert(digest == 0xee510d4daf24756c7b56b56b838212b193d9265c85c4a3b2c74f5a3189477c80);
 /// }
@@ -102,11 +100,10 @@ pub fn node_digest(left: b256, right: b256) -> b256 {
 ///
 /// ```sway
 /// use sway_libs::merkle::binary_proof::process_proof;
-/// use std::contants::ZERO_B256;
 ///
 /// fn foo() {
 ///     let key = 0;
-///     let leaf = ZERO_B256;
+///     let leaf = b256::zero();
 ///     let num_leaves = 3;
 ///     let mut proof = Vec::new();
 ///     proof.push(0xb51fc5c7f5b6393a5b13bb6068de2247ac09df1d3b1bec17627502cb1d1a6ac6);
@@ -203,11 +200,10 @@ pub fn process_proof(
 ///
 /// ```sway
 /// use sway_libs::merkle::binary_proof::process_proof;
-/// use std::contants::ZERO_B256;
 ///
 /// fn foo() {
 ///     let key = 0;
-///     let leaf = ZERO_B256;
+///     let leaf = b256::zero();
 ///     let num_leaves = 3;
 ///     let mut proof = Vec::new();
 ///     proof.push(0xb51fc5c7f5b6393a5b13bb6068de2247ac09df1d3b1bec17627502cb1d1a6ac6);

--- a/libs/src/ownership.sw
+++ b/libs/src/ownership.sw
@@ -81,7 +81,7 @@ pub fn only_owner() {
 /// use sway_libs::ownership::{_owner, renounce_ownership};
 ///
 /// fn foo() {
-///     assert(_owner() == State::Initialized(Identity::Address(Address::from(ZERO_B256)));
+///     assert(_owner() == State::Initialized(Identity::Address(Address::zero()));
 ///     renounce_ownership();
 ///     assert(_owner() == State::Revoked);
 /// }
@@ -158,7 +158,7 @@ pub fn initialize_ownership(new_owner: Identity) {
 /// use sway_libs::ownership::{_owner, transfer_ownership};
 ///
 /// fn foo(new_owner: Identity) {
-///     assert(_owner() == State::Initialized(Identity::Address(Address::from(ZERO_B256)));
+///     assert(_owner() == State::Initialized(Identity::Address(Address::zero()));
 ///     transfer_ownership(new_owner);
 ///     assert(_owner() == State::Initialized(new_owner));
 /// }

--- a/libs/src/signed_integers/i128.sw
+++ b/libs/src/signed_integers/i128.sw
@@ -13,7 +13,7 @@ use ::signed_integers::errors::Error;
 /// Max value is 2 ^ 127 - 1, min value is - 2 ^ 127
 pub struct I128 {
     /// The underlying unsigned number representing the `I128` type.
-    pub underlying: U128,
+    underlying: U128,
 }
 
 impl I128 {
@@ -104,7 +104,7 @@ impl I128 {
     /// fn foo() {
     ///     let underlying = U128::from((0, 1));
     ///     let i128 = I128::from_uint(underlying);
-    ///     assert(i128.underlying == underlying);
+    ///     assert(i128.underlying() == underlying);
     /// }
     /// ```
     pub fn from_uint(underlying: U128) -> Self {
@@ -125,7 +125,7 @@ impl I128 {
     ///
     /// fn foo() {
     ///     let i128 = I128::max();
-    ///     assert(i128.underlying == U128::max());
+    ///     assert(i128.underlying() == U128::max());
     /// }
     /// ```
     pub fn max() -> Self {
@@ -148,7 +148,7 @@ impl I128 {
     ///
     /// fn foo() {
     ///     let i128 = I128::min();
-    ///     assert(i128.underlying == U128::min());
+    ///     assert(i128.underlying() == U128::min());
     /// }
     /// ```
     pub fn min() -> Self {
@@ -176,7 +176,7 @@ impl I128 {
     /// fn foo() {
     ///     let underlying = U128::from((1, 0));
     ///     let i128 = I128::neg_from(underlying);
-    ///     assert(i128.underlying == U128::from((0, 0)));
+    ///     assert(i128.underlying() == U128::from((0, 0)));
     /// }
     /// ```
     pub fn neg_from(value: U128) -> Self {
@@ -203,13 +203,75 @@ impl I128 {
     ///
     /// fn foo() {
     ///     let i128 = I128::new();
-    ///     assert(i128.underlying == U128::from(1, 0));
+    ///     assert(i128.underlying() == U128::from(1, 0));
     /// }
     /// ```
     pub fn new() -> Self {
         Self {
             underlying: Self::indent(),
         }
+    }
+
+    /// The zero value `I128`.
+    ///
+    /// # Returns
+    ///
+    /// * [I128] - The newly created `I128` type.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use sway_libs::signed_integers::i128::I128;
+    /// use std::u128::U128;
+    ///
+    /// fn foo() {
+    ///     let i128 = I128::zero();
+    ///     assert(i128.underlying() == U128::from((1, 0)));
+    /// }
+    /// ```
+    pub fn zero() -> Self {
+        Self { underlying: Self::indent() }
+    }
+
+    /// Returns whether a `I128` is set to zero.
+    ///
+    /// # Returns
+    ///
+    /// * [bool] -> True if the `I128` is zero, otherwise false.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use sway_libs::signed_integers::i128::I128;
+    ///
+    /// fn foo() {
+    ///     let i128 = I128::zero();
+    ///     assert(i128.is_zero());
+    /// }
+    /// ```
+    pub fn is_zero(self) -> bool {
+        self.underlying == Self::indent()
+    }
+
+    /// Returns the underlying `u128` representing the `I128`.
+    ///
+    /// # Returns
+    ///
+    /// * [u128] - The `u128` representing the `I128`.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use sway_libs::signed_integers::i128::I128;
+    /// use std::u128::U128;
+    ///
+    /// fn foo() {
+    ///     let i128 = I128::zero();
+    ///     assert(i128.underlying() == U128::from((1, 0)));
+    /// }
+    /// ```
+    pub fn underlying(self) -> U128 {
+        self.underlying
     }
 }
 

--- a/libs/src/signed_integers/i128.sw
+++ b/libs/src/signed_integers/i128.sw
@@ -230,7 +230,9 @@ impl I128 {
     /// }
     /// ```
     pub fn zero() -> Self {
-        Self { underlying: Self::indent() }
+        Self {
+            underlying: Self::indent(),
+        }
     }
 
     /// Returns whether a `I128` is set to zero.

--- a/libs/src/signed_integers/i16.sw
+++ b/libs/src/signed_integers/i16.sw
@@ -222,7 +222,9 @@ impl I16 {
     /// }
     /// ```
     pub fn zero() -> Self {
-        Self { underlying: Self::indent() }
+        Self {
+            underlying: Self::indent(),
+        }
     }
 
     /// Returns whether a `I16` is set to zero.

--- a/libs/src/signed_integers/i16.sw
+++ b/libs/src/signed_integers/i16.sw
@@ -12,7 +12,7 @@ use ::signed_integers::common::TwosComplement;
 /// Max value is 2 ^ 15 - 1, min value is - 2 ^ 15
 pub struct I16 {
     /// The underlying value representing the signed integer.
-    pub underlying: u16,
+    underlying: u16,
 }
 
 impl I16 {
@@ -101,7 +101,7 @@ impl I16 {
     /// fn foo() {
     ///     let underlying = 1u16;
     ///     let i16 = I16::from_uint(underlying);
-    ///     assert(i16.underlying == underlying);
+    ///     assert(i16.underlying() == underlying);
     /// }
     /// ```
     pub fn from_uint(underlying: u16) -> Self {
@@ -121,7 +121,7 @@ impl I16 {
     ///
     /// fn foo() {
     ///     let i16 = I16::max();
-    ///     assert(i16.underlying == u16::max());
+    ///     assert(i16.underlying() == u16::max());
     /// }
     /// ```
     pub fn max() -> Self {
@@ -143,7 +143,7 @@ impl I16 {
     ///
     /// fn foo() {
     ///     let i16 = I16::min();
-    ///     assert(i16.underlying == u16::min());
+    ///     assert(i16.underlying() == u16::min());
     /// }
     /// ```
     pub fn min() -> Self {
@@ -170,7 +170,7 @@ impl I16 {
     /// fn foo() {
     ///     let underlying = 1u16;
     ///     let i16 = I16::neg_from(underlying);
-    ///     assert(i16.underlying == 32767u16)
+    ///     assert(i16.underlying() == 32767u16)
     /// }
     /// ```
     pub fn neg_from(value: u16) -> Self {
@@ -196,13 +196,73 @@ impl I16 {
     ///
     /// fn foo() {
     ///     let i16 = I16::new();
-    ///     assert(i16.underlying == 32768u16);
+    ///     assert(i16.underlying() == 32768u16);
     /// }
     /// ```
     pub fn new() -> Self {
         Self {
             underlying: Self::indent(),
         }
+    }
+
+    /// The zero value `I16`.
+    ///
+    /// # Returns
+    ///
+    /// * [I16] - The newly created `I16` type.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use sway_libs::signed_integers::i16::I16;
+    ///
+    /// fn foo() {
+    ///     let i16 = I16::zero();
+    ///     assert(i16.underlying() == 32768u16);
+    /// }
+    /// ```
+    pub fn zero() -> Self {
+        Self { underlying: Self::indent() }
+    }
+
+    /// Returns whether a `I16` is set to zero.
+    ///
+    /// # Returns
+    ///
+    /// * [bool] -> True if the `I16` is zero, otherwise false.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use sway_libs::signed_integers::i16::I16;
+    ///
+    /// fn foo() {
+    ///     let i16 = I16::zero();
+    ///     assert(i16.is_zero());
+    /// }
+    /// ```
+    pub fn is_zero(self) -> bool {
+        self.underlying == Self::indent()
+    }
+
+    /// Returns the underlying `u16` representing the `I16`.
+    ///
+    /// # Returns
+    ///
+    /// * [u16] - The `u16` representing the `I16`.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use sway_libs::signed_integers::i16::I16;
+    ///
+    /// fn foo() {
+    ///     let i16 = I16::zero();
+    ///     assert(i16.underlying() == 32768u16);
+    /// }
+    /// ```
+    pub fn underlying(self) -> u16 {
+        self.underlying
     }
 }
 

--- a/libs/src/signed_integers/i256.sw
+++ b/libs/src/signed_integers/i256.sw
@@ -227,7 +227,9 @@ impl I256 {
     /// }
     /// ```
     pub fn zero() -> Self {
-        Self { underlying: Self::indent() }
+        Self {
+            underlying: Self::indent(),
+        }
     }
 
     /// Returns whether a `I256` is set to zero.

--- a/libs/src/signed_integers/i256.sw
+++ b/libs/src/signed_integers/i256.sw
@@ -11,7 +11,7 @@ use ::signed_integers::errors::Error;
 /// Actual value is underlying value minus 2 ^ 255
 /// Max value is 2 ^ 255 - 1, min value is - 2 ^ 255
 pub struct I256 {
-    pub underlying: u256,
+    underlying: u256,
 }
 
 impl I256 {
@@ -106,7 +106,7 @@ impl I256 {
     /// fn foo() {
     ///     let underlying = 0x0000000000000000000000000000000000000000000000000000000000000001u256;
     ///     let i256 = I256::from_uint(underlying);
-    ///     assert(256.underlying == underlying);
+    ///     assert(i256.underlying() == underlying);
     /// }
     /// ```
     pub fn from_uint(underlying: u256) -> Self {
@@ -126,7 +126,7 @@ impl I256 {
     ///
     /// fn foo() {
     ///     let i256 = I256::max();
-    ///     assert(i256.underlying == u256::max());
+    ///     assert(i256.underlying() == u256::max());
     /// }
     /// ```
     pub fn max() -> Self {
@@ -148,7 +148,7 @@ impl I256 {
     ///
     /// fn foo() {
     ///     let i256 = I256::min();
-    ///     assert(i256.underlying == u256::min());
+    ///     assert(i256.underlying() == u256::min());
     /// }
     /// ```
     pub fn min() -> Self {
@@ -175,7 +175,7 @@ impl I256 {
     /// fn foo() {
     ///     let underlying = 0x0000000000000000000000000000001000000000000000000000000000000000u256;
     ///     let i256 = I256::neg_from(underlying);
-    ///     assert(i256.underlying == 0x0000000000000000000000000000000000000000000000000000000000000000u256);
+    ///     assert(i256.underlying() == 0x0000000000000000000000000000000000000000000000000000000000000000u256);
     /// }
     /// ```
     pub fn neg_from(value: u256) -> Self {
@@ -201,13 +201,73 @@ impl I256 {
     ///
     /// fn foo() {
     ///     let i256 = I256::new();
-    ///     assert(i256.underlying == 0x0000000000000000000000000000001000000000000000000000000000000000u256);
+    ///     assert(i256.underlying() == 0x0000000000000000000000000000001000000000000000000000000000000000u256);
     /// }
     /// ```
     pub fn new() -> Self {
         Self {
             underlying: Self::indent(),
         }
+    }
+
+    /// The zero value `I256`.
+    ///
+    /// # Returns
+    ///
+    /// * [I256] - The newly created `I256` type.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use sway_libs::signed_integers::i256::I256;
+    ///
+    /// fn foo() {
+    ///     let i256 = I256::zero();
+    ///     assert(i256.underlying() == 0x0000000000000000000000000000001000000000000000000000000000000000u256);
+    /// }
+    /// ```
+    pub fn zero() -> Self {
+        Self { underlying: Self::indent() }
+    }
+
+    /// Returns whether a `I256` is set to zero.
+    ///
+    /// # Returns
+    ///
+    /// * [bool] -> True if the `I256` is zero, otherwise false.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use sway_libs::signed_integers::i256::I256;
+    ///
+    /// fn foo() {
+    ///     let i256 = I256::zero();
+    ///     assert(i256.is_zero());
+    /// }
+    /// ```
+    pub fn is_zero(self) -> bool {
+        self.underlying == Self::indent()
+    }
+
+    /// Returns the underlying `u256` representing the `I256`.
+    ///
+    /// # Returns
+    ///
+    /// * [u256] - The `u256` representing the `I256`.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use sway_libs::signed_integers::i256::I256;
+    ///
+    /// fn foo() {
+    ///     let i256 = I256::zero();
+    ///     assert(i256.underlying() == 0x0000000000000000000000000000001000000000000000000000000000000000u256);
+    /// }
+    /// ```
+    pub fn underlying(self) -> u256 {
+        self.underlying
     }
 }
 

--- a/libs/src/signed_integers/i32.sw
+++ b/libs/src/signed_integers/i32.sw
@@ -12,7 +12,7 @@ use ::signed_integers::errors::Error;
 /// Max value is 2 ^ 31 - 1, min value is - 2 ^ 31
 pub struct I32 {
     /// The underlying u32 type that represent a I32.
-    pub underlying: u32,
+    underlying: u32,
 }
 
 impl I32 {
@@ -100,7 +100,7 @@ impl I32 {
     /// fn foo() {
     ///     let underlying = 1u32;
     ///     let i32 = I32::from_uint(underlying);
-    ///     assert(i32.underlying == underlying);
+    ///     assert(i32.underlying() == underlying);
     /// }
     /// ```
     pub fn from_uint(underlying: u32) -> Self {
@@ -120,7 +120,7 @@ impl I32 {
     ///
     /// fn foo() {
     ///     let i32 = I32::max();
-    ///     assert(i32.underlying == u32::max());
+    ///     assert(i32.underlying() == u32::max());
     /// }
     /// ```
     pub fn max() -> Self {
@@ -142,7 +142,7 @@ impl I32 {
     ///
     /// fn foo() {
     ///     let i32 = I32::min();
-    ///     assert(i32.underlying == u32::min());
+    ///     assert(i32.underlying() == u32::min());
     /// }
     /// ```
     pub fn min() -> Self {
@@ -169,7 +169,7 @@ impl I32 {
     /// fn foo() {
     ///     let underlying = 1u32;
     ///     let i32 = I32::neg_from(underlying);
-    ///     assert(i32.underlying == 2147483647u32)
+    ///     assert(i32.underlying() == 2147483647u32)
     /// }
     /// ```
     pub fn neg_from(value: u32) -> Self {
@@ -195,13 +195,73 @@ impl I32 {
     ///
     /// fn foo() {
     ///     let i32 = I32::new();
-    ///     assert(i32.underlying == 2147483648u32);
+    ///     assert(i32.underlying() == 2147483648u32);
     /// }
     /// ```
     pub fn new() -> Self {
         Self {
             underlying: Self::indent(),
         }
+    }
+
+    /// The zero value `I32`.
+    ///
+    /// # Returns
+    ///
+    /// * [I32] - The newly created `I32` type.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use sway_libs::signed_integers::i32::I32;
+    ///
+    /// fn foo() {
+    ///     let i32 = I32::zero();
+    ///     assert(i32.underlying() == 2147483648u32);
+    /// }
+    /// ```
+    pub fn zero() -> Self {
+        Self { underlying: Self::indent() }
+    }
+
+    /// Returns whether a `I32` is set to zero.
+    ///
+    /// # Returns
+    ///
+    /// * [bool] -> True if the `I32` is zero, otherwise false.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use sway_libs::signed_integers::i32::I32;
+    ///
+    /// fn foo() {
+    ///     let i32 = I32::zero();
+    ///     assert(i32.is_zero());
+    /// }
+    /// ```
+    pub fn is_zero(self) -> bool {
+        self.underlying == Self::indent()
+    }
+
+    /// Returns the underlying `u32` representing the `I32`.
+    ///
+    /// # Returns
+    ///
+    /// * [u32] - The `u32` representing the `I32`.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use sway_libs::signed_integers::i32::I32;
+    ///
+    /// fn foo() {
+    ///     let i32 = I32::zero();
+    ///     assert(i32.underlying() == 2147483648u32);
+    /// }
+    /// ```
+    pub fn underlying(self) -> u32 {
+        self.underlying
     }
 }
 

--- a/libs/src/signed_integers/i32.sw
+++ b/libs/src/signed_integers/i32.sw
@@ -221,7 +221,9 @@ impl I32 {
     /// }
     /// ```
     pub fn zero() -> Self {
-        Self { underlying: Self::indent() }
+        Self {
+            underlying: Self::indent(),
+        }
     }
 
     /// Returns whether a `I32` is set to zero.

--- a/libs/src/signed_integers/i64.sw
+++ b/libs/src/signed_integers/i64.sw
@@ -12,7 +12,7 @@ use ::signed_integers::errors::Error;
 /// Max value is 2 ^ 63 - 1, min value is - 2 ^ 63
 pub struct I64 {
     /// The underlying unsigned number representing the `I64` type.
-    pub underlying: u64,
+    underlying: u64,
 }
 
 impl I64 {
@@ -100,7 +100,7 @@ impl I64 {
     /// fn foo() {
     ///     let underlying = 1u64;
     ///     let i64 = I64::from_uint(underlying);
-    ///     assert(i64.underlying == underlying);
+    ///     assert(i64.underlying() == underlying);
     /// }
     /// ```
     pub fn from_uint(underlying: u64) -> Self {
@@ -120,7 +120,7 @@ impl I64 {
     ///
     /// fn foo() {
     ///     let i64 = I64::max();
-    ///     assert(i64.underlying == u64::max());
+    ///     assert(i64.underlying() == u64::max());
     /// }
     /// ```
     pub fn max() -> Self {
@@ -142,7 +142,7 @@ impl I64 {
     ///
     /// fn foo() {
     ///     let i64 = I64::min();
-    ///     assert(i64.underlying == u64::min());
+    ///     assert(i64.underlying() == u64::min());
     /// }
     /// ```
     pub fn min() -> Self {
@@ -169,7 +169,7 @@ impl I64 {
     /// fn foo() {
     ///     let underlying = 1u64;
     ///     let i64 = I64::neg_from(underlying);
-    ///     assert(i64.underlying == 9223372036854775807u64);
+    ///     assert(i64.underlying() == 9223372036854775807u64);
     /// }
     /// ```
     pub fn neg_from(value: u64) -> Self {
@@ -195,13 +195,73 @@ impl I64 {
     ///
     /// fn foo() {
     ///     let i64 = I64::new();
-    ///     assert(i64.underlying == 9223372036854775808);
+    ///     assert(i64.underlying() == 9223372036854775808);
     /// }
     /// ```
     pub fn new() -> Self {
         Self {
             underlying: Self::indent(),
         }
+    }
+
+    /// The zero value `I64`.
+    ///
+    /// # Returns
+    ///
+    /// * [I64] - The newly created `I64` type.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use sway_libs::signed_integers::i64::I64;
+    ///
+    /// fn foo() {
+    ///     let i64 = I64::zero();
+    ///     assert(i64.underlying() == 9223372036854775808);
+    /// }
+    /// ```
+    pub fn zero() -> Self {
+        Self { underlying: Self::indent() }
+    }
+
+    /// Returns whether a `I64` is set to zero.
+    ///
+    /// # Returns
+    ///
+    /// * [bool] -> True if the `I64` is zero, otherwise false.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use sway_libs::signed_integers::i64::I64;
+    ///
+    /// fn foo() {
+    ///     let i64 = I64::zero();
+    ///     assert(i64.is_zero());
+    /// }
+    /// ```
+    pub fn is_zero(self) -> bool {
+        self.underlying == Self::indent()
+    }
+
+    /// Returns the underlying `u64` representing the `I64`.
+    ///
+    /// # Returns
+    ///
+    /// * [u64] - The `u64` representing the `I64`.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use sway_libs::signed_integers::i64::I64;
+    ///
+    /// fn foo() {
+    ///     let i64 = I64::zero();
+    ///     assert(i64.underlying() == 9223372036854775808);
+    /// }
+    /// ```
+    pub fn underlying(self) -> u64 {
+        self.underlying
     }
 }
 

--- a/libs/src/signed_integers/i64.sw
+++ b/libs/src/signed_integers/i64.sw
@@ -221,7 +221,9 @@ impl I64 {
     /// }
     /// ```
     pub fn zero() -> Self {
-        Self { underlying: Self::indent() }
+        Self {
+            underlying: Self::indent(),
+        }
     }
 
     /// Returns whether a `I64` is set to zero.

--- a/libs/src/signed_integers/i8.sw
+++ b/libs/src/signed_integers/i8.sw
@@ -12,7 +12,7 @@ use ::signed_integers::common::TwosComplement;
 /// Max value is 2 ^ 7 - 1, min value is - 2 ^ 7
 pub struct I8 {
     /// The underlying unsigned `u8` type that makes up the signed `I8` type.
-    pub underlying: u8,
+    underlying: u8,
 }
 
 impl I8 {
@@ -100,7 +100,7 @@ impl I8 {
     /// fn foo() {
     ///     let underlying = 1u8;
     ///     let i8 = I8::from_uint(underlying);
-    ///     assert(i8.underlying == underlying);
+    ///     assert(i8.underlying() == underlying);
     /// }
     /// ```
     pub fn from_uint(underlying: u8) -> Self {
@@ -120,7 +120,7 @@ impl I8 {
     ///
     /// fn foo() {
     ///     let i8 = I8::max();
-    ///     assert(i8.underlying == u8::max());
+    ///     assert(i8.underlying() == u8::max());
     /// }
     /// ```
     pub fn max() -> Self {
@@ -142,7 +142,7 @@ impl I8 {
     ///
     /// fn foo() {
     ///     let i8 = I8::new();
-    ///     assert(i8.underlying == u8::min());
+    ///     assert(i8.underlying() == u8::min());
     /// }
     /// ```
     pub fn min() -> Self {
@@ -169,7 +169,7 @@ impl I8 {
     /// fn foo() {
     ///     let underlying = 1u8;
     ///     let i8 = I8::neg_from(underlying);
-    ///     assert(i8.underlying == 127u8);
+    ///     assert(i8.underlying() == 127u8);
     /// }
     /// ```
     pub fn neg_from(value: u8) -> Self {
@@ -195,13 +195,73 @@ impl I8 {
     ///
     /// fn foo() {
     ///     let i8 = I8::new();
-    ///     assert(i8.underlying == 128u8);
+    ///     assert(i8.underlying() == 128u8);
     /// }
     /// ```
     pub fn new() -> Self {
         Self {
             underlying: Self::indent(),
         }
+    }
+
+    /// The zero value `I8`.
+    ///
+    /// # Returns
+    ///
+    /// * [I8] - The newly created `I8` type.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use sway_libs::signed_integers::i8::I8;
+    ///
+    /// fn foo() {
+    ///     let i8 = I8::zero();
+    ///     assert(i8.underlying() == 128u8);
+    /// }
+    /// ```
+    pub fn zero() -> Self {
+        Self { underlying: Self::indent() }
+    }
+
+    /// Returns whether a `I8` is set to zero.
+    ///
+    /// # Returns
+    ///
+    /// * [bool] -> True if the `I8` is zero, otherwise false.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use sway_libs::signed_integers::i8::I8;
+    ///
+    /// fn foo() {
+    ///     let i8 = I8::zero();
+    ///     assert(i8.is_zero());
+    /// }
+    /// ```
+    pub fn is_zero(self) -> bool {
+        self.underlying == Self::indent()
+    }
+
+    /// Returns the underlying `u8` representing the `I8`.
+    ///
+    /// # Returns
+    ///
+    /// * [u8] - The `u8` representing the `I8`.
+    ///
+    /// # Examples
+    ///
+    /// ```sway
+    /// use sway_libs::signed_integers::i8::I8;
+    ///
+    /// fn foo() {
+    ///     let i8 = I8::zero();
+    ///     assert(i8.underlying() == 128u8);
+    /// }
+    /// ```
+    pub fn underlying(self) -> u8 {
+        self.underlying
     }
 }
 

--- a/libs/src/signed_integers/i8.sw
+++ b/libs/src/signed_integers/i8.sw
@@ -221,7 +221,9 @@ impl I8 {
     /// }
     /// ```
     pub fn zero() -> Self {
-        Self { underlying: Self::indent() }
+        Self {
+            underlying: Self::indent(),
+        }
     }
 
     /// Returns whether a `I8` is set to zero.

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 
 [dependencies]
 fuel-merkle = { version = "0.49.0" }
-fuels = { version = "0.58.0", features = ["fuel-core-lib"] }
+fuels = { version = "0.62.0", features = ["fuel-core-lib"] }
 sha2 = { version = "0.10" }
 tokio = { version = "1.12", features = ["rt", "macros"] }
 rand = { version = "0.8.5", default-features = false, features = ["std_rng", "getrandom"] }

--- a/tests/src/admin/Forc.toml
+++ b/tests/src/admin/Forc.toml
@@ -5,5 +5,5 @@ license = "Apache-2.0"
 name = "admin_test"
 
 [dependencies]
-standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.4.3" }
+standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.5.0" }
 sway_libs = { path = "../../../libs" }

--- a/tests/src/bytecode/test_artifacts/complex_contract/src/main.sw
+++ b/tests/src/bytecode/test_artifacts/complex_contract/src/main.sw
@@ -1,6 +1,6 @@
 contract;
 
-use std::{constants::ZERO_B256, hash::*, math::*, storage::storage_vec::*,};
+use std::{hash::*, math::*, storage::storage_vec::*,};
 
 struct SimpleStruct {
     x: u32,
@@ -17,7 +17,7 @@ configurable {
     VALUE: u64 = 1,
     STRUCT: SimpleStruct = SimpleStruct {
         x: 0u32,
-        y: ZERO_B256,
+        y: b256::zero(),
     },
     ENUM: SimpleEnum = SimpleEnum::X,
 }

--- a/tests/src/bytecode/tests/utils/mod.rs
+++ b/tests/src/bytecode/tests/utils/mod.rs
@@ -40,11 +40,11 @@ const DEFAULT_PREDICATE_BALANCE: u64 = 512;
 const HEX_STR_1: &str = "0xacbe4bfc77e55c071db31f2e37c824d75794867d88499107dc8318cb22aceea5";
 const HEX_STR_2: &str = "0x0b1af92ac5a3e8cfeafede9586a1f853a9e0258e7cdccae5e5181edac081f2c1b";
 const HEX_STR_3: &str = "0x0345c74edfb0ce0820409176d0cbc2c44eac1e5e4c7382ee7e7c38d611d9ba767";
-const SIMPLE_PREDICATE_OFFSET: u64 = 116;
-const SIMPLE_CONTRACT_OFFSET: u64 = 936;
-const COMPLEX_CONTRACT_OFFSET_1: u64 = 28008;
-const COMPLEX_CONTRACT_OFFSET_2: u64 = 28016;
-const COMPLEX_CONTRACT_OFFSET_3: u64 = 28056;
+const SIMPLE_PREDICATE_OFFSET: u64 = 408;
+const SIMPLE_CONTRACT_OFFSET: u64 = 1432;
+const COMPLEX_CONTRACT_OFFSET_1: u64 = 23344;
+const COMPLEX_CONTRACT_OFFSET_2: u64 = 23360;
+const COMPLEX_CONTRACT_OFFSET_3: u64 = 23400;
 
 pub mod abi_calls {
 
@@ -99,7 +99,6 @@ pub mod abi_calls {
             .with_encoder_config(EncoderConfig {
                 max_depth: 10,
                 max_tokens: 100_000,
-                max_total_enum_width: 10_000,
             })
             .methods()
             .compute_bytecode_root(bytecode)
@@ -119,7 +118,6 @@ pub mod abi_calls {
             .with_encoder_config(EncoderConfig {
                 max_depth: 10,
                 max_tokens: 100_000,
-                max_total_enum_width: 10_000,
             })
             .methods()
             .compute_bytecode_root_with_configurables(bytecode, configurables)
@@ -151,7 +149,6 @@ pub mod abi_calls {
             .with_encoder_config(EncoderConfig {
                 max_depth: 10,
                 max_tokens: 100_000,
-                max_total_enum_width: 10_000,
             })
             .methods()
             .swap_configurables(bytecode, configurables)
@@ -201,7 +198,6 @@ pub mod abi_calls {
             .with_encoder_config(EncoderConfig {
                 max_depth: 10,
                 max_tokens: 100_000,
-                max_total_enum_width: 10_000,
             })
             .methods()
             .verify_contract_bytecode(contract_id, bytecode)
@@ -239,7 +235,6 @@ pub mod abi_calls {
             .with_encoder_config(EncoderConfig {
                 max_depth: 10,
                 max_tokens: 100_000,
-                max_total_enum_width: 10_000,
             })
             .methods()
             .verify_contract_bytecode_with_configurables(contract_id, bytecode, configurables)
@@ -701,16 +696,7 @@ pub mod test_helpers {
         my_configurables.push((COMPLEX_CONTRACT_OFFSET_1, data1));
 
         let mut data2: Vec<u8> = Vec::new();
-        data2.extend_from_slice(&[
-            0u8,
-            0u8,
-            0u8,
-            0u8,
-            0u8,
-            0u8,
-            0u8,
-            config_struct.x.try_into().unwrap(),
-        ]);
+        data2.extend_from_slice(&[0u8, 0u8, 0u8, config_struct.x.try_into().unwrap()]);
         let bits1 = *Bytes32::from_str(HEX_STR_1).expect("failed to create Bytes32 from string");
         data2.extend_from_slice(&bits1);
         my_configurables.push((COMPLEX_CONTRACT_OFFSET_2, data2));

--- a/tests/src/fixed_point/ifp64_exp_test/src/main.sw
+++ b/tests/src/fixed_point/ifp64_exp_test/src/main.sw
@@ -6,24 +6,23 @@ use std::assert::assert;
 fn main() -> bool {
     let one = IFP64::from_uint(1u32);
     let mut res = IFP64::exp(one);
-    assert(res.underlying.value == 178142u32);
+    assert(res.underlying().underlying() == 178142u32);
 
     let two = IFP64::from_uint(2u32);
     res = IFP64::exp(two);
-    assert(res.underlying.value == 483696u32);
+    assert(res.underlying().underlying() == 483696u32);
 
     let four = IFP64::from_uint(4u32);
     res = IFP64::exp(four);
-    assert(res.underlying.value == 3394688u32);
+    assert(res.underlying().underlying() == 3394688u32);
 
     let seven = IFP64::from_uint(7u32);
     res = IFP64::exp(seven);
-    assert(res.underlying.value == 43019636u32);
+    assert(res.underlying().underlying() == 43019636u32);
 
     let ten = IFP64::from_uint(10u32);
     res = IFP64::exp(ten);
-    std::logging::log(res.underlying.value);
-    assert(res.underlying.value == 317819696u32);
+    assert(res.underlying().underlying() == 317819696u32);
 
     true
 }

--- a/tests/src/fixed_point/ifp64_test/src/main.sw
+++ b/tests/src/fixed_point/ifp64_test/src/main.sw
@@ -25,51 +25,39 @@ fn main() -> bool {
     assert(IFP64::from_uint(156u32) == res);
 
     // recip
-    let mut u_value = UFP32 {
-        value: 1u32 << 16 + 3,
-    };
+    let mut u_value = UFP32::from(1u32 << 16 + 3);
     let mut value = IFP64::from(u_value);
 
     res = IFP64::recip(value);
-    assert(IFP64::from(UFP32 {
-        value: 8192u32,
-    }) == res);
+    assert(IFP64::from(UFP32::from(8192u32)) == res);
 
     // trunc
-    u_value = UFP32 {
-        value: (1u32 << 16) + 3u32,
-    };
+    u_value = UFP32::from((1u32 << 16) + 3u32);
     value = IFP64::from(u_value);
 
     res = value.trunc();
     assert(IFP64::from_uint(1u32) == res);
 
     // floor
-    u_value = UFP32 {
-        value: (1u32 << 16) + 3u32,
-    };
+    u_value = UFP32::from((1u32 << 16) + 3u32);
     value = IFP64::from(u_value);
 
     res = value.floor();
     assert(IFP64::from_uint(1u32) == res);
 
     // fract
-    u_value = UFP32 {
-        value: (1u32 << 16) + 3u32,
-    };
+    u_value = UFP32::from((1u32 << 16) + 3u32);
     value = IFP64::from(u_value);
 
     res = value.fract();
-    assert(IFP64::from(UFP32 { value: 3u32 }) == res);
+    assert(IFP64::from(UFP32::from(3u32)) == res);
 
     value = IFP64::from_uint(1u32);
     res = value.fract();
     assert(IFP64::from_uint(0u32) == res);
 
     // ceil
-    u_value = UFP32 {
-        value: (1u32 << 16) + 3u32,
-    };
+    u_value = UFP32::from((1u32 << 16) + 3u32);
     value = IFP64::from(u_value);
 
     res = value.ceil();
@@ -80,17 +68,13 @@ fn main() -> bool {
     assert(IFP64::from_uint(1u32) == res);
 
     // round
-    u_value = UFP32 {
-        value: (1u32 << 16) + 3u32,
-    };
+    u_value = UFP32::from((1u32 << 16) + 3u32);
     value = IFP64::from(u_value);
 
     res = value.round();
     assert(IFP64::from_uint(1u32) == res);
 
-    u_value = UFP32 {
-        value: (1u32 << 16) + (1u32 << 15) + 1u32,
-    };
+    u_value = UFP32::from((1u32 << 16) + (1u32 << 15) + 1u32);
     value = IFP64::from(u_value);
 
     res = value.round();

--- a/tests/src/fixed_point/ufp128_test/src/main.sw
+++ b/tests/src/fixed_point/ufp128_test/src/main.sw
@@ -25,45 +25,31 @@ fn main() -> bool {
     assert(UFP128::from((156, 0)) == res);
 
     // recip
-    let mut value = UFP128 {
-        value: U128::from((1, 3)),
-    };
+    let mut value = UFP128::from(U128::from((1, 3)));
     res = UFP128::recip(value);
-    assert(UFP128 {
-        value: U128::from((0, 18446744073709551613)),
-    } == res);
+    assert(UFP128::from(U128::from((0, 18446744073709551613))) == res);
 
     // trunc
-    let mut value = UFP128 {
-        value: U128::from((1, 3)),
-    };
+    let mut value = UFP128::from(U128::from((1, 3)));
     res = value.trunc();
     assert(UFP128::from_uint(1) == res);
 
     // floor
-    value = UFP128 {
-        value: U128::from((1, 3)),
-    };
+    value = UFP128::from(U128::from((1, 3)));
     res = value.floor();
     assert(UFP128::from_uint(1) == res);
 
     // fract
-    value = UFP128 {
-        value: U128::from((1, 3)),
-    };
+    value = UFP128::from(U128::from((1, 3)));
     res = value.fract();
-    assert(UFP128 {
-        value: U128::from((0, 3)),
-    } == res);
+    assert(UFP128::from(U128::from((0, 3))) == res);
 
     value = UFP128::from_uint(1);
     res = value.fract();
     assert(UFP128::from_uint(0) == res);
 
     // ceil
-    value = UFP128 {
-        value: U128::from((1, 3)),
-    };
+    value = UFP128::from(U128::from((1, 3)));
     res = value.ceil();
     assert(UFP128::from_uint(2) == res);
 
@@ -72,15 +58,11 @@ fn main() -> bool {
     assert(UFP128::from_uint(1) == res);
 
     // round
-    value = UFP128 {
-        value: U128::from((1, 3)),
-    };
+    value = UFP128::from(U128::from((1, 3)));
     res = value.round();
     assert(UFP128::from_uint(1) == res);
 
-    value = UFP128 {
-        value: U128::from((1, (1 << 63) + 1)),
-    };
+    value = UFP128::from(U128::from((1, (1 << 63) + 1)));
     res = value.round();
     assert(UFP128::from_uint(2) == res);
 

--- a/tests/src/fixed_point/ufp32_exp_test/src/main.sw
+++ b/tests/src/fixed_point/ufp32_exp_test/src/main.sw
@@ -6,23 +6,23 @@ use std::assert::assert;
 fn main() -> bool {
     let one = UFP32::from_uint(1);
     let mut res = UFP32::exp(one);
-    assert(res.value == 11674811894);
+    assert(res.underlying() == 11674811894);
 
     let two = UFP32::from_uint(2);
     res = UFP32::exp(two);
-    assert(res.value == 31700949040);
+    assert(res.underlying() == 31700949040);
 
     let four = UFP32::from_uint(4);
     res = UFP32::exp(four);
-    assert(res.value == 222506572928);
+    assert(res.underlying() == 222506572928);
 
     let seven = UFP32::from_uint(7);
     res = UFP32::exp(seven);
-    assert(res.value == 2819944203710);
+    assert(res.underlying() == 2819944203710);
 
     let ten = UFP32::from_uint(10);
     res = UFP32::exp(ten);
-    assert(res.value == 20833521987056);
+    assert(res.underlying() == 20833521987056);
 
     true
 }

--- a/tests/src/fixed_point/ufp32_test/src/main.sw
+++ b/tests/src/fixed_point/ufp32_test/src/main.sw
@@ -25,33 +25,31 @@ fn main() -> bool {
     assert(UFP32::from_uint(156) == res);
 
     // recip
-    let mut value = UFP32 { value: 3u32 };
+    let mut value = UFP32::from(3u32);
     res = UFP32::recip(value);
-    assert(UFP32 {
-        value: 536870912,
-    } == res);
+    assert(UFP32::from(536870912) == res);
 
     // trunc
-    value = UFP32 { value: 3u32 };
+    value = UFP32::from(3u32);
     res = value.trunc();
     assert(UFP32::from_uint(1) == res);
 
     // floor
-    value = UFP32 { value: 3u32 };
+    value = UFP32::from(3u32);
     res = value.floor();
     assert(UFP32::from_uint(1) == res);
 
     // fract
-    value = UFP32 { value: 3u32 };
+    value = UFP32::from(3u32);
     res = value.fract();
-    assert(UFP32 { value: 3 } == res);
+    assert(UFP32::from(3) == res);
 
     value = UFP32::from_uint(1);
     res = value.fract();
     assert(UFP32::from_uint(0) == res);
 
     // ceil
-    value = UFP32 { value: 3u32 };
+    value = UFP32::from(3u32);
     res = value.ceil();
     assert(UFP32::from_uint(2) == res);
 
@@ -60,13 +58,11 @@ fn main() -> bool {
     assert(UFP32::from_uint(1) == res);
 
     // round
-    value = UFP32 { value: 3u32 };
+    value = UFP32::from(3u32);
     res = value.round();
     assert(UFP32::from_uint(1) == res);
 
-    value = UFP32 {
-        value: 2147483649u32,
-    };
+    value = UFP32::from(2147483649u32);
     res = value.round();
     assert(UFP32::from_uint(2) == res);
 

--- a/tests/src/fixed_point/ufp64_exp_test/src/main.sw
+++ b/tests/src/fixed_point/ufp64_exp_test/src/main.sw
@@ -6,23 +6,23 @@ use std::assert::assert;
 fn main() -> bool {
     let one = UFP64::from_uint(1);
     let mut res = UFP64::exp(one);
-    assert(res.value == 11674811894);
+    assert(res.underlying() == 11674811894);
 
     let two = UFP64::from_uint(2);
     res = UFP64::exp(two);
-    assert(res.value == 31700949040);
+    assert(res.underlying() == 31700949040);
 
     let four = UFP64::from_uint(4);
     res = UFP64::exp(four);
-    assert(res.value == 222506572928);
+    assert(res.underlying() == 222506572928);
 
     let seven = UFP64::from_uint(7);
     res = UFP64::exp(seven);
-    assert(res.value == 2819944203710);
+    assert(res.underlying() == 2819944203710);
 
     let ten = UFP64::from_uint(10);
     res = UFP64::exp(ten);
-    assert(res.value == 20833521987056);
+    assert(res.underlying() == 20833521987056);
 
     true
 }

--- a/tests/src/fixed_point/ufp64_test/src/main.sw
+++ b/tests/src/fixed_point/ufp64_test/src/main.sw
@@ -25,43 +25,31 @@ fn main() -> bool {
     assert(UFP64::from_uint(156) == res);
 
     // recip
-    let mut value = UFP64 {
-        value: 1 << 32 + 3,
-    };
+    let mut value = UFP64::from(1 << 32 + 3);
     res = UFP64::recip(value);
-    assert(UFP64 {
-        value: 536870912,
-    } == res);
+    assert(UFP64::from(536870912) == res);
 
     // trunc
-    value = UFP64 {
-        value: (1 << 32) + 3,
-    };
+    value = UFP64::from((1 << 32) + 3);
     res = value.trunc();
     assert(UFP64::from_uint(1) == res);
 
     // floor
-    value = UFP64 {
-        value: (1 << 32) + 3,
-    };
+    value = UFP64::from((1 << 32) + 3);
     res = value.floor();
     assert(UFP64::from_uint(1) == res);
 
     // fract
-    value = UFP64 {
-        value: (1 << 32) + 3,
-    };
+    value = UFP64::from((1 << 32) + 3);
     res = value.fract();
-    assert(UFP64 { value: 3 } == res);
+    assert(UFP64::from(3) == res);
 
     value = UFP64::from_uint(1);
     res = value.fract();
     assert(UFP64::from_uint(0) == res);
 
     // ceil
-    value = UFP64 {
-        value: (1 << 32) + 3,
-    };
+    value = UFP64::from((1 << 32) + 3);
     res = value.ceil();
     assert(UFP64::from_uint(2) == res);
 
@@ -70,15 +58,11 @@ fn main() -> bool {
     assert(UFP64::from_uint(1) == res);
 
     // round
-    value = UFP64 {
-        value: (1 << 32) + 3,
-    };
+    value = UFP64::from((1 << 32) + 3);
     res = value.round();
     assert(UFP64::from_uint(1) == res);
 
-    value = UFP64 {
-        value: (1 << 32) + (1 << 31) + 1,
-    };
+    value = UFP64::from((1 << 32) + (1 << 31) + 1);
     res = value.round();
     assert(UFP64::from_uint(2) == res);
 

--- a/tests/src/native_asset/Forc.toml
+++ b/tests/src/native_asset/Forc.toml
@@ -5,5 +5,5 @@ license = "Apache-2.0"
 name = "native_asset_lib"
 
 [dependencies]
-standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.4.3" }
+standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.5.0" }
 sway_libs = { path = "../../../libs" }

--- a/tests/src/native_asset/src/main.sw
+++ b/tests/src/native_asset/src/main.sw
@@ -111,8 +111,6 @@ impl SetAssetMetadata for Contract {
 
 #[test]
 fn test_total_assets() {
-    use std::constants::ZERO_B256;
-
     let src3_abi = abi(SRC3, CONTRACT_ID);
     let src20_abi = abi(SRC20, CONTRACT_ID);
 
@@ -131,13 +129,11 @@ fn test_total_assets() {
 
 #[test]
 fn test_total_supply() {
-    use std::constants::ZERO_B256;
-
     let src3_abi = abi(SRC3, CONTRACT_ID);
     let src20_abi = abi(SRC20, CONTRACT_ID);
 
     let recipient = Identity::ContractId(ContractId::from(CONTRACT_ID));
-    let sub_id = ZERO_B256;
+    let sub_id = SubId::zero();
     let asset_id = AssetId::new(ContractId::from(CONTRACT_ID), sub_id);
 
     assert(src20_abi.total_supply(asset_id).is_none());
@@ -151,13 +147,11 @@ fn test_total_supply() {
 
 #[test]
 fn test_name() {
-    use std::constants::ZERO_B256;
-
     let src20_abi = abi(SRC20, CONTRACT_ID);
     let attributes_abi = abi(SetAssetAttributes, CONTRACT_ID);
 
     let recipient = Identity::ContractId(ContractId::from(CONTRACT_ID));
-    let sub_id = ZERO_B256;
+    let sub_id = SubId::zero();
     let asset_id = AssetId::new(ContractId::from(CONTRACT_ID), sub_id);
     let name = String::from_ascii_str("Fuel Asset");
 
@@ -169,13 +163,11 @@ fn test_name() {
 
 #[test]
 fn test_symbol() {
-    use std::constants::ZERO_B256;
-
     let src20_abi = abi(SRC20, CONTRACT_ID);
     let attributes_abi = abi(SetAssetAttributes, CONTRACT_ID);
 
     let recipient = Identity::ContractId(ContractId::from(CONTRACT_ID));
-    let sub_id = ZERO_B256;
+    let sub_id = SubId::zero();
     let asset_id = AssetId::new(ContractId::from(CONTRACT_ID), sub_id);
     let symbol = String::from_ascii_str("FUEL");
 
@@ -187,13 +179,11 @@ fn test_symbol() {
 
 #[test]
 fn test_decimals() {
-    use std::constants::ZERO_B256;
-
     let src20_abi = abi(SRC20, CONTRACT_ID);
     let attributes_abi = abi(SetAssetAttributes, CONTRACT_ID);
 
     let recipient = Identity::ContractId(ContractId::from(CONTRACT_ID));
-    let sub_id = ZERO_B256;
+    let sub_id = SubId::zero();
     let asset_id = AssetId::new(ContractId::from(CONTRACT_ID), sub_id);
     let decimals = 8u8;
 
@@ -206,13 +196,12 @@ fn test_decimals() {
 #[test]
 fn test_mint() {
     use std::context::balance_of;
-    use std::constants::ZERO_B256;
 
     let src3_abi = abi(SRC3, CONTRACT_ID);
     let src20_abi = abi(SRC20, CONTRACT_ID);
 
     let recipient = Identity::ContractId(ContractId::from(CONTRACT_ID));
-    let sub_id = ZERO_B256;
+    let sub_id = SubId::zero();
     let asset_id = AssetId::new(ContractId::from(CONTRACT_ID), sub_id);
 
     assert(balance_of(ContractId::from(CONTRACT_ID), asset_id) == 0);
@@ -224,13 +213,12 @@ fn test_mint() {
 #[test]
 fn test_burn() {
     use std::context::balance_of;
-    use std::constants::ZERO_B256;
 
     let src3_abi = abi(SRC3, CONTRACT_ID);
     let src20_abi = abi(SRC20, CONTRACT_ID);
 
     let recipient = Identity::ContractId(ContractId::from(CONTRACT_ID));
-    let sub_id = ZERO_B256;
+    let sub_id = SubId::zero();
     let asset_id = AssetId::new(ContractId::from(CONTRACT_ID), sub_id);
 
     src3_abi.mint(recipient, sub_id, 10);
@@ -306,11 +294,9 @@ fn test_metadata_is_b256() {
 
 #[test]
 fn test_set_metadata_b256() {
-    use std::constants::ZERO_B256;
-
     let data_b256 = 0x0000000000000000000000000000000000000000000000000000000000000001;
     let metadata = Metadata::B256(data_b256);
-    let asset_id = AssetId::new(ContractId::from(CONTRACT_ID), ZERO_B256);
+    let asset_id = AssetId::new(ContractId::from(CONTRACT_ID), SubId::zero());
     let src7_abi = abi(SRC7, CONTRACT_ID);
     let set_metadata_abi = abi(SetAssetMetadata, CONTRACT_ID);
     let key = String::from_ascii_str("my_key");
@@ -324,11 +310,9 @@ fn test_set_metadata_b256() {
 
 #[test]
 fn test_set_metadata_u64() {
-    use std::constants::ZERO_B256;
-
     let data_int = 1;
     let metadata = Metadata::Int(data_int);
-    let asset_id = AssetId::new(ContractId::from(CONTRACT_ID), ZERO_B256);
+    let asset_id = AssetId::new(ContractId::from(CONTRACT_ID), SubId::zero());
     let src7_abi = abi(SRC7, CONTRACT_ID);
     let set_metadata_abi = abi(SetAssetMetadata, CONTRACT_ID);
     let key = String::from_ascii_str("my_key");
@@ -342,11 +326,9 @@ fn test_set_metadata_u64() {
 
 #[test]
 fn test_set_metadata_string() {
-    use std::constants::ZERO_B256;
-
     let data_string = String::from_ascii_str("Fuel is blazingly fast");
     let metadata = Metadata::String(data_string);
-    let asset_id = AssetId::new(ContractId::from(CONTRACT_ID), ZERO_B256);
+    let asset_id = AssetId::new(ContractId::from(CONTRACT_ID), SubId::zero());
     let src7_abi = abi(SRC7, CONTRACT_ID);
     let set_metadata_abi = abi(SetAssetMetadata, CONTRACT_ID);
     let key = String::from_ascii_str("my_key");
@@ -360,11 +342,9 @@ fn test_set_metadata_string() {
 
 #[test]
 fn test_set_metadata_bytes() {
-    use std::constants::ZERO_B256;
-
     let data_bytes = String::from_ascii_str("Fuel is blazingly fast").as_bytes();
     let metadata = Metadata::Bytes(data_bytes);
-    let asset_id = AssetId::new(ContractId::from(CONTRACT_ID), ZERO_B256);
+    let asset_id = AssetId::new(ContractId::from(CONTRACT_ID), SubId::zero());
     let src7_abi = abi(SRC7, CONTRACT_ID);
     let set_metadata_abi = abi(SetAssetMetadata, CONTRACT_ID);
     let key = String::from_ascii_str("my_key");
@@ -379,13 +359,12 @@ fn test_set_metadata_bytes() {
 #[test]
 fn total_assets_only_incremented_once() {
     use std::context::balance_of;
-    use std::constants::ZERO_B256;
 
     let src3_abi = abi(SRC3, CONTRACT_ID);
     let src20_abi = abi(SRC20, CONTRACT_ID);
 
     let recipient = Identity::ContractId(ContractId::from(CONTRACT_ID));
-    let sub_id = ZERO_B256;
+    let sub_id = SubId::zero();
     let asset_id = AssetId::new(ContractId::from(CONTRACT_ID), sub_id);
 
     assert(src20_abi.total_assets() == 0);

--- a/tests/src/ownership/Forc.toml
+++ b/tests/src/ownership/Forc.toml
@@ -5,5 +5,5 @@ license = "Apache-2.0"
 name = "ownership_test"
 
 [dependencies]
-standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.4.3" }
+standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.5.0" }
 sway_libs = { path = "../../../libs" }

--- a/tests/src/reentrancy/reentrancy_attacker_contract/src/main.sw
+++ b/tests/src/reentrancy/reentrancy_attacker_contract/src/main.sw
@@ -1,6 +1,6 @@
 contract;
 
-use std::{auth::*, constants::ZERO_B256};
+use std::auth::*;
 
 use reentrancy_target_abi::Target;
 use reentrancy_attacker_abi::Attacker;
@@ -15,8 +15,8 @@ fn get_msg_sender_id_or_panic() -> ContractId {
 }
 
 storage {
-    target_id: ContractId = ContractId::from(ZERO_B256),
-    helper: ContractId = ContractId::from(ZERO_B256),
+    target_id: ContractId = ContractId::zero(),
+    helper: ContractId = ContractId::zero(),
 }
 
 impl Attacker for Contract {

--- a/tests/src/reentrancy/reentrancy_target_contract/src/main.sw
+++ b/tests/src/reentrancy/reentrancy_target_contract/src/main.sw
@@ -20,9 +20,7 @@ impl Target for Contract {
             true
         } else {
             // this call transfers control to the attacker contract, allowing it to execute arbitrary code.
-            abi(Attacker, get_msg_sender_id_or_panic()
-                .bits())
-                .evil_callback_1()
+            abi(Attacker, get_msg_sender_id_or_panic().bits()).evil_callback_1()
         }
     }
 

--- a/tests/src/signed_integers/signed_i128/src/main.sw
+++ b/tests/src/signed_integers/signed_i128/src/main.sw
@@ -13,7 +13,7 @@ fn main() -> bool {
     let u128_10 = U128::from((0, 10));
     let u128_11 = U128::from((0, 11));
     res = I128::from(u128_10) - I128::from(u128_11);
-    assert(res.underlying.lower() == u64::max());
+    assert(res.underlying().lower() == u64::max());
 
     res = I128::from(u128_10) * I128::neg_from(u128_one);
     assert(res == I128::neg_from(u128_10));
@@ -24,9 +24,7 @@ fn main() -> bool {
 
     let u128_lower_max_u64 = U128::from((0, u64::max()));
 
-    res = I128::from(u128_10) / I128 {
-        underlying: u128_lower_max_u64,
-    };
+    res = I128::from(u128_10) / I128::from(u128_lower_max_u64);
     assert(res == I128::neg_from(u128_10));
 
     let u128_5 = U128::from((0, 5));

--- a/tests/src/signed_integers/signed_i128_twos_complement/src/main.sw
+++ b/tests/src/signed_integers/signed_i128_twos_complement/src/main.sw
@@ -13,19 +13,19 @@ fn main() -> bool {
     assert(res.twos_complement() == I128::from(U128::from((0, 10))));
 
     res = I128::neg_from(U128::from((0, 5)));
-    assert(res.twos_complement().underlying - u_one + res.underlying == U128::max());
+    assert(res.twos_complement().underlying() - u_one + res.underlying() == U128::max());
 
     res = I128::neg_from(U128::from((0, 27)));
-    assert(res.twos_complement().underlying - u_one + res.underlying == U128::max());
+    assert(res.twos_complement().underlying() - u_one + res.underlying() == U128::max());
 
     res = I128::neg_from(U128::from((0, 110)));
-    assert(res.twos_complement().underlying - u_one + res.underlying == U128::max());
+    assert(res.twos_complement().underlying() - u_one + res.underlying() == U128::max());
 
     res = I128::neg_from(U128::from((0, 93)));
-    assert(res.twos_complement().underlying - u_one + res.underlying == U128::max());
+    assert(res.twos_complement().underlying() - u_one + res.underlying() == U128::max());
 
     res = I128::neg_from(U128::from((0, 78)));
-    assert(res.twos_complement().underlying - u_one + res.underlying == U128::max());
+    assert(res.twos_complement().underlying() - u_one + res.underlying() == U128::max());
 
     true
 }

--- a/tests/src/signed_integers/signed_i16/src/main.sw
+++ b/tests/src/signed_integers/signed_i16/src/main.sw
@@ -8,9 +8,7 @@ fn main() -> bool {
     assert(res == I16::from(2u16));
 
     res = I16::from(10u16) - I16::from(11u16);
-    assert(res == I16 {
-        underlying: 32767u16,
-    });
+    assert(res == I16::from(32767u16));
 
     res = I16::from(10u16) * I16::neg_from(1u16);
     assert(res == I16::neg_from(10u16));

--- a/tests/src/signed_integers/signed_i16_twos_complement/src/main.sw
+++ b/tests/src/signed_integers/signed_i16_twos_complement/src/main.sw
@@ -11,19 +11,19 @@ fn main() -> bool {
     assert(res.twos_complement() == I16::from(10u16));
 
     res = I16::neg_from(5);
-    assert(res.twos_complement().underlying + res.underlying == u16::max() + 1);
+    assert(res.twos_complement().underlying() + res.underlying() == u16::max() + 1);
 
     res = I16::neg_from(27u16);
-    assert(res.twos_complement().underlying + res.underlying == u16::max() + 1);
+    assert(res.twos_complement().underlying() + res.underlying() == u16::max() + 1);
 
     res = I16::neg_from(110u16);
-    assert(res.twos_complement().underlying + res.underlying == u16::max() + 1);
+    assert(res.twos_complement().underlying() + res.underlying() == u16::max() + 1);
 
     res = I16::neg_from(93u16);
-    assert(res.twos_complement().underlying + res.underlying == u16::max() + 1);
+    assert(res.twos_complement().underlying() + res.underlying() == u16::max() + 1);
 
     res = I16::neg_from(78u16);
-    assert(res.twos_complement().underlying + res.underlying == u16::max() + 1);
+    assert(res.twos_complement().underlying() + res.underlying() == u16::max() + 1);
 
     true
 }

--- a/tests/src/signed_integers/signed_i256/src/main.sw
+++ b/tests/src/signed_integers/signed_i256/src/main.sw
@@ -48,9 +48,7 @@ fn main() -> bool {
         r1: u256
     };
 
-    res = I256::from(u128_10) / I256 {
-        underlying: u128_lower_max_u64,
-    };
+    res = I256::from(u128_10) / I256::from(u128_lower_max_u64);
     assert(res == I256::neg_from(u128_10));
 
     let parts_5 = (0, 0, 0, 5);

--- a/tests/src/signed_integers/signed_i256_twos_complement/src/main.sw
+++ b/tests/src/signed_integers/signed_i256_twos_complement/src/main.sw
@@ -27,35 +27,35 @@ fn main() -> bool {
         r1: u256
     };
     res = I256::neg_from(u_5);
-    assert(res.twos_complement().underlying - u_one + res.underlying == U256::max());
+    assert(res.twos_complement().underlying() - u_one + res.underlying() == U256::max());
 
     let parts_27 = (0, 0, 0, 27);
     let u_27 = asm(r1: parts_27) {
         r1: u256
     };
     res = I256::neg_from(u_27);
-    assert(res.twos_complement().underlying - u_one + res.underlying == U256::max());
+    assert(res.twos_complement().underlying() - u_one + res.underlying() == U256::max());
 
     let parts_110 = (0, 0, 0, 110);
     let u_110 = asm(r1: parts_110) {
         r1: u256
     };
     res = I256::neg_from(u_110);
-    assert(res.twos_complement().underlying - u_one + res.underlying == U256::max());
+    assert(res.twos_complement().underlying() - u_one + res.underlying() == U256::max());
 
     let parts_93 = (0, 0, 0, 93);
     let u_93 = asm(r1: parts_93) {
         r1: u256
     };
     res = I256::neg_from(parts_93);
-    assert(res.twos_complement().underlying - u_one + res.underlying == U256::max());
+    assert(res.twos_complement().underlying() - u_one + res.underlying() == U256::max());
 
     let parts_78 = (0, 0, 0, 78);
     let u_78 = asm(r1: parts_78) {
         r1: u256
     };
     res = I256::neg_from(u_78);
-    assert(res.twos_complement().underlying - u_one + res.underlying == U256::max());
+    assert(res.twos_complement().underlying() - u_one + res.underlying() == U256::max());
 
     true
 }

--- a/tests/src/signed_integers/signed_i32/src/main.sw
+++ b/tests/src/signed_integers/signed_i32/src/main.sw
@@ -3,52 +3,24 @@ script;
 use sway_libs::signed_integers::i32::I32;
 
 fn main() -> bool {
-    let one = I32 {
-        underlying: 1u32,
-    };
-    let mut res = one + I32 {
-        underlying: 1u32,
-    };
-    assert(res == I32 {
-        underlying: 2u32,
-    });
+    let one = I32::from(1u32);
+    let mut res = one + I32::from(1u32);
+    assert(res == I32::from(2u32));
 
-    res = I32 {
-        underlying: 10u32,
-    } - I32 {
-        underlying: 11u32,
-    };
+    res = I32::from(10u32) - I32::from(11u32);
     assert(res == I32::from(2147483647u32));
 
-    res = I32 {
-        underlying: 10u32,
-    } * I32 {
-        underlying: 1u32,
-    };
+    res = I32::from(10u32) * I32::from(1u32);
     assert(res == I32::neg_from(10u32));
 
-    res = I32 {
-        underlying: 10u32,
-    } * I32 {
-        underlying: 10u32,
-    };
-    assert(res == I32 {
-        underlying: 100u32,
-    });
+    res = I32::from(10u32) * I32::from(10u32);
+    assert(res == I32::from(100u32));
 
-    res = I32 {
-        underlying: 10u32,
-    } / I32::neg_from(1u32);
+    res = I32::from(10u32) / I32::neg_from(1u32);
     assert(res == I32::neg_from(10u32));
 
-    res = I32 {
-        underlying: 10u32,
-    } / I32 {
-        underlying: 5u32,
-    };
-    assert(res == I32 {
-        underlying: 2u32,
-    });
+    res = I32::from(10u32) / I32::from(5u32);
+    assert(res == I32::from(2u32));
 
     true
 }

--- a/tests/src/signed_integers/signed_i32_twos_complement/src/main.sw
+++ b/tests/src/signed_integers/signed_i32_twos_complement/src/main.sw
@@ -11,19 +11,19 @@ fn main() -> bool {
     assert(res.twos_complement() == I32::from(10u32));
 
     res = I32::neg_from(5);
-    assert(res.twos_complement().underlying + res.underlying == u32::max() + 1);
+    assert(res.twos_complement().underlying() + res.underlying() == u32::max() + 1);
 
     res = I32::neg_from(27u32);
-    assert(res.twos_complement().underlying + res.underlying == u32::max() + 1);
+    assert(res.twos_complement().underlying() + res.underlying() == u32::max() + 1);
 
     res = I32::neg_from(110u32);
-    assert(res.twos_complement().underlying + res.underlying == u32::max() + 1);
+    assert(res.twos_complement().underlying() + res.underlying() == u32::max() + 1);
 
     res = I32::neg_from(93u32);
-    assert(res.twos_complement().underlying + res.underlying == u32::max() + 1);
+    assert(res.twos_complement().underlying() + res.underlying() == u32::max() + 1);
 
     res = I32::neg_from(78u32);
-    assert(res.twos_complement().underlying + res.underlying == u32::max() + 1);
+    assert(res.twos_complement().underlying() + res.underlying() == u32::max() + 1);
 
     true
 }

--- a/tests/src/signed_integers/signed_i64/src/main.sw
+++ b/tests/src/signed_integers/signed_i64/src/main.sw
@@ -8,18 +8,14 @@ fn main() -> bool {
     assert(res == I64::from(2u64));
 
     res = I64::from(10u64) - I64::from(11u64);
-    assert(res == I64 {
-        underlying: 9223372036854775807u64,
-    });
+    assert(res == I64::from(9223372036854775807u64));
     res = I64::from(10u64) * I64::neg_from(1);
     assert(res == I64::neg_from(10));
 
     res = I64::from(10u64) * I64::from(10u64);
     assert(res == I64::from(100u64));
 
-    res = I64::from(10u64) / I64 {
-        underlying: 9223372036854775807u64,
-    };
+    res = I64::from(10u64) / I64::from(9223372036854775807u64);
     assert(res == I64::neg_from(10u64));
 
     res = I64::from(10u64) / I64::from(5u64);

--- a/tests/src/signed_integers/signed_i64_twos_complement/src/main.sw
+++ b/tests/src/signed_integers/signed_i64_twos_complement/src/main.sw
@@ -11,19 +11,19 @@ fn main() -> bool {
     assert(res.twos_complement() == I64::from(10));
 
     res = I64::neg_from(5);
-    assert(res.twos_complement().underlying + res.underlying == u64::max() + 1);
+    assert(res.twos_complement().underlying() + res.underlying() == u64::max() + 1);
 
     res = I64::neg_from(27);
-    assert(res.twos_complement().underlying + res.underlying == u64::max() + 1);
+    assert(res.twos_complement().underlying() + res.underlying() == u64::max() + 1);
 
     res = I64::neg_from(110);
-    assert(res.twos_complement().underlying + res.underlying == u64::max() + 1);
+    assert(res.twos_complement().underlying() + res.underlying() == u64::max() + 1);
 
     res = I64::neg_from(93);
-    assert(res.twos_complement().underlying + res.underlying == u64::max() + 1);
+    assert(res.twos_complement().underlying() + res.underlying() == u64::max() + 1);
 
     res = I64::neg_from(78);
-    assert(res.twos_complement().underlying + res.underlying == u64::max() + 1);
+    assert(res.twos_complement().underlying() + res.underlying() == u64::max() + 1);
 
     true
 }

--- a/tests/src/signed_integers/signed_i8/src/main.sw
+++ b/tests/src/signed_integers/signed_i8/src/main.sw
@@ -8,26 +8,16 @@ fn main() -> bool {
     assert(res == I8::from(2u8));
 
     res = I8::from(10u8) - I8::from(11u8);
-    assert(res == I8 {
-        underlying: 127u8,
-    });
+    assert(res == I8::from(127u8));
 
-    res = I8::from(10u8) * I8 {
-        underlying: 127u8,
-    };
-    assert(res == I8 {
-        underlying: 118u8,
-    });
+    res = I8::from(10u8) * I8::from(127u8);
+    assert(res == I8::from(118u8));
 
     res = I8::from(10u8) * I8::from(10u8);
     assert(res == I8::from(100u8));
 
-    res = I8::from(10u8) / I8 {
-        underlying: 127u8,
-    };
-    assert(res == I8 {
-        underlying: 118u8,
-    });
+    res = I8::from(10u8) / I8::from(127u8);
+    assert(res == I8::from(118u8));
 
     res = I8::from(10u8) / I8::from(5u8);
     assert(res == I8::from(2u8));

--- a/tests/src/signed_integers/signed_i8_twos_complement/src/main.sw
+++ b/tests/src/signed_integers/signed_i8_twos_complement/src/main.sw
@@ -11,19 +11,19 @@ fn main() -> bool {
     assert(res.twos_complement() == I8::from(10u8));
 
     res = I8::neg_from(5);
-    assert(res.twos_complement().underlying + res.underlying == u8::max() + 1);
+    assert(res.twos_complement().underlying() + res.underlying() == u8::max() + 1);
 
     res = I8::neg_from(27u8);
-    assert(res.twos_complement().underlying + res.underlying == u8::max() + 1);
+    assert(res.twos_complement().underlying() + res.underlying() == u8::max() + 1);
 
     res = I8::neg_from(110u8);
-    assert(res.twos_complement().underlying + res.underlying == u8::max() + 1);
+    assert(res.twos_complement().underlying() + res.underlying() == u8::max() + 1);
 
     res = I8::neg_from(93u8);
-    assert(res.twos_complement().underlying + res.underlying == u8::max() + 1);
+    assert(res.twos_complement().underlying() + res.underlying() == u8::max() + 1);
 
     res = I8::neg_from(78u8);
-    assert(res.twos_complement().underlying + res.underlying == u8::max() + 1);
+    assert(res.twos_complement().underlying() + res.underlying() == u8::max() + 1);
 
     true
 }


### PR DESCRIPTION
## Type of change

<!--Delete points that do not apply-->

- Improvement (refactoring, restructuring repository, cleaning tech debt, ...)

## Changes

The following changes have been made:

- Updates the repository to use forc v0.60.0
- Makes fields in signed integers and fixed point numbers private
- Adds `Self::zero()`, `self::is_zero()`, and `self::underlying()` to signed integers and fixed point numbers

# Breaking Changes

Public struct fields are now PRIVATE in the `fixed_point` and `signed_integers` libraries. If the fields are needed, they can be fetched with a corresponding `my_type.underlying()` function. For example, `I8`'s underlying `u8` may be fetched with:

```sway
let my_i8: I8 = I8::zero();
let underlying: u8 = my_i8.underlying();
```

For types that have a `non_negative` field, the same applies:

```sway
let my_ifp64: IFP64 = IFP64::zero();
let non_negative: bool = my_ifp64.non_negative();
```