### PR TITLE
add nightly ci

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -3,6 +3,7 @@ name: Nightly Tests
 on:
   schedule:
     - cron: '0 0 * * *'  # Run every day at midnight UTC
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,56 @@
+name: Nightly Tests
+
+on:
+  schedule:
+    - cron: '0 0 * * *'  # Run every day at midnight UTC
+
+env:
+  CARGO_TERM_COLOR: always
+  REGISTRY: ghcr.io
+
+jobs:
+  nightly-tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        job: [build-sway-lib, forc-inline-tests, contributing-book, build-forc-doc-sway-libs, build-examples]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly
+          components: rustfmt
+
+      - name: Init cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install Fuel toolchain
+        uses: FuelLabs/action-fuel-toolchain@v0.6.0
+        with:
+          toolchain: nightly
+
+      - name: Run ${{ matrix.job }}
+        run: |
+          if [ "${{ matrix.job }}" = "build-sway-lib" ]; then
+            forc fmt --path libs --check
+            cargo fmt --manifest-path tests/Cargo.toml --verbose --check
+            forc build --path libs --release --locked
+            forc build --path tests --release --locked
+            cargo test --manifest-path tests/Cargo.toml
+          elif [ "${{ matrix.job }}" = "forc-inline-tests" ]; then
+            forc build --path libs --release --locked && forc test --path libs --locked
+            forc build --path tests --release --locked && forc test --path tests --locked
+          elif [ "${{ matrix.job }}" = "contributing-book" ]; then
+            forc fmt --path docs/contributing-book/src/code --check
+            forc build --path docs/contributing-book/src/code --release
+          elif [ "${{ matrix.job }}" = "build-forc-doc-sway-libs" ]; then
+            forc doc --manifest-path libs
+          elif [ "${{ matrix.job }}" = "build-examples" ]; then
+            forc fmt --path examples --check
+            cargo fmt --manifest-path examples/Cargo.toml --verbose --check
+            forc build --path examples --release --locked
+            cargo test --manifest-path examples/Cargo.toml
+          fi

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -38,12 +38,12 @@ jobs:
           if [ "${{ matrix.job }}" = "build-sway-lib" ]; then
             forc fmt --path libs --check
             cargo fmt --manifest-path tests/Cargo.toml --verbose --check
-            forc build --path libs --release --locked
-            forc build --path tests --release --locked
+            forc build --path libs --release
+            forc build --path tests --release
             cargo test --manifest-path tests/Cargo.toml
           elif [ "${{ matrix.job }}" = "forc-inline-tests" ]; then
-            forc build --path libs --release --locked && forc test --path libs --locked
-            forc build --path tests --release --locked && forc test --path tests --locked
+            forc build --path libs --release && forc test --path libs
+            forc build --path tests --release && forc test --path tests
           elif [ "${{ matrix.job }}" = "contributing-book" ]; then
             forc fmt --path docs/contributing-book/src/code --check
             forc build --path docs/contributing-book/src/code --release
@@ -52,6 +52,6 @@ jobs:
           elif [ "${{ matrix.job }}" = "build-examples" ]; then
             forc fmt --path examples --check
             cargo fmt --manifest-path examples/Cargo.toml --verbose --check
-            forc build --path examples --release --locked
+            forc build --path examples --release
             cargo test --manifest-path examples/Cargo.toml
           fi

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -3,7 +3,7 @@ name: Nightly Tests
 on:
   schedule:
     - cron: '0 0 * * *'  # Run every day at midnight UTC
-  workflow_dispatch:
+  pull_request:
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
## Type of change

- New feature

## Changes

The following changes have been made:

- Adds a new ci action to run all existing actions using the nightly versions of all tools (rust, forc, fuel-core) every day at midnight UTC

## Related Issues

Closes #244 

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
- [ ] I have updated the changelog to reflect the changes on this PR.
