### PR TITLE
Fix `From` implementation for Signed Integers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Description of the upcoming release here.
 - [#262](https://github.com/FuelLabs/sway-libs/pull/262) Fixes incorrect ordering comparison for IFP64, IFP128 and IFP256.
 - [#263](https://github.com/FuelLabs/sway-libs/pull/263) Fixes `I256`'s returned bits.
 - [#263](https://github.com/FuelLabs/sway-libs/pull/263) Fixes `I128` and `I256`'s zero or "indent" value.
+- [#272](https://github.com/FuelLabs/sway-libs/pull/272) Fixes `From` implementations for Signed Integers with `TryFrom`.
 
 #### Breaking
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Description of the upcoming release here.
 - [#259](https://github.com/FuelLabs/sway-libs/pull/259) Adds a new upgradability library, including associated tests and documentation.
 - [#265](https://github.com/FuelLabs/sway-libs/pull/265) Adds the `SetMetadataEvent` and emits `SetMetadataEvent` when the `_set_metadata()` function is called.
 - [#270](https://github.com/FuelLabs/sway-libs/pull/270) Adds `OrdEq` functionality to Signed Integers.
+- [#272](https://github.com/FuelLabs/sway-libs/pull/272) Adds the `TryFrom` implementation from signed integers to unsigned integers.
 
 ### Changed
 
@@ -44,3 +45,5 @@ After:
 let my_i8 = i8::zero();
 let wrapping_neg = my_i8.wrapping_neg();
 ```
+
+- [#272](https://github.com/FuelLabs/sway-libs/pull/272) 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,4 +46,16 @@ let my_i8 = i8::zero();
 let wrapping_neg = my_i8.wrapping_neg();
 ```
 
-- [#272](https://github.com/FuelLabs/sway-libs/pull/272) 
+- [#272](https://github.com/FuelLabs/sway-libs/pull/272) The `From` implementation for all signed integers to their respective unsigned integer has been removed. The `TryFrom` implementation has been added in its place.
+
+The following demonstrates the breaking change. While this example code uses the `I8` type, the same logic may be applied to the `I16`, `I32`, `I64`, `I128`, and `I256` types.
+
+Before:
+```sway
+let my_i8: I8 = I8::from(1u8);
+```
+
+After:
+```sway
+let my_i8: I8 = I8::try_from(1u8).unwrap();
+```

--- a/libs/src/signed_integers/i128.sw
+++ b/libs/src/signed_integers/i128.sw
@@ -1,6 +1,6 @@
 library;
 
-use std::u128::U128;
+use std::{convert::TryFrom, u128::U128};
 use ::signed_integers::common::WrappingNeg;
 use ::signed_integers::errors::Error;
 
@@ -36,15 +36,6 @@ impl I128 {
     /// ```
     pub fn indent() -> U128 {
         U128::from((9223372036854775808, 0))
-    }
-}
-
-impl From<U128> for I128 {
-    /// Helper function to get a signed number from with an underlying
-    fn from(value: U128) -> Self {
-        // as the minimal value of I128 is -I128::indent() (1 << 63) we should add I128::indent() (1 << 63) 
-        let underlying: U128 = value + Self::indent();
-        Self { underlying }
     }
 }
 
@@ -416,5 +407,28 @@ impl WrappingNeg for I128 {
             return self::min()
         }
         self * Self::neg_from(U128::from((0, 1)))
+    }
+}
+
+impl TryFrom<U128> for I128 {
+    fn try_from(value: U128) -> Option<Self> {
+        // as the minimal value of I128 is -I128::indent() (1 << 63) we should add I128::indent() (1 << 63) 
+        if value < U128::max() - Self::indent() {
+            Some(Self {
+                underlying: value + Self::indent(),
+            })
+        } else {
+            None
+        }
+    }
+}
+
+impl TryFrom<I128> for U128 {
+    fn try_from(value: I128) -> Option<Self> {
+        if value >= I128::zero() {
+            Some(value.underlying - I128::indent())
+        } else {
+            None
+        }
     }
 }

--- a/libs/src/signed_integers/i16.sw
+++ b/libs/src/signed_integers/i16.sw
@@ -1,5 +1,6 @@
 library;
 
+use std::convert::TryFrom;
 use ::signed_integers::errors::Error;
 use ::signed_integers::common::WrappingNeg;
 
@@ -34,15 +35,6 @@ impl I16 {
     /// ```
     pub fn indent() -> u16 {
         32768u16
-    }
-}
-
-impl From<u16> for I16 {
-    /// Helper function to get a signed number from with an underlying
-    fn from(value: u16) -> Self {
-        // as the minimal value of I16 is -I16::indent() (1 << 15) we should add I16::indent() (1 << 15)
-        let underlying: u16 = value + Self::indent();
-        Self { underlying }
     }
 }
 
@@ -399,5 +391,28 @@ impl WrappingNeg for I16 {
             return self::min()
         }
         self * Self::neg_from(1u16)
+    }
+}
+
+impl TryFrom<u16> for I16 {
+    fn try_from(value: u16) -> Option<Self> {
+        // as the minimal value of I16 is -I16::indent() (1 << 15) we should add I16::indent() (1 << 15)
+        if value < u16::max() - Self::indent() {
+            Some(Self {
+                underlying: value + Self::indent(),
+            })
+        } else {
+            None
+        }
+    }
+}
+
+impl TryFrom<I16> for u16 {
+    fn try_from(value: I16) -> Option<Self> {
+        if value >= I16::zero() {
+            Some(value.underlying - I16::indent())
+        } else {
+            None
+        }
     }
 }

--- a/libs/src/signed_integers/i256.sw
+++ b/libs/src/signed_integers/i256.sw
@@ -1,5 +1,6 @@
 library;
 
+use std::convert::TryFrom;
 use ::signed_integers::common::WrappingNeg;
 use ::signed_integers::errors::Error;
 
@@ -37,14 +38,6 @@ impl I256 {
     /// ```
     pub fn indent() -> u256 {
         0x8000000000000000000000000000000000000000000000000000000000000000u256
-    }
-}
-
-impl From<u256> for I256 {
-    fn from(value: u256) -> Self {
-        // as the minimal value of I256 is -I256::indent() (1 << 63) we should add I256::indent() (1 << 63) 
-        let underlying = value + Self::indent();
-        Self { underlying }
     }
 }
 
@@ -394,5 +387,28 @@ impl WrappingNeg for I256 {
             return self::min()
         }
         self * Self::neg_from(0x0000000000000000000000000000000000000000000000000000000000000001u256)
+    }
+}
+
+impl TryFrom<u256> for I256 {
+    fn try_from(value: u256) -> Option<Self> {
+        // as the minimal value of I256 is -I256::indent() (1 << 63) we should add I256::indent() (1 << 63) 
+        if value < u256::max() - Self::indent() {
+            Some(Self {
+                underlying: value + Self::indent(),
+            })
+        } else {
+            None
+        }
+    }
+}
+
+impl TryFrom<I256> for u256 {
+    fn try_from(value: I256) -> Option<Self> {
+        if value >= I256::zero() {
+            Some(value.underlying - I256::indent())
+        } else {
+            None
+        }
     }
 }

--- a/libs/src/signed_integers/i32.sw
+++ b/libs/src/signed_integers/i32.sw
@@ -1,5 +1,6 @@
 library;
 
+use std::convert::TryFrom;
 use ::signed_integers::common::WrappingNeg;
 use ::signed_integers::errors::Error;
 
@@ -34,14 +35,6 @@ impl I32 {
     /// ```
     pub fn indent() -> u32 {
         2147483648u32
-    }
-}
-
-impl From<u32> for I32 {
-    fn from(value: u32) -> Self {
-        // as the minimal value of I32 is 2147483648 (1 << 31) we should add I32::indent() (1 << 31) 
-        let underlying = value + Self::indent();
-        Self { underlying }
     }
 }
 
@@ -398,5 +391,28 @@ impl WrappingNeg for I32 {
             return self::min()
         }
         self * Self::neg_from(1u32)
+    }
+}
+
+impl TryFrom<u32> for I32 {
+    fn try_from(value: u32) -> Option<Self> {
+        // as the minimal value of I32 is 2147483648 (1 << 31) we should add I32::indent() (1 << 31) 
+        if value < u32::max() - Self::indent() {
+            Some(Self {
+                underlying: value + Self::indent(),
+            })
+        } else {
+            None
+        }
+    }
+}
+
+impl TryFrom<I32> for u32 {
+    fn try_from(value: I32) -> Option<Self> {
+        if value >= I32::zero() {
+            Some(value.underlying - I32::indent())
+        } else {
+            None
+        }
     }
 }

--- a/libs/src/signed_integers/i64.sw
+++ b/libs/src/signed_integers/i64.sw
@@ -1,5 +1,6 @@
 library;
 
+use std::convert::TryFrom;
 use ::signed_integers::common::WrappingNeg;
 use ::signed_integers::errors::Error;
 
@@ -34,14 +35,6 @@ impl I64 {
     /// ```
     pub fn indent() -> u64 {
         9223372036854775808u64
-    }
-}
-
-impl From<u64> for I64 {
-    fn from(value: u64) -> Self {
-        // as the minimal value of I64 is -I64::indent() (1 << 63) we should add I64::indent() (1 << 63) 
-        let underlying = value + Self::indent();
-        Self { underlying }
     }
 }
 
@@ -399,5 +392,28 @@ impl WrappingNeg for I64 {
             return self::min()
         }
         self * Self::neg_from(1)
+    }
+}
+
+impl TryFrom<u64> for I64 {
+    fn try_from(value: u64) -> Option<Self> {
+        // as the minimal value of I64 is -I64::indent() (1 << 63) we should add I64::indent() (1 << 63) 
+        if value < u64::max() - Self::indent() {
+            Some(Self {
+                underlying: value + Self::indent(),
+            })
+        } else {
+            None
+        }
+    }
+}
+
+impl TryFrom<I64> for u64 {
+    fn try_from(value: I64) -> Option<Self> {
+        if value >= I64::zero() {
+            Some(value.underlying - I64::indent())
+        } else {
+            None
+        }
     }
 }

--- a/libs/src/signed_integers/i8.sw
+++ b/libs/src/signed_integers/i8.sw
@@ -1,5 +1,6 @@
 library;
 
+use std::convert::TryFrom;
 use ::signed_integers::errors::Error;
 use ::signed_integers::common::WrappingNeg;
 
@@ -34,14 +35,6 @@ impl I8 {
     /// ```
     pub fn indent() -> u8 {
         128u8
-    }
-}
-
-impl From<u8> for I8 {
-    fn from(value: u8) -> Self {
-        // as the minimal value of I8 is -I8::indent() (1 << 7) we should add I8::indent() (1 << 7) 
-        let underlying: u8 = value + Self::indent();
-        Self { underlying }
     }
 }
 
@@ -398,5 +391,28 @@ impl WrappingNeg for I8 {
             return self::min()
         }
         self * Self::neg_from(1u8)
+    }
+}
+
+impl TryFrom<u8> for I8 {
+    fn try_from(value: u8) -> Option<Self> {
+        // as the minimal value of I8 is -I8::indent() (1 << 7) we should add I8::indent() (1 << 7)
+        if value < u8::max() - Self::indent() {
+            Some(Self {
+                underlying: value + Self::indent(),
+            })
+        } else {
+            None
+        }
+    }
+}
+
+impl TryFrom<I8> for u8 {
+    fn try_from(value: I8) -> Option<Self> {
+        if value >= I8::zero() {
+            Some(value.underlying - I8::indent())
+        } else {
+            None
+        }
     }
 }

--- a/tests/src/signed_integers/signed_i128/src/main.sw
+++ b/tests/src/signed_integers/signed_i128/src/main.sw
@@ -2,41 +2,42 @@ script;
 
 use sway_libs::signed_integers::i128::I128;
 use std::u128::U128;
+use std::convert::*;
 
 fn main() -> bool {
     let u128_one = U128::from((0, 1));
     let u128_two = U128::from((0, 2));
-    let one = I128::from(u128_one);
-    let mut res = one + I128::from(u128_one);
-    assert(res == I128::from(u128_two));
+    let one = I128::try_from(u128_one).unwrap();
+    let mut res = one + I128::try_from(u128_one).unwrap();
+    assert(res == I128::try_from(u128_two).unwrap());
 
     let u128_10 = U128::from((0, 10));
     let u128_11 = U128::from((0, 11));
-    res = I128::from(u128_10) - I128::from(u128_11);
+    res = I128::try_from(u128_10).unwrap() - I128::try_from(u128_11).unwrap();
     assert(res.underlying().lower() == u64::max());
 
-    res = I128::from(u128_10) * I128::neg_from(u128_one);
+    res = I128::try_from(u128_10).unwrap() * I128::neg_from(u128_one);
     assert(res == I128::neg_from(u128_10));
 
-    res = I128::from(u128_10) * I128::from(u128_10);
+    res = I128::try_from(u128_10).unwrap() * I128::try_from(u128_10).unwrap();
     let u128_100 = U128::from((0, 100));
-    assert(res == I128::from(u128_100));
+    assert(res == I128::try_from(u128_100).unwrap());
 
     let u128_lower_max_u64 = U128::from((0, u64::max()));
 
-    res = I128::from(u128_10) / I128::from(u128_lower_max_u64);
+    res = I128::try_from(u128_10).unwrap() / I128::try_from(u128_lower_max_u64).unwrap();
     assert(res == I128::neg_from(u128_10));
 
     let u128_5 = U128::from((0, 5));
 
     let u128_2 = U128::from((0, 2));
 
-    res = I128::from(u128_10) / I128::from(u128_5);
-    assert(res == I128::from(u128_2));
+    res = I128::try_from(u128_10).unwrap() / I128::try_from(u128_5).unwrap();
+    assert(res == I128::try_from(u128_2).unwrap());
 
     // OrqEq Tests
-    let one_1 = I128::from(U128::from((0, 1)));
-    let one_2 = I128::from(U128::from((0, 1)));
+    let one_1 = I128::try_from(U128::from((0, 1))).unwrap();
+    let one_2 = I128::try_from(U128::from((0, 1))).unwrap();
     let neg_one_1 = I128::neg_from(U128::from((0, 1)));
     let neg_one_2 = I128::neg_from(U128::from((0, 1)));
     let max_1 = I128::max();
@@ -66,6 +67,58 @@ fn main() -> bool {
     assert(one_1 >= neg_one_1);
     assert(one_1 >= min_1);
     assert(neg_one_1 >= min_1);
+
+    // Test into I128
+    let indent: U128 = I128::indent();
+
+    let i128_max_try_from = I128::try_from(indent);
+    assert(i128_max_try_from.is_some());
+    assert(i128_max_try_from.unwrap() == I128::max());
+
+    let i128_min_try_from = I128::try_from(U128::min());
+    assert(i128_min_try_from.is_some());
+    assert(i128_min_try_from.unwrap() == I128::zero());
+
+    let i128_overflow_try_from = I128::try_from(indent + U128::from((0, 1)));
+    assert(i128_overflow_try_from.is_none());
+
+    let i128_max_try_into: Option<I128> = indent.try_into();
+    assert(i128_max_try_into.is_some());
+    assert(i128_max_try_into.unwrap() == I128::max());
+
+    let i128_min_try_into: Option<I128> = U128::min().try_into();
+    assert(i128_min_try_into.is_some());
+    assert(i128_min_try_into.unwrap() == I128::zero());
+
+    let i128_overflow_try_into: Option<I128> = (indent + U128::from((0, 1))).try_into();
+    assert(i128_overflow_try_into.is_none());
+
+    // Test into U128
+    let zero = I128::zero();
+    let negative = I128::neg_from(U128::from((0, 1)));
+    let max = I128::max();
+
+    let U128_max_try_from: Option<U128> = U128::try_from(max);
+    assert(U128_max_try_from.is_some());
+    assert(U128_max_try_from.unwrap() == indent);
+
+    let U128_min_try_from: Option<U128> = U128::try_from(zero);
+    assert(U128_min_try_from.is_some());
+    assert(U128_min_try_from.unwrap() == U128::zero());
+
+    let U128_overflow_try_from: Option<U128> = U128::try_from(negative);
+    assert(U128_overflow_try_from.is_none());
+
+    let U128_max_try_into: Option<U128> = zero.try_into();
+    assert(U128_max_try_into.is_some());
+    assert(U128_max_try_into.unwrap() == indent);
+
+    let U128_min_try_into: Option<U128> = zero.try_into();
+    assert(U128_min_try_into.is_some());
+    assert(U128_min_try_into.unwrap() == U128::zero());
+
+    let U128_overflow_try_into: Option<U128> = negative.try_into();
+    assert(U128_overflow_try_into.is_none());
 
     true
 }

--- a/tests/src/signed_integers/signed_i128/src/main.sw
+++ b/tests/src/signed_integers/signed_i128/src/main.sw
@@ -36,8 +36,8 @@ fn main() -> bool {
     assert(res == I128::try_from(u128_2).unwrap());
 
     // Subtraction tests
-    let pos1 = I128::from(U128::from((0, 1)));
-    let pos2 = I128::from(U128::from((0, 2)));
+    let pos1 = I128::try_from(U128::from((0, 1))).unwrap();
+    let pos2 = I128::try_from(U128::from((0, 2))).unwrap();
     let neg1 = I128::neg_from(U128::from((0, 1)));
     let neg2 = I128::neg_from(U128::from((0, 2)));
 
@@ -47,11 +47,11 @@ fn main() -> bool {
     assert(res1 == I128::neg_from(U128::from((0, 1))));
 
     let res2 = pos2 - pos1;
-    assert(res2 == I128::from(U128::from((0, 1))));
+    assert(res2 == I128::try_from(U128::from((0, 1))).unwrap());
 
     // First positive
     let res3 = pos1 - neg1;
-    assert(res3 == I128::from(U128::from((0, 2))));
+    assert(res3 == I128::try_from(U128::from((0, 2))).unwrap());
 
     // Second positive
     let res4 = neg1 - pos1;
@@ -59,7 +59,7 @@ fn main() -> bool {
 
     // Both negative
     let res5 = neg1 - neg2;
-    assert(res5 == I128::from(U128::from((0, 1))));
+    assert(res5 == I128::try_from(U128::from((0, 1))).unwrap());
 
     let res6 = neg2 - neg1;
     assert(res6 == I128::neg_from(U128::from((0, 1))));

--- a/tests/src/signed_integers/signed_i128_wrapping_neg/src/main.sw
+++ b/tests/src/signed_integers/signed_i128_wrapping_neg/src/main.sw
@@ -4,25 +4,25 @@ use sway_libs::signed_integers::i128::I128;
 use std::u128::U128;
 
 fn main() -> bool {
-    let one = I128::from(U128::from(1u64));
+    let one = I128::try_from(U128::from(1u64)).unwrap();
     let neg_one = I128::neg_from(U128::from(1u64));
 
-    let two = I128::from(U128::from(2u64));
+    let two = I128::try_from(U128::from(2u64)).unwrap();
     let neg_two = I128::neg_from(U128::from(2u64));
 
-    let ten = I128::from(U128::from(10u64));
+    let ten = I128::try_from(U128::from(10u64)).unwrap();
     let neg_ten = I128::neg_from(U128::from(10u64));
 
-    let twenty_seven = I128::from(U128::from(27u64));
+    let twenty_seven = I128::try_from(U128::from(27u64)).unwrap();
     let neg_twenty_seven = I128::neg_from(U128::from(27u64));
 
-    let ninty_three = I128::from(U128::from(93u64));
+    let ninty_three = I128::try_from(U128::from(93u64)).unwrap();
     let neg_ninty_three = I128::neg_from(U128::from(93u64));
 
-    let zero = I128::from(U128::zero());
+    let zero = I128::try_from(U128::zero()).unwrap();
     let max = I128::max();
     let min = I128::min();
-    let neg_min_plus_one = I128::min() + I128::from(U128::from((0, 1)));
+    let neg_min_plus_one = I128::min() + I128::try_from(U128::from((0, 1))).unwrap();
 
     let res1 = one.wrapping_neg();
     let res2 = neg_one.wrapping_neg();

--- a/tests/src/signed_integers/signed_i16/src/main.sw
+++ b/tests/src/signed_integers/signed_i16/src/main.sw
@@ -1,30 +1,31 @@
 script;
 
 use sway_libs::signed_integers::i16::I16;
+use std::convert::*;
 
 fn main() -> bool {
-    let one = I16::from(1u16);
-    let mut res = one + I16::from(1u16);
-    assert(res == I16::from(2u16));
+    let one = I16::try_from(1u16).unwrap();
+    let mut res = one + I16::try_from(1u16).unwrap();
+    assert(res == I16::try_from(2u16).unwrap());
 
-    res = I16::from(10u16) - I16::from(11u16);
-    assert(res == I16::from(32767u16));
+    res = I16::try_from(10u16).unwrap() - I16::try_from(11u16).unwrap();
+    assert(res == I16::try_from(32767u16).unwrap());
 
-    res = I16::from(10u16) * I16::neg_from(1u16);
+    res = I16::try_from(10u16).unwrap() * I16::neg_from(1u16);
     assert(res == I16::neg_from(10u16));
 
-    res = I16::from(10u16) * I16::from(10u16);
-    assert(res == I16::from(100u16));
+    res = I16::try_from(10u16).unwrap() * I16::try_from(10u16).unwrap();
+    assert(res == I16::try_from(100u16).unwrap());
 
-    res = I16::from(10u16) / I16::neg_from(1u16);
+    res = I16::try_from(10u16).unwrap() / I16::neg_from(1u16);
     assert(res == I16::neg_from(10u16));
 
-    res = I16::from(10u16) / I16::from(5u16);
-    assert(res == I16::from(2u16));
+    res = I16::try_from(10u16).unwrap() / I16::try_from(5u16).unwrap();
+    assert(res == I16::try_from(2u16).unwrap());
 
     // OrqEq Tests
-    let one_1 = I16::from(1u16);
-    let one_2 = I16::from(1u16);
+    let one_1 = I16::try_from(1u16).unwrap();
+    let one_2 = I16::try_from(1u16).unwrap();
     let neg_one_1 = I16::neg_from(1u16);
     let neg_one_2 = I16::neg_from(1u16);
     let max_1 = I16::max();
@@ -54,6 +55,58 @@ fn main() -> bool {
     assert(one_1 >= neg_one_1);
     assert(one_1 >= min_1);
     assert(neg_one_1 >= min_1);
+
+    // Test into I16
+    let indent: u16 = I16::indent();
+
+    let i16_max_try_from = I16::try_from(indent);
+    assert(i16_max_try_from.is_some());
+    assert(i16_max_try_from.unwrap() == I16::max());
+
+    let i16_min_try_from = I16::try_from(u16::min());
+    assert(i16_min_try_from.is_some());
+    assert(i16_min_try_from.unwrap() == I16::zero());
+
+    let i16_overflow_try_from = I16::try_from(indent + 1);
+    assert(i16_overflow_try_from.is_none());
+
+    let i16_max_try_into: Option<I16> = indent.try_into();
+    assert(i16_max_try_into.is_some());
+    assert(i16_max_try_into.unwrap() == I16::max());
+
+    let i16_min_try_into: Option<I16> = u16::min().try_into();
+    assert(i16_min_try_into.is_some());
+    assert(i16_min_try_into.unwrap() == I16::zero());
+
+    let i16_overflow_try_into: Option<I16> = (indent + 1).try_into();
+    assert(i16_overflow_try_into.is_none());
+
+    // Test into u16
+    let zero = I16::zero();
+    let negative = I16::neg_from(1);
+    let max = I16::max();
+
+    let u16_max_try_from: Option<u16> = u16::try_from(max);
+    assert(u16_max_try_from.is_some());
+    assert(u16_max_try_from.unwrap() == indent);
+
+    let u16_min_try_from: Option<u16> = u16::try_from(zero);
+    assert(u16_min_try_from.is_some());
+    assert(u16_min_try_from.unwrap() == u16::zero());
+
+    let u16_overflow_try_from: Option<u16> = u16::try_from(negative);
+    assert(u16_overflow_try_from.is_none());
+
+    let u16_max_try_into: Option<u16> = zero.try_into();
+    assert(u16_max_try_into.is_some());
+    assert(u16_max_try_into.unwrap() == indent);
+
+    let u16_min_try_into: Option<u16> = zero.try_into();
+    assert(u16_min_try_into.is_some());
+    assert(u16_min_try_into.unwrap() == u16::zero());
+
+    let u16_overflow_try_into: Option<u16> = negative.try_into();
+    assert(u16_overflow_try_into.is_none());
 
     true
 }

--- a/tests/src/signed_integers/signed_i16/src/main.sw
+++ b/tests/src/signed_integers/signed_i16/src/main.sw
@@ -24,8 +24,8 @@ fn main() -> bool {
     assert(res == I16::try_from(2u16).unwrap());
 
     // Subtraction tests
-    let pos1 = I16::from(1);
-    let pos2 = I16::from(2);
+    let pos1 = I16::try_from(1).unwrap();
+    let pos2 = I16::try_from(2).unwrap();
     let neg1 = I16::neg_from(1);
     let neg2 = I16::neg_from(2);
 
@@ -35,11 +35,11 @@ fn main() -> bool {
     assert(res1 == I16::neg_from(1));
 
     let res2 = pos2 - pos1;
-    assert(res2 == I16::from(1));
+    assert(res2 == I16::try_from(1).unwrap());
 
     // First positive
     let res3 = pos1 - neg1;
-    assert(res3 == I16::from(2));
+    assert(res3 == I16::try_from(2).unwrap());
 
     // Second positive
     let res4 = neg1 - pos1;
@@ -47,7 +47,7 @@ fn main() -> bool {
 
     // Both negative
     let res5 = neg1 - neg2;
-    assert(res5 == I16::from(1));
+    assert(res5 == I16::try_from(1).unwrap());
 
     let res6 = neg2 - neg1;
     assert(res6 == I16::neg_from(1));

--- a/tests/src/signed_integers/signed_i16_wrapping_neg/src/main.sw
+++ b/tests/src/signed_integers/signed_i16_wrapping_neg/src/main.sw
@@ -3,25 +3,25 @@ script;
 use sway_libs::signed_integers::i16::I16;
 
 fn main() -> bool {
-    let one = I16::from(1u16);
-    let neg_one = I16::from(0u16) - I16::from(1u16);
+    let one = I16::try_from(1u16).unwrap();
+    let neg_one = I16::try_from(0u16).unwrap() - I16::try_from(1u16).unwrap();
 
-    let two = I16::from(2u16);
-    let neg_two = I16::from(0u16) - I16::from(2u16);
+    let two = I16::try_from(2u16).unwrap();
+    let neg_two = I16::try_from(0u16).unwrap() - I16::try_from(2u16).unwrap();
 
-    let ten = I16::from(10u16);
-    let neg_ten = I16::from(0u16) - I16::from(10u16);
+    let ten = I16::try_from(10u16).unwrap();
+    let neg_ten = I16::try_from(0u16).unwrap() - I16::try_from(10u16).unwrap();
 
-    let twenty_seven = I16::from(27u16);
-    let neg_twenty_seven = I16::from(0u16) - I16::from(27u16);
+    let twenty_seven = I16::try_from(27u16).unwrap();
+    let neg_twenty_seven = I16::try_from(0u16).unwrap() - I16::try_from(27u16).unwrap();
 
-    let ninty_three = I16::from(93u16);
-    let neg_ninty_three = I16::from(0u16) - I16::from(93u16);
+    let ninty_three = I16::try_from(93u16).unwrap();
+    let neg_ninty_three = I16::try_from(0u16).unwrap() - I16::try_from(93u16).unwrap();
 
-    let zero = I16::from(0u16);
+    let zero = I16::try_from(0u16).unwrap();
     let max = I16::max();
     let min = I16::min();
-    let neg_min_plus_one = I16::min() + I16::from(1u16);
+    let neg_min_plus_one = I16::min() + I16::try_from(1u16).unwrap();
 
     let res1 = one.wrapping_neg();
     let res2 = neg_one.wrapping_neg();

--- a/tests/src/signed_integers/signed_i256/src/main.sw
+++ b/tests/src/signed_integers/signed_i256/src/main.sw
@@ -70,8 +70,8 @@ fn main() -> bool {
     assert(res == i256_2);
 
     // Subtraction tests
-    let pos1 = I256::from(u256_one);
-    let pos2 = I256::from(u256_two);
+    let pos1 = I256::try_from(u256_one).unwrap();
+    let pos2 = I256::try_from(u256_two).unwrap();
     let neg1 = I256::neg_from(u256_one);
     let neg2 = I256::neg_from(u256_two);
 
@@ -80,11 +80,11 @@ fn main() -> bool {
     assert(res1 == I256::neg_from(u256_one));
 
     let res2 = pos2 - pos1;
-    assert(res2 == I256::from(u256_one));
+    assert(res2 == I256::try_from(u256_one).unwrap());
 
     // First positive
     let res3 = pos1 - neg1;
-    assert(res3 == I256::from(u256_two));
+    assert(res3 == I256::try_from(u256_two).unwrap());
 
     // Second positive
     let res4 = neg1 - pos1;
@@ -92,7 +92,7 @@ fn main() -> bool {
 
     // Both negative
     let res5 = neg1 - neg2;
-    assert(res5 == I256::from(u256_one));
+    assert(res5 == I256::try_from(u256_one).unwrap());
 
     let res6 = neg2 - neg1;
     assert(res6 == I256::neg_from(u256_one));

--- a/tests/src/signed_integers/signed_i256/src/main.sw
+++ b/tests/src/signed_integers/signed_i256/src/main.sw
@@ -1,5 +1,6 @@
 script;
 
+use std::convert::*;
 use sway_libs::signed_integers::i256::I256;
 
 fn main() -> bool {
@@ -12,9 +13,9 @@ fn main() -> bool {
         r1: u256
     };
 
-    let one = I256::from(u256_one);
-    let mut res = one + I256::from(u256_one);
-    assert(res == I256::from(u256_two));
+    let one = I256::try_from(u256_one).unwrap();
+    let mut res = one + I256::try_from(u256_one).unwrap();
+    assert(res == I256::try_from(u256_two).unwrap());
 
     let parts_10 = (0, 0, 0, 10);
     let u256_10 = asm(r1: parts_10) {
@@ -26,29 +27,29 @@ fn main() -> bool {
         r1: u256
     };
 
-    res = I256::from(u256_10) - I256::from(u256_11);
+    res = I256::try_from(u256_10).unwrap() - I256::try_from(u256_11).unwrap();
     let (a, b, c, d) = asm(r1: res) {
         r1: (u64, u64, u64, u64)
     };
     assert(c == u64::max());
     assert(d == u64::max());
 
-    res = I256::from(u256_10) * I256::neg_from(u256_one);
+    res = I256::try_from(u256_10).unwrap() * I256::neg_from(u256_one);
     assert(res == I256::neg_from(u256_10));
 
-    res = I256::from(u256_10) * I256::from(u256_10);
+    res = I256::try_from(u256_10).unwrap() * I256::try_from(u256_10).unwrap();
     let parts_100 = (0, 0, 0, 100);
     let u256_100 = asm(r1: parts_100) {
         r1: u256
     };
-    assert(res == I256::from(u256_100));
+    assert(res == I256::try_from(u256_100).unwrap());
 
     let parts_lower_max_u64 = (0, 0, 0, u64::max());
     let u256_lower_max_u64 = asm(r1: parts_lower_max_u64) {
         r1: u256
     };
 
-    res = I256::from(u256_10) / I256::from(u256_lower_max_u64);
+    res = I256::try_from(u256_10).unwrap() / I256::try_from(u256_lower_max_u64).unwrap();
     assert(res == I256::neg_from(u256_10));
 
     let parts_5 = (0, 0, 0, 5);
@@ -61,16 +62,16 @@ fn main() -> bool {
         r1: u256
     };
 
-    let i256_10 = I256::from(u256_10);
-    let i256_5 = I256::from(u256_5);
-    let i256_2 = I256::from(u256_2);
+    let i256_10 = I256::try_from(u256_10).unwrap();
+    let i256_5 = I256::try_from(u256_5).unwrap();
+    let i256_2 = I256::try_from(u256_2).unwrap();
 
     res = i256_10 / i256_5;
     assert(res == i256_2);
 
     // OrqEq Tests
-    let one_1 = I256::from(u256_one);
-    let one_2 = I256::from(u256_one);
+    let one_1 = I256::try_from(u256_one).unwrap();
+    let one_2 = I256::try_from(u256_one).unwrap();
     let neg_one_1 = I256::neg_from(u256_one);
     let neg_one_2 = I256::neg_from(u256_one);
     let max_1 = I256::max();
@@ -100,5 +101,58 @@ fn main() -> bool {
     assert(one_1 >= neg_one_1);
     assert(one_1 >= min_1);
     assert(neg_one_1 >= min_1);
+
+    // Test into I256
+    let indent: u256 = I256::indent();
+
+    let i256_max_try_from = I256::try_from(indent);
+    assert(i256_max_try_from.is_some());
+    assert(i256_max_try_from.unwrap() == I256::max());
+
+    let i256_min_try_from = I256::try_from(u256::min());
+    assert(i256_min_try_from.is_some());
+    assert(i256_min_try_from.unwrap() == I256::zero());
+
+    let i256_overflow_try_from = I256::try_from(indent + u256_one);
+    assert(i256_overflow_try_from.is_none());
+
+    let i256_max_try_into: Option<I256> = indent.try_into();
+    assert(i256_max_try_into.is_some());
+    assert(i256_max_try_into.unwrap() == I256::max());
+
+    let i256_min_try_into: Option<I256> = u256::min().try_into();
+    assert(i256_min_try_into.is_some());
+    assert(i256_min_try_into.unwrap() == I256::zero());
+
+    let i256_overflow_try_into: Option<I256> = (indent + u256_one).try_into();
+    assert(i256_overflow_try_into.is_none());
+
+    // Test into u256
+    let zero = I256::zero();
+    let negative = I256::neg_from(u256_one);
+    let max = I256::max();
+
+    let u256_max_try_from: Option<u256> = u256::try_from(max);
+    assert(u256_max_try_from.is_some());
+    assert(u256_max_try_from.unwrap() == indent);
+
+    let u256_min_try_from: Option<u256> = u256::try_from(zero);
+    assert(u256_min_try_from.is_some());
+    assert(u256_min_try_from.unwrap() == u256::zero());
+
+    let u256_overflow_try_from: Option<u256> = u256::try_from(negative);
+    assert(u256_overflow_try_from.is_none());
+
+    let u256_max_try_into: Option<u256> = zero.try_into();
+    assert(u256_max_try_into.is_some());
+    assert(u256_max_try_into.unwrap() == indent);
+
+    let u256_min_try_into: Option<u256> = zero.try_into();
+    assert(u256_min_try_into.is_some());
+    assert(u256_min_try_into.unwrap() == u256::zero());
+
+    let u256_overflow_try_into: Option<u256> = negative.try_into();
+    assert(u256_overflow_try_into.is_none());
+
     true
 }

--- a/tests/src/signed_integers/signed_i256_wrapping_neg/src/main.sw
+++ b/tests/src/signed_integers/signed_i256_wrapping_neg/src/main.sw
@@ -24,25 +24,25 @@ fn main() -> bool {
         r1: u256
     };
 
-    let one = I256::from(u_one);
+    let one = I256::try_from(u_one).unwrap();
     let neg_one = I256::neg_from(u_one);
 
-    let two = I256::from(u_two);
+    let two = I256::try_from(u_two).unwrap();
     let neg_two = I256::neg_from(u_two);
 
-    let ten = I256::from(u_ten);
+    let ten = I256::try_from(u_ten).unwrap();
     let neg_ten = I256::neg_from(u_ten);
 
-    let twenty_seven = I256::from(u_twenty_seven);
+    let twenty_seven = I256::try_from(u_twenty_seven).unwrap();
     let neg_twenty_seven = I256::neg_from(u_twenty_seven);
 
-    let ninty_three = I256::from(u_ninty_three);
+    let ninty_three = I256::try_from(u_ninty_three).unwrap();
     let neg_ninty_three = I256::neg_from(u_ninty_three);
 
-    let zero = I256::from(u256::zero());
+    let zero = I256::try_from(u256::zero()).unwrap();
     let max = I256::max();
     let min = I256::min();
-    let neg_min_plus_one = I256::min() + I256::from(u_one);
+    let neg_min_plus_one = I256::min() + I256::try_from(u_one).unwrap();
 
     let res1 = one.wrapping_neg();
     let res2 = neg_one.wrapping_neg();

--- a/tests/src/signed_integers/signed_i32/src/main.sw
+++ b/tests/src/signed_integers/signed_i32/src/main.sw
@@ -1,30 +1,31 @@
 script;
 
 use sway_libs::signed_integers::i32::I32;
+use std::convert::*;
 
 fn main() -> bool {
-    let one = I32::from(1u32);
-    let mut res = one + I32::from(1u32);
-    assert(res == I32::from(2u32));
+    let one = I32::try_from(1u32).unwrap();
+    let mut res = one + I32::try_from(1u32).unwrap();
+    assert(res == I32::try_from(2u32).unwrap());
 
-    res = I32::from(10u32) - I32::from(11u32);
-    assert(res == I32::from(2147483647u32));
+    res = I32::try_from(10u32).unwrap() - I32::try_from(11u32).unwrap();
+    assert(res == I32::try_from(2147483647u32).unwrap());
 
-    res = I32::from(10u32) * I32::from(1u32);
+    res = I32::try_from(10u32).unwrap() * I32::try_from(1u32).unwrap();
     assert(res == I32::neg_from(10u32));
 
-    res = I32::from(10u32) * I32::from(10u32);
-    assert(res == I32::from(100u32));
+    res = I32::try_from(10u32).unwrap() * I32::try_from(10u32).unwrap();
+    assert(res == I32::try_from(100u32).unwrap());
 
-    res = I32::from(10u32) / I32::neg_from(1u32);
+    res = I32::try_from(10u32).unwrap() / I32::neg_from(1u32);
     assert(res == I32::neg_from(10u32));
 
-    res = I32::from(10u32) / I32::from(5u32);
-    assert(res == I32::from(2u32));
+    res = I32::try_from(10u32).unwrap() / I32::try_from(5u32).unwrap();
+    assert(res == I32::try_from(2u32).unwrap());
 
     // OrqEq Tests
-    let one_1 = I32::from(1u32);
-    let one_2 = I32::from(1u32);
+    let one_1 = I32::try_from(1u32).unwrap();
+    let one_2 = I32::try_from(1u32).unwrap();
     let neg_one_1 = I32::neg_from(1u32);
     let neg_one_2 = I32::neg_from(1u32);
     let max_1 = I32::max();
@@ -54,6 +55,58 @@ fn main() -> bool {
     assert(one_1 >= neg_one_1);
     assert(one_1 >= min_1);
     assert(neg_one_1 >= min_1);
+
+    // Test into I32
+    let indent: u32 = I32::indent();
+
+    let i32_max_try_from = I32::try_from(indent);
+    assert(i32_max_try_from.is_some());
+    assert(i32_max_try_from.unwrap() == I32::max());
+
+    let i32_min_try_from = I32::try_from(u32::min());
+    assert(i32_min_try_from.is_some());
+    assert(i32_min_try_from.unwrap() == I32::zero());
+
+    let i32_overflow_try_from = I32::try_from(indent + 1);
+    assert(i32_overflow_try_from.is_none());
+
+    let i32_max_try_into: Option<I32> = indent.try_into();
+    assert(i32_max_try_into.is_some());
+    assert(i32_max_try_into.unwrap() == I32::max());
+
+    let i32_min_try_into: Option<I32> = u32::min().try_into();
+    assert(i32_min_try_into.is_some());
+    assert(i32_min_try_into.unwrap() == I32::zero());
+
+    let i32_overflow_try_into: Option<I32> = (indent + 1).try_into();
+    assert(i32_overflow_try_into.is_none());
+
+    // Test into u32
+    let zero = I32::zero();
+    let negative = I32::neg_from(1);
+    let max = I32::max();
+
+    let u32_max_try_from: Option<u32> = u32::try_from(max);
+    assert(u32_max_try_from.is_some());
+    assert(u32_max_try_from.unwrap() == indent);
+
+    let u32_min_try_from: Option<u32> = u32::try_from(zero);
+    assert(u32_min_try_from.is_some());
+    assert(u32_min_try_from.unwrap() == u32::zero());
+
+    let u32_overflow_try_from: Option<u32> = u32::try_from(negative);
+    assert(u32_overflow_try_from.is_none());
+
+    let u32_max_try_into: Option<u32> = zero.try_into();
+    assert(u32_max_try_into.is_some());
+    assert(u32_max_try_into.unwrap() == indent);
+
+    let u32_min_try_into: Option<u32> = zero.try_into();
+    assert(u32_min_try_into.is_some());
+    assert(u32_min_try_into.unwrap() == u32::zero());
+
+    let u32_overflow_try_into: Option<u32> = negative.try_into();
+    assert(u32_overflow_try_into.is_none());
 
     true
 }

--- a/tests/src/signed_integers/signed_i32/src/main.sw
+++ b/tests/src/signed_integers/signed_i32/src/main.sw
@@ -24,8 +24,8 @@ fn main() -> bool {
     assert(res == I32::try_from(2u32).unwrap());
 
     // Subtraction Tests
-    let pos1 = I32::from(1);
-    let pos2 = I32::from(2);
+    let pos1 = I32::try_from(1).unwrap();
+    let pos2 = I32::try_from(2).unwrap();
     let neg1 = I32::neg_from(1);
     let neg2 = I32::neg_from(2);
 
@@ -35,11 +35,11 @@ fn main() -> bool {
     assert(res1 == I32::neg_from(1));
 
     let res2 = pos2 - pos1;
-    assert(res2 == I32::from(1));
+    assert(res2 == I32::try_from(1).unwrap());
 
     // First positive
     let res3 = pos1 - neg1;
-    assert(res3 == I32::from(2));
+    assert(res3 == I32::try_from(2).unwrap());
 
     // Second positive
     let res4 = neg1 - pos1;
@@ -47,7 +47,7 @@ fn main() -> bool {
 
     // Both negative
     let res5 = neg1 - neg2;
-    assert(res5 == I32::from(1));
+    assert(res5 == I32::try_from(1).unwrap());
 
     let res6 = neg2 - neg1;
     assert(res6 == I32::neg_from(1));

--- a/tests/src/signed_integers/signed_i32_wrapping_neg/src/main.sw
+++ b/tests/src/signed_integers/signed_i32_wrapping_neg/src/main.sw
@@ -3,25 +3,25 @@ script;
 use sway_libs::signed_integers::i32::I32;
 
 fn main() -> bool {
-    let one = I32::from(1u32);
-    let neg_one = I32::from(0u32) - I32::from(1u32);
+    let one = I32::try_from(1u32).unwrap();
+    let neg_one = I32::try_from(0u32).unwrap() - I32::try_from(1u32).unwrap();
 
-    let two = I32::from(2u32);
-    let neg_two = I32::from(0u32) - I32::from(2u32);
+    let two = I32::try_from(2u32).unwrap();
+    let neg_two = I32::try_from(0u32).unwrap() - I32::try_from(2u32).unwrap();
 
-    let ten = I32::from(10u32);
-    let neg_ten = I32::from(0u32) - I32::from(10u32);
+    let ten = I32::try_from(10u32).unwrap();
+    let neg_ten = I32::try_from(0u32).unwrap() - I32::try_from(10u32).unwrap();
 
-    let twenty_seven = I32::from(27u32);
-    let neg_twenty_seven = I32::from(0u32) - I32::from(27u32);
+    let twenty_seven = I32::try_from(27u32).unwrap();
+    let neg_twenty_seven = I32::try_from(0u32).unwrap() - I32::try_from(27u32).unwrap();
 
-    let ninty_three = I32::from(93u32);
-    let neg_ninty_three = I32::from(0u32) - I32::from(93u32);
+    let ninty_three = I32::try_from(93u32).unwrap();
+    let neg_ninty_three = I32::try_from(0u32).unwrap() - I32::try_from(93u32).unwrap();
 
-    let zero = I32::from(0u32);
+    let zero = I32::try_from(0u32).unwrap();
     let max = I32::max();
     let min = I32::min();
-    let neg_min_plus_one = I32::min() + I32::from(1u32);
+    let neg_min_plus_one = I32::min() + I32::try_from(1u32).unwrap();
 
     let res1 = one.wrapping_neg();
     let res2 = neg_one.wrapping_neg();

--- a/tests/src/signed_integers/signed_i64/src/main.sw
+++ b/tests/src/signed_integers/signed_i64/src/main.sw
@@ -1,29 +1,30 @@
 script;
 
 use sway_libs::signed_integers::i64::I64;
+use std::convert::*;
 
 fn main() -> bool {
-    let one = I64::from(1u64);
-    let mut res = one + I64::from(1u64);
-    assert(res == I64::from(2u64));
+    let one = I64::try_from(1u64).unwrap();
+    let mut res = one + I64::try_from(1u64).unwrap();
+    assert(res == I64::try_from(2u64).unwrap());
 
-    res = I64::from(10u64) - I64::from(11u64);
-    assert(res == I64::from(9223372036854775807u64));
-    res = I64::from(10u64) * I64::neg_from(1);
+    res = I64::try_from(10u64).unwrap() - I64::try_from(11u64).unwrap();
+    assert(res == I64::try_from(9223372036854775807u64).unwrap());
+    res = I64::try_from(10u64).unwrap() * I64::neg_from(1);
     assert(res == I64::neg_from(10));
 
-    res = I64::from(10u64) * I64::from(10u64);
-    assert(res == I64::from(100u64));
+    res = I64::try_from(10u64).unwrap() * I64::try_from(10u64).unwrap();
+    assert(res == I64::try_from(100u64).unwrap());
 
-    res = I64::from(10u64) / I64::from(9223372036854775807u64);
+    res = I64::try_from(10u64).unwrap() / I64::try_from(9223372036854775807u64).unwrap();
     assert(res == I64::neg_from(10u64));
 
-    res = I64::from(10u64) / I64::from(5u64);
-    assert(res == I64::from(2u64));
+    res = I64::try_from(10u64).unwrap() / I64::try_from(5u64).unwrap();
+    assert(res == I64::try_from(2u64).unwrap());
 
     // OrqEq Tests
-    let one_1 = I64::from(1u64);
-    let one_2 = I64::from(1u64);
+    let one_1 = I64::try_from(1u64).unwrap();
+    let one_2 = I64::try_from(1u64).unwrap();
     let neg_one_1 = I64::neg_from(1u64);
     let neg_one_2 = I64::neg_from(1u64);
     let max_1 = I64::max();
@@ -53,6 +54,58 @@ fn main() -> bool {
     assert(one_1 >= neg_one_1);
     assert(one_1 >= min_1);
     assert(neg_one_1 >= min_1);
+
+    // Test into I64
+    let indent: u64 = I64::indent();
+
+    let i64_max_try_from = I64::try_from(indent);
+    assert(i64_max_try_from.is_some());
+    assert(i64_max_try_from.unwrap() == I64::max());
+
+    let i64_min_try_from = I64::try_from(u64::min());
+    assert(i64_min_try_from.is_some());
+    assert(i64_min_try_from.unwrap() == I64::zero());
+
+    let i64_overflow_try_from = I64::try_from(indent + 1);
+    assert(i64_overflow_try_from.is_none());
+
+    let i64_max_try_into: Option<I64> = indent.try_into();
+    assert(i64_max_try_into.is_some());
+    assert(i64_max_try_into.unwrap() == I64::max());
+
+    let i64_min_try_into: Option<I64> = u64::min().try_into();
+    assert(i64_min_try_into.is_some());
+    assert(i64_min_try_into.unwrap() == I64::zero());
+
+    let i64_overflow_try_into: Option<I64> = (indent + 1).try_into();
+    assert(i64_overflow_try_into.is_none());
+
+    // Test into u64
+    let zero = I64::zero();
+    let negative = I64::neg_from(1);
+    let max = I64::max();
+
+    let u64_max_try_from: Option<u64> = u64::try_from(max);
+    assert(u64_max_try_from.is_some());
+    assert(u64_max_try_from.unwrap() == indent);
+
+    let u64_min_try_from: Option<u64> = u64::try_from(zero);
+    assert(u64_min_try_from.is_some());
+    assert(u64_min_try_from.unwrap() == u64::zero());
+
+    let u64_overflow_try_from: Option<u64> = u64::try_from(negative);
+    assert(u64_overflow_try_from.is_none());
+
+    let u64_max_try_into: Option<u64> = zero.try_into();
+    assert(u64_max_try_into.is_some());
+    assert(u64_max_try_into.unwrap() == indent);
+
+    let u64_min_try_into: Option<u64> = zero.try_into();
+    assert(u64_min_try_into.is_some());
+    assert(u64_min_try_into.unwrap() == u64::zero());
+
+    let u64_overflow_try_into: Option<u64> = negative.try_into();
+    assert(u64_overflow_try_into.is_none());
 
     true
 }

--- a/tests/src/signed_integers/signed_i64/src/main.sw
+++ b/tests/src/signed_integers/signed_i64/src/main.sw
@@ -23,8 +23,8 @@ fn main() -> bool {
     assert(res == I64::try_from(2u64).unwrap());
 
     // Subtraction Tests
-    let pos1 = I64::from(1);
-    let pos2 = I64::from(2);
+    let pos1 = I64::try_from(1).unwrap();
+    let pos2 = I64::try_from(2).unwrap();
     let neg1 = I64::neg_from(1);
     let neg2 = I64::neg_from(2);
 
@@ -34,11 +34,11 @@ fn main() -> bool {
     assert(res1 == I64::neg_from(1));
 
     let res2 = pos2 - pos1;
-    assert(res2 == I64::from(1));
+    assert(res2 == I64::try_from(1).unwrap());
 
     // First positive
     let res3 = pos1 - neg1;
-    assert(res3 == I64::from(2));
+    assert(res3 == I64::try_from(2).unwrap());
 
     // Second positive
     let res4 = neg1 - pos1;
@@ -46,7 +46,7 @@ fn main() -> bool {
 
     // Both negative
     let res5 = neg1 - neg2;
-    assert(res5 == I64::from(1));
+    assert(res5 == I64::try_from(1).unwrap());
 
     let res6 = neg2 - neg1;
     assert(res6 == I64::neg_from(1));

--- a/tests/src/signed_integers/signed_i64_wrapping_neg/src/main.sw
+++ b/tests/src/signed_integers/signed_i64_wrapping_neg/src/main.sw
@@ -3,25 +3,25 @@ script;
 use sway_libs::signed_integers::i64::I64;
 
 fn main() -> bool {
-    let one = I64::from(1u64);
-    let neg_one = I64::from(0u64) - I64::from(1u64);
+    let one = I64::try_from(1u64).unwrap();
+    let neg_one = I64::try_from(0u64).unwrap() - I64::try_from(1u64).unwrap();
 
-    let two = I64::from(2u64);
-    let neg_two = I64::from(0u64) - I64::from(2u64);
+    let two = I64::try_from(2u64).unwrap();
+    let neg_two = I64::try_from(0u64).unwrap() - I64::try_from(2u64).unwrap();
 
-    let ten = I64::from(10u64);
-    let neg_ten = I64::from(0u64) - I64::from(10u64);
+    let ten = I64::try_from(10u64).unwrap();
+    let neg_ten = I64::try_from(0u64).unwrap() - I64::try_from(10u64).unwrap();
 
-    let twenty_seven = I64::from(27u64);
-    let neg_twenty_seven = I64::from(0u64) - I64::from(27u64);
+    let twenty_seven = I64::try_from(27u64).unwrap();
+    let neg_twenty_seven = I64::try_from(0u64).unwrap() - I64::try_from(27u64).unwrap();
 
-    let ninty_three = I64::from(93u64);
-    let neg_ninty_three = I64::from(0u64) - I64::from(93u64);
+    let ninty_three = I64::try_from(93u64).unwrap();
+    let neg_ninty_three = I64::try_from(0u64).unwrap() - I64::try_from(93u64).unwrap();
 
-    let zero = I64::from(0u64);
+    let zero = I64::try_from(0u64).unwrap();
     let max = I64::max();
     let min = I64::min();
-    let neg_min_plus_one = I64::min() + I64::from(1);
+    let neg_min_plus_one = I64::min() + I64::try_from(1).unwrap();
 
     let res1 = one.wrapping_neg();
     let res2 = neg_one.wrapping_neg();

--- a/tests/src/signed_integers/signed_i8/src/main.sw
+++ b/tests/src/signed_integers/signed_i8/src/main.sw
@@ -24,8 +24,8 @@ fn main() -> bool {
     assert(res == I8::try_from(2u8).unwrap());
 
     // Subtraction Tests
-    let pos1 = I8::from(1);
-    let pos2 = I8::from(2);
+    let pos1 = I8::try_from(1).unwrap();
+    let pos2 = I8::try_from(2).unwrap();
     let neg1 = I8::neg_from(1);
     let neg2 = I8::neg_from(2);
 
@@ -34,11 +34,11 @@ fn main() -> bool {
     assert(res1 == I8::neg_from(1));
 
     let res2 = pos2 - pos1;
-    assert(res2 == I8::from(1));
+    assert(res2 == I8::try_from(1).unwrap());
 
     // First positive
     let res3 = pos1 - neg1;
-    assert(res3 == I8::from(2));
+    assert(res3 == I8::try_from(2).unwrap());
 
     // Second positive
     let res4 = neg1 - pos1;
@@ -46,7 +46,7 @@ fn main() -> bool {
 
     // Both negative
     let res5 = neg1 - neg2;
-    assert(res5 == I8::from(1));
+    assert(res5 == I8::try_from(1).unwrap());
 
     let res6 = neg2 - neg1;
     assert(res6 == I8::neg_from(1));

--- a/tests/src/signed_integers/signed_i8/src/main.sw
+++ b/tests/src/signed_integers/signed_i8/src/main.sw
@@ -1,30 +1,31 @@
 script;
 
 use sway_libs::signed_integers::i8::I8;
+use std::convert::*;
 
 fn main() -> bool {
-    let one = I8::from(1u8);
-    let mut res = one + I8::from(1u8);
-    assert(res == I8::from(2u8));
+    let one = I8::try_from(1u8).unwrap();
+    let mut res = one + I8::try_from(1u8).unwrap();
+    assert(res == I8::try_from(2u8).unwrap());
 
-    res = I8::from(10u8) - I8::from(11u8);
-    assert(res == I8::from(127u8));
+    res = I8::try_from(10u8).unwrap() - I8::try_from(11u8).unwrap();
+    assert(res == I8::try_from(127u8).unwrap());
 
-    res = I8::from(10u8) * I8::from(127u8);
-    assert(res == I8::from(118u8));
+    res = I8::try_from(10u8).unwrap() * I8::try_from(127u8).unwrap();
+    assert(res == I8::try_from(118u8).unwrap());
 
-    res = I8::from(10u8) * I8::from(10u8);
-    assert(res == I8::from(100u8));
+    res = I8::try_from(10u8).unwrap() * I8::try_from(10u8).unwrap();
+    assert(res == I8::try_from(100u8).unwrap());
 
-    res = I8::from(10u8) / I8::from(127u8);
-    assert(res == I8::from(118u8));
+    res = I8::try_from(10u8).unwrap() / I8::try_from(127u8).unwrap();
+    assert(res == I8::try_from(118u8).unwrap());
 
-    res = I8::from(10u8) / I8::from(5u8);
-    assert(res == I8::from(2u8));
+    res = I8::try_from(10u8).unwrap() / I8::try_from(5u8).unwrap();
+    assert(res == I8::try_from(2u8).unwrap());
 
     // OrqEq Tests
-    let one_1 = I8::from(1u8);
-    let one_2 = I8::from(1u8);
+    let one_1 = I8::try_from(1u8).unwrap();
+    let one_2 = I8::try_from(1u8).unwrap();
     let neg_one_1 = I8::neg_from(1u8);
     let neg_one_2 = I8::neg_from(1u8);
     let max_1 = I8::max();
@@ -54,6 +55,58 @@ fn main() -> bool {
     assert(one_1 >= neg_one_1);
     assert(one_1 >= min_1);
     assert(neg_one_1 >= min_1);
+
+    // Test into I8
+    let indent: u8 = I8::indent();
+
+    let i8_max_try_from = I8::try_from(indent);
+    assert(i8_max_try_from.is_some());
+    assert(i8_max_try_from.unwrap() == I8::max());
+
+    let i8_min_try_from = I8::try_from(u8::min());
+    assert(i8_min_try_from.is_some());
+    assert(i8_min_try_from.unwrap() == I8::zero());
+
+    let i8_overflow_try_from = I8::try_from(indent + 1);
+    assert(i8_overflow_try_from.is_none());
+
+    let i8_max_try_into: Option<I8> = indent.try_into();
+    assert(i8_max_try_into.is_some());
+    assert(i8_max_try_into.unwrap() == I8::max());
+
+    let i8_min_try_into: Option<I8> = u8::min().try_into();
+    assert(i8_min_try_into.is_some());
+    assert(i8_min_try_into.unwrap() == I8::zero());
+
+    let i8_overflow_try_into: Option<I8> = (indent + 1).try_into();
+    assert(i8_overflow_try_into.is_none());
+
+    // Test into u8
+    let zero = I8::zero();
+    let negative = I8::neg_from(1);
+    let max = I8::max();
+
+    let u8_max_try_from: Option<u8> = u8::try_from(max);
+    assert(u8_max_try_from.is_some());
+    assert(u8_max_try_from.unwrap() == indent);
+
+    let u8_min_try_from: Option<u8> = u8::try_from(zero);
+    assert(u8_min_try_from.is_some());
+    assert(u8_min_try_from.unwrap() == u8::zero());
+
+    let u8_overflow_try_from: Option<u8> = u8::try_from(negative);
+    assert(u8_overflow_try_from.is_none());
+
+    let u8_max_try_into: Option<u8> = zero.try_into();
+    assert(u8_max_try_into.is_some());
+    assert(u8_max_try_into.unwrap() == indent);
+
+    let u8_min_try_into: Option<u8> = zero.try_into();
+    assert(u8_min_try_into.is_some());
+    assert(u8_min_try_into.unwrap() == u8::zero());
+
+    let u8_overflow_try_into: Option<u8> = negative.try_into();
+    assert(u8_overflow_try_into.is_none());
 
     true
 }

--- a/tests/src/signed_integers/signed_i8_wrapping_neg/src/main.sw
+++ b/tests/src/signed_integers/signed_i8_wrapping_neg/src/main.sw
@@ -3,25 +3,25 @@ script;
 use sway_libs::signed_integers::i8::I8;
 
 fn main() -> bool {
-    let one = I8::from(1u8);
-    let neg_one = I8::from(0u8) - I8::from(1u8);
+    let one = I8::try_from(1u8).unwrap();
+    let neg_one = I8::try_from(0u8).unwrap() - I8::try_from(1u8).unwrap();
 
-    let two = I8::from(2u8);
-    let neg_two = I8::from(0u8) - I8::from(2u8);
+    let two = I8::try_from(2u8).unwrap();
+    let neg_two = I8::try_from(0u8).unwrap() - I8::try_from(2u8).unwrap();
 
-    let ten = I8::from(10u8);
-    let neg_ten = I8::from(0u8) - I8::from(10u8);
+    let ten = I8::try_from(10u8).unwrap();
+    let neg_ten = I8::try_from(0u8).unwrap() - I8::try_from(10u8).unwrap();
 
-    let twenty_seven = I8::from(27u8);
-    let neg_twenty_seven = I8::from(0u8) - I8::from(27u8);
+    let twenty_seven = I8::try_from(27u8).unwrap();
+    let neg_twenty_seven = I8::try_from(0u8).unwrap() - I8::try_from(27u8).unwrap();
 
-    let ninty_three = I8::from(93u8);
-    let neg_ninty_three = I8::from(0u8) - I8::from(93u8);
+    let ninty_three = I8::try_from(93u8).unwrap();
+    let neg_ninty_three = I8::try_from(0u8).unwrap() - I8::try_from(93u8).unwrap();
 
-    let zero = I8::from(0u8);
+    let zero = I8::try_from(0u8).unwrap();
     let max = I8::max();
     let min = I8::min();
-    let neg_min_plus_one = I8::min() + I8::from(1u8);
+    let neg_min_plus_one = I8::min() + I8::try_from(1u8).unwrap();
 
     let res1 = one.wrapping_neg();
     let res2 = neg_one.wrapping_neg();


### PR DESCRIPTION
## Type of change

<!--Delete points that do not apply-->

- Bug fix
- New feature
- Improvement (refactoring, restructuring repository, cleaning tech debt, ...)

## Breaking

The `From` implementation for all signed integers to their respective unsigned integer has been removed. The `TryFrom` implementation has been added in its place.

The following demonstrates the breaking change. While this example code uses the I8 type, the same logic may be applied to the I16, I32, I64, I128, and I256 types.

Before:
```sway
let my_i8: I8 = I8::from(1u8);
```

After:
```sway
let my_i8: I8 = I8::try_from(1u8).unwrap();
```

## Changes

The following changes have been made:

- Removes the `From` implementation for `u8` into `I8`
- Removes the `From` implementation for `u16` into `I16`
- Removes the `From` implementation for `u32` into `I32`
- Removes the `From` implementation for `u64` into `I64`
- Removes the `From` implementation for `U128` into `I128`
- Removes the `From` implementation for `u256` into `I256`
- Adds the `TryFrom` implementation for `u8` into `I8`
- Adds the `TryFrom` implementation for `u16` into `I16`
- Adds the `TryFrom` implementation for `u32` into `I32`
- Adds the `TryFrom` implementation for `u64` into `I64`
- Adds the `TryFrom` implementation for `U128` into `I128`
- Adds the `TryFrom` implementation for `u256` into `I256`
- Adds the `TryFrom` implementation for `I8` into `u8`
- Adds the `TryFrom` implementation for `I16` into `u16`
- Adds the `TryFrom` implementation for `I32` into `u32`
- Adds the `TryFrom` implementation for `I64` into `u64`
- Adds the `TryFrom` implementation for `I128` into `U128`
- Adds the `TryFrom` implementation for `I256` into `u256`

## Notes

- Reported in the Fuel Attackathon
- This is a breaking change
- Previously the `From` implementations would revert if the input was greater than the indent.

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
- [x] I have updated the changelog to reflect the changes on this PR.
