### PR TITLE
Add `OrdEq` impl to Signed Integers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Description of the upcoming release here.
 
 - [#259](https://github.com/FuelLabs/sway-libs/pull/259) Adds a new upgradability library, including associated tests and documentation.
 - [#265](https://github.com/FuelLabs/sway-libs/pull/265) Adds the `SetMetadataEvent` and emits `SetMetadataEvent` when the `_set_metadata()` function is called.
+- [https://github.com/FuelLabs/sway-libs/pull/270](https://github.com/FuelLabs/sway-libs/pull/270) Adds `OrdEq` functionality to Signed Integers.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Description of the upcoming release here.
 
 - [#259](https://github.com/FuelLabs/sway-libs/pull/259) Adds a new upgradability library, including associated tests and documentation.
 - [#265](https://github.com/FuelLabs/sway-libs/pull/265) Adds the `SetMetadataEvent` and emits `SetMetadataEvent` when the `_set_metadata()` function is called.
-- [https://github.com/FuelLabs/sway-libs/pull/270](https://github.com/FuelLabs/sway-libs/pull/270) Adds `OrdEq` functionality to Signed Integers.
+- [#270](https://github.com/FuelLabs/sway-libs/pull/270) Adds `OrdEq` functionality to Signed Integers.
 
 ### Changed
 

--- a/libs/src/signed_integers/i128.sw
+++ b/libs/src/signed_integers/i128.sw
@@ -64,6 +64,8 @@ impl core::ops::Ord for I128 {
     }
 }
 
+impl core::ops::OrdEq for I128 {}
+
 impl I128 {
     /// The size of this type in bits.
     ///

--- a/libs/src/signed_integers/i16.sw
+++ b/libs/src/signed_integers/i16.sw
@@ -62,6 +62,8 @@ impl core::ops::Ord for I16 {
     }
 }
 
+impl core::ops::OrdEq for I16 {}
+
 impl I16 {
     /// The size of this type in bits.
     ///

--- a/libs/src/signed_integers/i256.sw
+++ b/libs/src/signed_integers/i256.sw
@@ -64,6 +64,8 @@ impl core::ops::Ord for I256 {
     }
 }
 
+impl core::ops::OrdEq for I256 {}
+
 impl I256 {
     /// The size of this type in bits.
     ///

--- a/libs/src/signed_integers/i32.sw
+++ b/libs/src/signed_integers/i32.sw
@@ -61,6 +61,8 @@ impl core::ops::Ord for I32 {
     }
 }
 
+impl core::ops::OrdEq for I32 {}
+
 impl I32 {
     /// The size of this type in bits.
     ///

--- a/libs/src/signed_integers/i64.sw
+++ b/libs/src/signed_integers/i64.sw
@@ -61,6 +61,8 @@ impl core::ops::Ord for I64 {
     }
 }
 
+impl core::ops::OrdEq for I64 {}
+
 impl I64 {
     /// The size of this type in bits.
     ///

--- a/libs/src/signed_integers/i8.sw
+++ b/libs/src/signed_integers/i8.sw
@@ -61,6 +61,8 @@ impl core::ops::Ord for I8 {
     }
 }
 
+impl core::ops::OrdEq for I8 {}
+
 impl I8 {
     /// The size of this type in bits.
     ///

--- a/tests/src/signed_integers/signed_i128/src/main.sw
+++ b/tests/src/signed_integers/signed_i128/src/main.sw
@@ -34,5 +34,38 @@ fn main() -> bool {
     res = I128::from(u128_10) / I128::from(u128_5);
     assert(res == I128::from(u128_2));
 
+    // OrqEq Tests
+    let one_1 = I128::from(U128::from((0, 1)));
+    let one_2 = I128::from(U128::from((0, 1)));
+    let neg_one_1 = I128::neg_from(U128::from((0, 1)));
+    let neg_one_2 = I128::neg_from(U128::from((0, 1)));
+    let max_1 = I128::max();
+    let max_2 = I128::max();
+    let min_1 = I128::min();
+    let min_2 = I128::min();
+
+    assert(one_1 >= one_2);
+    assert(one_1 <= one_2);
+    assert(neg_one_1 >= neg_one_2);
+    assert(neg_one_1 <= neg_one_2);
+    assert(max_1 >= max_1);
+    assert(max_1 <= max_1);
+    assert(min_1 >= min_1);
+    assert(min_1 <= min_1);
+
+    assert(min_1 <= one_1);
+    assert(min_1 <= neg_one_1);
+    assert(min_1 <= max_1);
+    assert(neg_one_1 <= max_1);
+    assert(neg_one_1 <= one_1);
+    assert(one_1 <= max_1);
+
+    assert(max_1 >= one_1);
+    assert(max_1 >= neg_one_1);
+    assert(max_1 >= min_1);
+    assert(one_1 >= neg_one_1);
+    assert(one_1 >= min_1);
+    assert(neg_one_1 >= min_1);
+
     true
 }

--- a/tests/src/signed_integers/signed_i16/src/main.sw
+++ b/tests/src/signed_integers/signed_i16/src/main.sw
@@ -22,5 +22,38 @@ fn main() -> bool {
     res = I16::from(10u16) / I16::from(5u16);
     assert(res == I16::from(2u16));
 
+    // OrqEq Tests
+    let one_1 = I16::from(1u16);
+    let one_2 = I16::from(1u16);
+    let neg_one_1 = I16::neg_from(1u16);
+    let neg_one_2 = I16::neg_from(1u16);
+    let max_1 = I16::max();
+    let max_2 = I16::max();
+    let min_1 = I16::min();
+    let min_2 = I16::min();
+
+    assert(one_1 >= one_2);
+    assert(one_1 <= one_2);
+    assert(neg_one_1 >= neg_one_2);
+    assert(neg_one_1 <= neg_one_2);
+    assert(max_1 >= max_1);
+    assert(max_1 <= max_1);
+    assert(min_1 >= min_1);
+    assert(min_1 <= min_1);
+
+    assert(min_1 <= one_1);
+    assert(min_1 <= neg_one_1);
+    assert(min_1 <= max_1);
+    assert(neg_one_1 <= max_1);
+    assert(neg_one_1 <= one_1);
+    assert(one_1 <= max_1);
+
+    assert(max_1 >= one_1);
+    assert(max_1 >= neg_one_1);
+    assert(max_1 >= min_1);
+    assert(one_1 >= neg_one_1);
+    assert(one_1 >= min_1);
+    assert(neg_one_1 >= min_1);
+
     true
 }

--- a/tests/src/signed_integers/signed_i256/src/main.sw
+++ b/tests/src/signed_integers/signed_i256/src/main.sw
@@ -5,68 +5,100 @@ use sway_libs::signed_integers::i256::I256;
 fn main() -> bool {
     let parts_one = (0, 0, 0, 1);
     let parts_two = (0, 0, 0, 2);
-    let u128_one = asm(r1: parts_one) {
+    let u256_one = asm(r1: parts_one) {
         r1: u256
     };
-    let u128_two = asm(r1: parts_two) {
+    let u256_two = asm(r1: parts_two) {
         r1: u256
     };
 
-    let one = I256::from(u128_one);
-    let mut res = one + I256::from(u128_one);
-    assert(res == I256::from(u128_two));
+    let one = I256::from(u256_one);
+    let mut res = one + I256::from(u256_one);
+    assert(res == I256::from(u256_two));
 
     let parts_10 = (0, 0, 0, 10);
-    let u128_10 = asm(r1: parts_10) {
+    let u256_10 = asm(r1: parts_10) {
         r1: u256
     };
 
     let parts_11 = (0, 0, 0, 11);
-    let u128_11 = asm(r1: parts_11) {
+    let u256_11 = asm(r1: parts_11) {
         r1: u256
     };
 
-    res = I256::from(u128_10) - I256::from(u128_11);
+    res = I256::from(u256_10) - I256::from(u256_11);
     let (a, b, c, d) = asm(r1: res) {
         r1: (u64, u64, u64, u64)
     };
     assert(c == u64::max());
     assert(d == u64::max());
 
-    res = I256::from(u128_10) * I256::neg_from(u128_one);
-    assert(res == I256::neg_from(u128_10));
+    res = I256::from(u256_10) * I256::neg_from(u256_one);
+    assert(res == I256::neg_from(u256_10));
 
-    res = I256::from(u128_10) * I256::from(u128_10);
+    res = I256::from(u256_10) * I256::from(u256_10);
     let parts_100 = (0, 0, 0, 100);
-    let u128_100 = asm(r1: parts_100) {
+    let u256_100 = asm(r1: parts_100) {
         r1: u256
     };
-    assert(res == I256::from(u128_100));
+    assert(res == I256::from(u256_100));
 
     let parts_lower_max_u64 = (0, 0, 0, u64::max());
-    let u128_lower_max_u64 = asm(r1: parts_lower_max_u64) {
+    let u256_lower_max_u64 = asm(r1: parts_lower_max_u64) {
         r1: u256
     };
 
-    res = I256::from(u128_10) / I256::from(u128_lower_max_u64);
-    assert(res == I256::neg_from(u128_10));
+    res = I256::from(u256_10) / I256::from(u256_lower_max_u64);
+    assert(res == I256::neg_from(u256_10));
 
     let parts_5 = (0, 0, 0, 5);
-    let u128_5 = asm(r1: parts_5) {
+    let u256_5 = asm(r1: parts_5) {
         r1: u256
     };
 
     let parts_2 = (0, 0, 0, 2);
-    let u128_2 = asm(r1: parts_2) {
+    let u256_2 = asm(r1: parts_2) {
         r1: u256
     };
 
-    let i256_10 = I256::from(u128_10);
-    let i256_5 = I256::from(u128_5);
-    let i256_2 = I256::from(u128_2);
+    let i256_10 = I256::from(u256_10);
+    let i256_5 = I256::from(u256_5);
+    let i256_2 = I256::from(u256_2);
 
     res = i256_10 / i256_5;
     assert(res == i256_2);
 
+    // OrqEq Tests
+    let one_1 = I256::from(u256_one);
+    let one_2 = I256::from(u256_one);
+    let neg_one_1 = I256::neg_from(u256_one);
+    let neg_one_2 = I256::neg_from(u256_one);
+    let max_1 = I256::max();
+    let max_2 = I256::max();
+    let min_1 = I256::min();
+    let min_2 = I256::min();
+
+    assert(one_1 >= one_2);
+    assert(one_1 <= one_2);
+    assert(neg_one_1 >= neg_one_2);
+    assert(neg_one_1 <= neg_one_2);
+    assert(max_1 >= max_1);
+    assert(max_1 <= max_1);
+    assert(min_1 >= min_1);
+    assert(min_1 <= min_1);
+
+    assert(min_1 <= one_1);
+    assert(min_1 <= neg_one_1);
+    assert(min_1 <= max_1);
+    assert(neg_one_1 <= max_1);
+    assert(neg_one_1 <= one_1);
+    assert(one_1 <= max_1);
+
+    assert(max_1 >= one_1);
+    assert(max_1 >= neg_one_1);
+    assert(max_1 >= min_1);
+    assert(one_1 >= neg_one_1);
+    assert(one_1 >= min_1);
+    assert(neg_one_1 >= min_1);
     true
 }

--- a/tests/src/signed_integers/signed_i32/src/main.sw
+++ b/tests/src/signed_integers/signed_i32/src/main.sw
@@ -22,5 +22,38 @@ fn main() -> bool {
     res = I32::from(10u32) / I32::from(5u32);
     assert(res == I32::from(2u32));
 
+    // OrqEq Tests
+    let one_1 = I32::from(1u32);
+    let one_2 = I32::from(1u32);
+    let neg_one_1 = I32::neg_from(1u32);
+    let neg_one_2 = I32::neg_from(1u32);
+    let max_1 = I32::max();
+    let max_2 = I32::max();
+    let min_1 = I32::min();
+    let min_2 = I32::min();
+
+    assert(one_1 >= one_2);
+    assert(one_1 <= one_2);
+    assert(neg_one_1 >= neg_one_2);
+    assert(neg_one_1 <= neg_one_2);
+    assert(max_1 >= max_1);
+    assert(max_1 <= max_1);
+    assert(min_1 >= min_1);
+    assert(min_1 <= min_1);
+
+    assert(min_1 <= one_1);
+    assert(min_1 <= neg_one_1);
+    assert(min_1 <= max_1);
+    assert(neg_one_1 <= max_1);
+    assert(neg_one_1 <= one_1);
+    assert(one_1 <= max_1);
+
+    assert(max_1 >= one_1);
+    assert(max_1 >= neg_one_1);
+    assert(max_1 >= min_1);
+    assert(one_1 >= neg_one_1);
+    assert(one_1 >= min_1);
+    assert(neg_one_1 >= min_1);
+
     true
 }

--- a/tests/src/signed_integers/signed_i64/src/main.sw
+++ b/tests/src/signed_integers/signed_i64/src/main.sw
@@ -21,5 +21,38 @@ fn main() -> bool {
     res = I64::from(10u64) / I64::from(5u64);
     assert(res == I64::from(2u64));
 
+    // OrqEq Tests
+    let one_1 = I64::from(1u64);
+    let one_2 = I64::from(1u64);
+    let neg_one_1 = I64::neg_from(1u64);
+    let neg_one_2 = I64::neg_from(1u64);
+    let max_1 = I64::max();
+    let max_2 = I64::max();
+    let min_1 = I64::min();
+    let min_2 = I64::min();
+
+    assert(one_1 >= one_2);
+    assert(one_1 <= one_2);
+    assert(neg_one_1 >= neg_one_2);
+    assert(neg_one_1 <= neg_one_2);
+    assert(max_1 >= max_1);
+    assert(max_1 <= max_1);
+    assert(min_1 >= min_1);
+    assert(min_1 <= min_1);
+
+    assert(min_1 <= one_1);
+    assert(min_1 <= neg_one_1);
+    assert(min_1 <= max_1);
+    assert(neg_one_1 <= max_1);
+    assert(neg_one_1 <= one_1);
+    assert(one_1 <= max_1);
+
+    assert(max_1 >= one_1);
+    assert(max_1 >= neg_one_1);
+    assert(max_1 >= min_1);
+    assert(one_1 >= neg_one_1);
+    assert(one_1 >= min_1);
+    assert(neg_one_1 >= min_1);
+
     true
 }

--- a/tests/src/signed_integers/signed_i8/src/main.sw
+++ b/tests/src/signed_integers/signed_i8/src/main.sw
@@ -22,5 +22,38 @@ fn main() -> bool {
     res = I8::from(10u8) / I8::from(5u8);
     assert(res == I8::from(2u8));
 
+    // OrqEq Tests
+    let one_1 = I8::from(1u8);
+    let one_2 = I8::from(1u8);
+    let neg_one_1 = I8::neg_from(1u8);
+    let neg_one_2 = I8::neg_from(1u8);
+    let max_1 = I8::max();
+    let max_2 = I8::max();
+    let min_1 = I8::min();
+    let min_2 = I8::min();
+
+    assert(one_1 >= one_2);
+    assert(one_1 <= one_2);
+    assert(neg_one_1 >= neg_one_2);
+    assert(neg_one_1 <= neg_one_2);
+    assert(max_1 >= max_1);
+    assert(max_1 <= max_1);
+    assert(min_1 >= min_1);
+    assert(min_1 <= min_1);
+
+    assert(min_1 <= one_1);
+    assert(min_1 <= neg_one_1);
+    assert(min_1 <= max_1);
+    assert(neg_one_1 <= max_1);
+    assert(neg_one_1 <= one_1);
+    assert(one_1 <= max_1);
+
+    assert(max_1 >= one_1);
+    assert(max_1 >= neg_one_1);
+    assert(max_1 >= min_1);
+    assert(one_1 >= neg_one_1);
+    assert(one_1 >= min_1);
+    assert(neg_one_1 >= min_1);
+
     true
 }


### PR DESCRIPTION
## Type of change

<!--Delete points that do not apply-->

- New feature

## Changes

The following changes have been made:

- `I8`, `I16`, `I32`, `I64`, `I128`, and `I256` now support `OrdEq`.

Closes #\<issue number\>

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
- [x] I have updated the changelog to reflect the changes on this PR.
