### PR TITLE
add cargo.toml with version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "sway-libs"
+version = "0.21.0"
+edition = "2021"


### PR DESCRIPTION
adds a Cargo.toml file with the repo version number to make it easier to get the current version in the docs-hub