### PR TITLE
Update to Sway-Standards v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - [#285](https://github.com/FuelLabs/sway-libs/pull/285) Adds the `BytecodeRoot` and `ContractConfigurables` types to the Bytecode Library.
+- [#286](https://github.com/FuelLabs/sway-libs/pull/286) Adds the `_metadata()` function to the Asset Library.
 
 ### Changed
 
-- Something changed here 1
-- Something changed here 2
+- [#286](https://github.com/FuelLabs/sway-libs/pull/286) Updates the repository to Sway-Standards v0.6.0 and implements the new SRC-20 and SRC-7 logging specifications.
+- [#286](https://github.com/FuelLabs/sway-libs/pull/286) `_set_metadata()`, `_set_name()` and `_set_symbol()` now revert if the metadata is an empty string.
+- [#286](https://github.com/FuelLabs/sway-libs/pull/286) `_set_metadata()` now reverts if the metadata is empty bytes.
+- [#286](https://github.com/FuelLabs/sway-libs/pull/286) `_mint()` and `_burn()` now revert if the `amount` argument is zero.
 
 ### Fixed
 
@@ -65,6 +68,79 @@ verify_contract_bytecode(my_contract_id, my_bytecode, Some(my_configurables)); /
 // Verify predicate address
 verify_predicate_address(my_predicate_address, my_bytecode, None); // No configurables
 verify_predicate_address(my_predicate_address, my_bytecode, Some(my_configurables)); // With configurables
+```
+
+- [#286](https://github.com/FuelLabs/sway-libs/pull/286) The support functions for `Metadata` have been removed. They have been moved to sway-standards.
+
+Before:
+
+```sway
+use sway_libs::asset::metadata::*;
+
+fn foo(my_metadata: Metadata) {
+     let res: bool = my_metadata.is_b256(); 
+     let res: bool = my_metadata.is_string(); 
+     let res: bool = my_metadata.is_bytes(); 
+     let res: bool = my_metadata.is_uint();
+}
+```
+
+After: 
+
+```sway
+use standards::src7::*;
+
+fn foo(my_metadata: Metadata) {
+     let res: bool = my_metadata.is_b256(); 
+     let res: bool = my_metadata.is_string(); 
+     let res: bool = my_metadata.is_bytes(); 
+     let res: bool = my_metadata.is_uint();
+}
+```
+
+- [#286](https://github.com/FuelLabs/sway-libs/pull/286) The `SetMetadata` abi `set_metadata` function definition has changed. The `metadata` argument is now an `Option<Metadata>` and the argument order has changed.
+
+Before:
+
+```sway
+abi SetAssetMetadata {
+    #[storage(read, write)]
+    fn set_metadata(asset: AssetId, key: String, metadata: Metadata);
+}
+```
+
+After:
+
+```sway
+abi SetAssetMetadata {
+    #[storage(read, write)]
+    fn set_metadata(asset: AssetId, metadata: Option<Metadata>, key: String);
+}
+```
+
+- [#286](https://github.com/FuelLabs/sway-libs/pull/286) The `_set_name()`, `_set_symbol()`, `_mint()`, and `_set_metdata()` functions `name`, `symbol`, `sub_id`, and `metadata` arguments are now `Option`s.
+
+Before: 
+
+```sway
+fn foo(asset: AssetId, recipient: Identity, amount: u64, key: String, metadata: Metadata) {
+    _set_name(storage.name, asset, String::from_ascii_str("Ether"));
+    _set_symbol(storage.symbol, asset, String::from_ascii_str("ETH"));
+    _mint(storage.total_assets, storage.total_supply, recipient, SubId::zero(), amount);
+    _set_metadata(storage.metadata, asset, key, metadata);
+}
+```
+
+After: 
+
+```sway
+fn foo(asset: AssetId, recipient: Identity, amount: u64, metadata: Metadata, key: String) {
+    _set_name(storage.name, asset, Some(String::from_ascii_str("Ether")));
+    _set_symbol(storage.symbol, asset, Some(String::from_ascii_str("ETH")));
+    _mint(storage.total_assets, storage.total_supply, recipient, Some(SubId::zero()), amount);
+    // Note: Ordering of arguments has changed for `_set_metadata()`
+    _set_metadata(storage.metadata, asset, Some(metadata), key);
+}
 ```
 
 ## [v0.23.1]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,7 +85,7 @@ fn foo(my_metadata: Metadata) {
 }
 ```
 
-After: 
+After:
 
 ```sway
 use standards::src7::*;
@@ -120,7 +120,7 @@ abi SetAssetMetadata {
 
 - [#286](https://github.com/FuelLabs/sway-libs/pull/286) The `_set_name()`, `_set_symbol()`, `_mint()`, and `_set_metdata()` functions `name`, `symbol`, `sub_id`, and `metadata` arguments are now `Option`s.
 
-Before: 
+Before:
 
 ```sway
 fn foo(asset: AssetId, recipient: Identity, amount: u64, key: String, metadata: Metadata) {
@@ -131,7 +131,7 @@ fn foo(asset: AssetId, recipient: Identity, amount: u64, key: String, metadata: 
 }
 ```
 
-After: 
+After:
 
 ```sway
 fn foo(asset: AssetId, recipient: Identity, amount: u64, metadata: Metadata, key: String) {

--- a/docs/book/src/asset/base.md
+++ b/docs/book/src/asset/base.md
@@ -60,6 +60,8 @@ To use the Asset Library's base functionly, simply pass the `StorageKey` from th
 
 To set some the asset attributes for an Asset, use the `SetAssetAttributes` ABI provided by the Asset Library. The example below shows the implementation of the `SetAssetAttributes` ABI with no user defined restrictions or custom functionality. It is recommended that the [Ownership Library](../ownership/index.md) is used in conjunction with the `SetAssetAttributes` ABI to ensure only a single user has permissions to set an Asset's attributes.
 
+The `_set_name()`, `_set_symbol()`, and `_set_decimals()` functions follows the SRC-20 standard for logging and will emit their respective log when called.
+
 ```sway
 {{#include ../../../../examples/asset/setting_src20_attributes/src/main.sw:setting_src20_attributes}}
 ```

--- a/docs/book/src/asset/metadata.md
+++ b/docs/book/src/asset/metadata.md
@@ -24,17 +24,6 @@ The Asset Library has the following complimentary data type for the [SRC-7](http
 
 - `StorageMetadata`
 
-The following additional functionality for the [SRC-7](https://docs.fuel.network/docs/sway-standards/src-7-asset-metadata/)'s `Metadata` type is provided:
-
-- `as_string()`
-- `is_string()`
-- `as_u64()`
-- `is_u64()`
-- `as_bytes()`
-- `is_bytes()`
-- `as_b256()`
-- `is_b256()`
-
 ## Setting Up Storage
 
 Once imported, the Asset Library's metadata functionality should be available. To use them, be sure to add the storage block bellow to your contract which enables the [SRC-7](https://docs.fuel.network/docs/sway-standards/src-7-asset-metadata/) standard.
@@ -47,7 +36,9 @@ Once imported, the Asset Library's metadata functionality should be available. T
 
 ### Setting Metadata
 
-To set some metadata for an Asset, use the `SetAssetMetadata` ABI provided by the Asset Library. Be sure to follow the [SRC-9](https://docs.fuel.network/docs/sway-standards/src-9-metadata-keys/) standard for your `key`. It is recommended that the [Ownership Library](../ownership/index.md) is used in conjunction with the `SetAssetMetadata` ABI to ensure only a single user has permissions to set an Asset's metadata.
+To set some metadata for an Asset, use the `SetAssetMetadata` ABI provided by the Asset Library with the `_set_metadata()` function. Be sure to follow the [SRC-9](https://docs.fuel.network/docs/sway-standards/src-9-metadata-keys/) standard for your `key`. It is recommended that the [Ownership Library](../ownership/index.md) is used in conjunction with the `SetAssetMetadata` ABI to ensure only a single user has permissions to set an Asset's metadata.
+
+The `_set_metadata()` function follows the SRC-7 standard for logging and will emit the `SetMetadataEvent` when called.
 
 ```sway
 {{#include ../../../../examples/asset/setting_src7_attributes/src/main.sw:setting_src7_attributes}}
@@ -57,59 +48,8 @@ To set some metadata for an Asset, use the `SetAssetMetadata` ABI provided by th
 
 ### Implementing the SRC-7 Standard with StorageMetadata
 
-To use the `StorageMetadata` type, simply get the stored metadata with the associated `key` and `AssetId`. The example below shows the implementation of the [SRC-7](https://docs.fuel.network/docs/sway-standards/src-7-asset-metadata/) standard in combination with the Asset Library's `StorageMetadata` type with no user defined restrictions or custom functionality.
+To use the `StorageMetadata` type, simply get the stored metadata with the associated `key` and `AssetId` using the provided `_metadata()` convenience function. The example below shows the implementation of the [SRC-7](https://docs.fuel.network/docs/sway-standards/src-7-asset-metadata/) standard in combination with the Asset Library's `StorageMetadata` type and the `_metadata()` function with no user defined restrictions or custom functionality.
 
 ```sway
-{{#include ../../../../examples/asset/basic_src7/src/main.sw:basic_src7}}
-```
-
-## Using the `Metadata` Extensions
-
-The `Metadata` type defined by the [SRC-7](https://docs.fuel.network/docs/sway-standards/src-7-asset-metadata/) standard can be one of 4 states:
-
-```sway
-pub enum Metadata {
-    B256: b256,
-    Bytes: Bytes,
-    Int: u64,
-    String: String,
-}
-```
-
-The Asset Library enables the following functionality for the `Metadata` type:
-
-### `is_b256()` and `as_b256()`
-
-The `is_b256()` check enables checking whether the `Metadata` type is a `b256`.
-The `as_b256()` returns the `b256` of the `Metadata` type.
-
-```sway
-{{#include ../../../../examples/asset/metadata_docs/src/main.sw:as_b256}}
-```
-
-### `is_bytes()` and `as_bytes()`
-
-The `is_bytes()` check enables checking whether the `Metadata` type is a `Bytes`.
-The `as_bytes()` returns the `Bytes` of the `Metadata` type.
-
-```sway
-{{#include ../../../../examples/asset/metadata_docs/src/main.sw:as_bytes}}
-```
-
-### `is_u64()` and `as_u64()`
-
-The `is_u64()` check enables checking whether the `Metadata` type is a `u64`.
-The `as_u64()` returns the `u64` of the `Metadata` type.
-
-```sway
-{{#include ../../../../examples/asset/metadata_docs/src/main.sw:as_u64}}
-```
-
-### `is_string()` and `as_string()`
-
-The `is_string()` check enables checking whether the `Metadata` type is a `String`.
-The `as_string()` returns the `String` of the `Metadata` type.
-
-```sway
-{{#include ../../../../examples/asset/metadata_docs/src/main.sw:as_string}}
+{{#include ../../../../examples/asset/basic_src7/src/main.sw:src7_metadata_convenience_function}}
 ```

--- a/docs/book/src/asset/supply.md
+++ b/docs/book/src/asset/supply.md
@@ -37,7 +37,9 @@ Once imported, the Asset Library's supply functionality should be available. To 
 
 ## Implementing the SRC-3 Standard with the Asset Library
 
-To use a base function, simply pass the `StorageKey` from the prescribed storage block. The example below shows the implementation of the [SRC-3](https://docs.fuel.network/docs/sway-standards/src-3-minting-and-burning/) standard in combination with the Asset Library with no user defined restrictions or custom functionality. It is recommended that the [Ownership Library](../ownership/index.md) is used in conjunction with the Asset Library;s supply functionality to ensure only a single user has permissions to mint an Asset.
+To use either function, simply pass the `StorageKey` from the prescribed storage block. The example below shows the implementation of the [SRC-3](https://docs.fuel.network/docs/sway-standards/src-3-minting-and-burning/) standard in combination with the Asset Library with no user defined restrictions or custom functionality. It is recommended that the [Ownership Library](../ownership/index.md) is used in conjunction with the Asset Library;s supply functionality to ensure only a single user has permissions to mint an Asset.
+
+The `_mint()` and `_burn()` functions follows the SRC-20 standard for logging and will emit the `TotalSupplyEvent` when called.
 
 ```sway
 {{#include ../../../../examples/asset/basic_src3/src/main.sw:basic_src3}}

--- a/examples/Forc.lock
+++ b/examples/Forc.lock
@@ -141,7 +141,7 @@ dependencies = [
 
 [[package]]
 name = "standards"
-source = "git+https://github.com/FuelLabs/sway-standards?tag=v0.5.2#270350e69bd7455b7e99f0aae2e29a94d42324bd"
+source = "git+https://github.com/FuelLabs/sway-standards?tag=v0.6.0#65e09f95ea8b9476b171a66c8a47108f352fa32c"
 dependencies = ["std"]
 
 [[package]]

--- a/examples/admin/Forc.toml
+++ b/examples/admin/Forc.toml
@@ -5,5 +5,5 @@ license = "Apache-2.0"
 name = "admin_examples"
 
 [dependencies]
-standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.5.2" }
+standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.6.0" }
 sway_libs = { path = "../../libs" }

--- a/examples/asset/base_docs/Forc.toml
+++ b/examples/asset/base_docs/Forc.toml
@@ -5,5 +5,5 @@ license = "Apache-2.0"
 name = "base_docs"
 
 [dependencies]
-standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.5.2" }
+standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.6.0" }
 sway_libs = { path = "../../../libs" }

--- a/examples/asset/basic_src20/Forc.toml
+++ b/examples/asset/basic_src20/Forc.toml
@@ -5,5 +5,5 @@ license = "Apache-2.0"
 name = "basic_src20"
 
 [dependencies]
-standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.5.2" }
+standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.6.0" }
 sway_libs = { path = "../../../libs" }

--- a/examples/asset/basic_src3/Forc.toml
+++ b/examples/asset/basic_src3/Forc.toml
@@ -5,5 +5,5 @@ license = "Apache-2.0"
 name = "basic_src3"
 
 [dependencies]
-standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.5.2" }
+standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.6.0" }
 sway_libs = { path = "../../../libs" }

--- a/examples/asset/basic_src3/src/main.sw
+++ b/examples/asset/basic_src3/src/main.sw
@@ -14,7 +14,7 @@ storage {
 // Implement the SRC-3 Standard for this contract
 impl SRC3 for Contract {
     #[storage(read, write)]
-    fn mint(recipient: Identity, sub_id: SubId, amount: u64) {
+    fn mint(recipient: Identity, sub_id: Option<SubId>, amount: u64) {
         // Pass the StorageKeys to the `_mint()` function from the Asset Library.
         _mint(
             storage

--- a/examples/asset/basic_src7/Forc.toml
+++ b/examples/asset/basic_src7/Forc.toml
@@ -5,5 +5,5 @@ license = "Apache-2.0"
 name = "basic_src7"
 
 [dependencies]
-standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.5.2" }
+standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.6.0" }
 sway_libs = { path = "../../../libs" }

--- a/examples/asset/metadata_docs/Forc.toml
+++ b/examples/asset/metadata_docs/Forc.toml
@@ -5,5 +5,5 @@ license = "Apache-2.0"
 name = "metadata_docs"
 
 [dependencies]
-standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.5.2" }
+standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.6.0" }
 sway_libs = { path = "../../../libs" }

--- a/examples/asset/metadata_docs/src/main.sw
+++ b/examples/asset/metadata_docs/src/main.sw
@@ -3,7 +3,7 @@ contract;
 use std::{bytes::Bytes, string::String};
 
 // ANCHOR: import
-use sway_libs::asset::metadata::{StorageMetadata, SetAssetMetadata, _set_metadata, _metadata};
+use sway_libs::asset::metadata::{_metadata, _set_metadata, SetAssetMetadata, StorageMetadata};
 use standards::src7::*;
 // ANCHOR_END: import
 

--- a/examples/asset/metadata_docs/src/main.sw
+++ b/examples/asset/metadata_docs/src/main.sw
@@ -3,7 +3,7 @@ contract;
 use std::{bytes::Bytes, string::String};
 
 // ANCHOR: import
-use sway_libs::asset::metadata::*;
+use sway_libs::asset::metadata::{StorageMetadata, SetAssetMetadata, _set_metadata, _metadata};
 use standards::src7::*;
 // ANCHOR_END: import
 
@@ -20,34 +20,20 @@ storage {
 }
 // ANCHOR_END: src7_storage
 
-// ANCHOR: as_b256
-fn b256_type(my_metadata: Metadata) {
-    assert(my_metadata.is_b256());
-
-    let my_b256: b256 = my_metadata.as_b256().unwrap();
+// ANCHOR src7_metadata_convenience_function
+impl SRC7 for Contract {
+    #[storage(read)]
+    fn metadata(asset: AssetId, key: String) -> Option<Metadata> {
+        _metadata(storage.metadata, asset, key)
+    }
 }
-// ANCHOR_END: as_b256
+// ANCHOR src7_metadata_convenience_function
 
-// ANCHOR: as_bytes
-fn bytes_type(my_metadata: Metadata) {
-    assert(my_metadata.is_bytes());
-
-    let my_bytes: Bytes = my_metadata.as_bytes().unwrap();
+// ANCHOR: src7_set_metadata
+impl SetAssetMetadata for Contract {
+    #[storage(read, write)]
+    fn set_metadata(asset: AssetId, metadata: Option<Metadata>, key: String) {
+        _set_metadata(storage.metadata, asset, metadata, key);
+    }
 }
-// ANCHOR_END: as_bytes
-
-// ANCHOR: as_u64
-fn u64_type(my_metadata: Metadata) {
-    assert(my_metadata.is_u64());
-
-    let my_u64: u64 = my_metadata.as_u64().unwrap();
-}
-// ANCHOR_END: as_u64
-
-// ANCHOR: as_string
-fn string_type(my_metadata: Metadata) {
-    assert(my_metadata.is_string());
-
-    let my_string: String = my_metadata.as_string().unwrap();
-}
-// ANCHOR_END: as_string
+// ANCHOR_END: src7_set_metadata

--- a/examples/asset/setting_src20_attributes/Forc.toml
+++ b/examples/asset/setting_src20_attributes/Forc.toml
@@ -5,5 +5,5 @@ license = "Apache-2.0"
 name = "setting_src20_attributes"
 
 [dependencies]
-standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.5.2" }
+standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.6.0" }
 sway_libs = { path = "../../../libs" }

--- a/examples/asset/setting_src20_attributes/src/main.sw
+++ b/examples/asset/setting_src20_attributes/src/main.sw
@@ -12,12 +12,12 @@ storage {
 
 impl SetAssetAttributes for Contract {
     #[storage(write)]
-    fn set_name(asset: AssetId, name: String) {
+    fn set_name(asset: AssetId, name: Option<String>) {
         _set_name(storage.name, asset, name);
     }
 
     #[storage(write)]
-    fn set_symbol(asset: AssetId, symbol: String) {
+    fn set_symbol(asset: AssetId, symbol: Option<String>) {
         _set_symbol(storage.symbol, asset, symbol);
     }
 

--- a/examples/asset/setting_src7_attributes/Forc.toml
+++ b/examples/asset/setting_src7_attributes/Forc.toml
@@ -5,5 +5,5 @@ license = "Apache-2.0"
 name = "setting_src7_attributes"
 
 [dependencies]
-standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.5.2" }
+standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.6.0" }
 sway_libs = { path = "../../../libs" }

--- a/examples/asset/setting_src7_attributes/src/main.sw
+++ b/examples/asset/setting_src7_attributes/src/main.sw
@@ -12,8 +12,8 @@ storage {
 
 impl SetAssetMetadata for Contract {
     #[storage(read, write)]
-    fn set_metadata(asset: AssetId, key: String, metadata: Metadata) {
-        _set_metadata(storage.metadata, asset, key, metadata);
+    fn set_metadata(asset: AssetId, metadata: Option<Metadata>, key: String) {
+        _set_metadata(storage.metadata, asset, metadata, key);
     }
 }
 // ANCHOR_END: setting_src7_attributes

--- a/examples/asset/supply_docs/Forc.toml
+++ b/examples/asset/supply_docs/Forc.toml
@@ -5,5 +5,5 @@ license = "Apache-2.0"
 name = "supply_docs"
 
 [dependencies]
-standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.5.2" }
+standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.6.0" }
 sway_libs = { path = "../../../libs" }

--- a/examples/asset/supply_docs/src/main.sw
+++ b/examples/asset/supply_docs/src/main.sw
@@ -10,7 +10,7 @@ use standards::src3::*;
 // ANCHOR: src3_abi
 abi SRC3 {
     #[storage(read, write)]
-    fn mint(recipient: Identity, vault_sub_id: SubId, amount: u64);
+    fn mint(recipient: Identity, sub_id: Option<SubId>, amount: u64);
     #[payable]
     #[storage(read, write)]
     fn burn(vault_sub_id: SubId, amount: u64);

--- a/examples/ownership/Forc.toml
+++ b/examples/ownership/Forc.toml
@@ -5,5 +5,5 @@ license = "Apache-2.0"
 name = "ownership_examples"
 
 [dependencies]
-standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.5.2" }
+standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.6.0" }
 sway_libs = { path = "../../libs" }

--- a/examples/upgradability/Forc.toml
+++ b/examples/upgradability/Forc.toml
@@ -5,5 +5,5 @@ license = "Apache-2.0"
 name = "upgradability_examples"
 
 [dependencies]
-standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.5.2" }
+standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.6.0" }
 sway_libs = { path = "../../libs" }

--- a/libs/Forc.lock
+++ b/libs/Forc.lock
@@ -4,7 +4,7 @@ source = "path+from-root-E19CE48B3E858B72"
 
 [[package]]
 name = "standards"
-source = "git+https://github.com/FuelLabs/sway-standards?tag=v0.5.2#270350e69bd7455b7e99f0aae2e29a94d42324bd"
+source = "git+https://github.com/FuelLabs/sway-standards?tag=v0.6.0#65e09f95ea8b9476b171a66c8a47108f352fa32c"
 dependencies = ["std"]
 
 [[package]]

--- a/libs/Forc.toml
+++ b/libs/Forc.toml
@@ -5,4 +5,4 @@ license = "Apache-2.0"
 name = "sway_libs"
 
 [dependencies]
-standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.5.2" }
+standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.6.0" }

--- a/libs/src/asset/base.sw
+++ b/libs/src/asset/base.sw
@@ -201,7 +201,7 @@ pub fn _decimals(
 ///
 /// * `name_key`: [StorageKey<StorageMap<AssetId, StorageKey<StorageString>>>] - The location in storage which the `StorageMap` that stores the names of assets is stored.
 /// * `asset`: [AssetId] - The asset of which to set the name.
-/// * `name`: [String] - The name of the asset.
+/// * `name`: [Option<String>] - The name of the asset.
 ///
 /// # Reverts
 ///
@@ -223,8 +223,8 @@ pub fn _decimals(
 ///
 /// fn foo(asset: AssetId) {
 ///     let name = String::from_ascii_str("Ether");
-///     _set_name(storage.name, asset, name);
-///     assert(_name(storage.name, asset) == name);
+///     _set_name(storage.name, asset, Some(name));
+///     assert(_name(storage.name, asset).unwrap() == name);
 /// }
 /// ```
 #[storage(write)]
@@ -262,7 +262,7 @@ pub fn _set_name(
 ///
 /// * `symbol_key`: [StorageKey<StorageMap<AssetId, StorageKey<StorageString>>>] - The location in storage which the `StorageMap` that stores the symbols of assets is stored.
 /// * `asset`: [AssetId] - The asset of which to set the symbol.
-/// * `symbol`: [String] - The symbol of the asset.
+/// * `symbol`: [Option<String>] - The symbol of the asset.
 ///
 /// # Reverts
 ///
@@ -284,8 +284,8 @@ pub fn _set_name(
 ///
 /// fn foo(asset: AssetId) {
 ///     let symbol = String::from_ascii_str("ETH");
-///     _set_symbol(storage.symbol, asset, symbol);
-///     assert(_symbol(storage.symbol, asset) == symbol);
+///     _set_symbol(storage.symbol, asset, Some(symbol));
+///     assert(_symbol(storage.symbol, asset).unwrap() == symbol);
 /// }
 /// ```
 #[storage(write)]
@@ -333,7 +333,6 @@ pub fn _set_symbol(
 ///
 /// ```sway
 /// use sway_libs::asset::base::{_set_decimals, _decimals};
-/// use std::string::String;
 ///
 /// storage {
 ///     decimals: StorageMap<AssetId, u8> = StorageMap {},
@@ -342,7 +341,7 @@ pub fn _set_symbol(
 /// fn foo(asset: AssetId) {
 ///     let decimals = 8u8;
 ///     _set_decimals(storage.decimals, asset, decimals);
-///     assert(_decimals(storage.decimals, asset) == decimals);
+///     assert(_decimals(storage.decimals, asset).unwrap() == decimals);
 /// }
 /// ```
 #[storage(write)]
@@ -361,10 +360,69 @@ pub fn _set_decimals(
 }
 
 abi SetAssetAttributes {
+    /// Stores the name for a specific asset.
+    ///
+    /// # Arguments
+    ///
+    /// * `asset`: [AssetId] - The asset for the name to be stored.
+    /// * `name`: [Option<String>] - The name which to be stored.
+    ///
+    /// # Example
+    ///
+    /// ```sway
+    /// use standards::src20::SRC20;
+    /// use sway_libs::asset::base::*;
+    /// use std::string::String;
+    ///
+    /// fn foo(contract_id: ContractId, asset: AssetId, name: Option<String>) {
+    ///     let contract_abi = abi(SetAssetAttributes, contract_id.bits());
+    ///     contract_abi.set_name(asset, name);
+    ///     assert(contract_abi.name(asset) == name);
+    /// }
+    /// ```
     #[storage(write)]
     fn set_name(asset: AssetId, name: Option<String>);
+    /// Stores the symbol for a specific asset.
+    ///
+    /// # Arguments
+    ///
+    /// * `asset`: [AssetId] - The asset for the symbol to be stored.
+    /// * `symbol`: [Option<String>] - The symbol which to be stored.
+    ///
+    /// # Example
+    ///
+    /// ```sway
+    /// use standards::src20::SRC20;
+    /// use sway_libs::asset::base::*;
+    /// use std::string::String;
+    ///
+    /// fn foo(contract_id: ContractId, asset: AssetId, symbol: Option<String>) {
+    ///     let contract_abi = abi(SetAssetAttributes, contract_id.bits());
+    ///     contract_abi.set_symbol(asset, symbol);
+    ///     assert(contract_abi.symbol(asset) == symbol);
+    /// }
+    /// ```
     #[storage(write)]
     fn set_symbol(asset: AssetId, symbol: Option<String>);
+    /// Stores the decimals for a specific asset.
+    ///
+    /// # Arguments
+    ///
+    /// * `asset`: [AssetId] - The asset for the symbol to be stored.
+    /// * `decimals`: [u8] - The decimals which to be stored.
+    ///
+    /// # Example
+    ///
+    /// ```sway
+    /// use standards::src20::SRC20;
+    /// use sway_libs::asset::base::*;
+    ///
+    /// fn foo(contract_id: ContractId, asset: AssetId, decimals: u8) {
+    ///     let contract_abi = abi(SetAssetAttributes, contract_id.bits());
+    ///     contract_abi.set_decimals(asset, decimals);
+    ///     assert(contract_abi.decimals(asset).unwrap() == decimals);
+    /// }
+    /// ```
     #[storage(write)]
     fn set_decimals(asset: AssetId, decimals: u8);
 }

--- a/libs/src/asset/errors.sw
+++ b/libs/src/asset/errors.sw
@@ -4,4 +4,20 @@ library;
 pub enum BurnError {
     /// Emitted when there are not enough coins owned by the contract to burn.
     NotEnoughCoins: (),
+    /// Emitted when attempting to burn zero coins.
+    ZeroAmount: (),
+}
+
+/// Error log for when something goes wrong when minting assets.
+pub enum MintError {
+    /// Emitted when attempting to mint zero coins.
+    ZeroAmount: (),
+}
+
+/// Error log for when something goes wrong when setting metadata.
+pub enum SetMetadataError {
+    /// Emitted when the metadata is an empty string.
+    EmptyString: (),
+    /// Emitted when the metadata is empty bytes.
+    EmptyBytes: (),
 }

--- a/libs/src/asset/metadata.sw
+++ b/libs/src/asset/metadata.sw
@@ -50,6 +50,7 @@ impl StorageKey<StorageMetadata> {
     /// ```sway
     /// use standards::src7::Metadata;
     /// use sway_libs::asset::metadata::*;
+    /// use std::string::String;
     ///
     /// storage {
     ///     metadata: StorageMetadata = StorageMetadata {}
@@ -119,6 +120,7 @@ impl StorageKey<StorageMetadata> {
     /// ```sway
     /// use standards::src7::Metadata;
     /// use sway_libs::asset::metadata::*;
+    /// use std::string::String;
     ///
     /// storage {
     ///     metadata: StorageMetadata = StorageMetadata {}
@@ -159,8 +161,8 @@ impl StorageKey<StorageMetadata> {
 ///
 /// * `metadata_key`: [StorageKey<StorageMetadata>] - The storage location for metadata.
 /// * `asset`: [AssetId] - The asset for the metadata to be stored.
+/// * `metadata`: [Option<Metadata>] - The metadata which to be stored.
 /// * `key`: [String] - The key for the metadata to be stored.
-/// * `metadata`: [Metadata] - The metadata which to be stored.
 ///
 /// # Number of Storage Accesses
 ///
@@ -171,13 +173,14 @@ impl StorageKey<StorageMetadata> {
 /// ```sway
 /// use standards::src7::Metadata;
 /// use sway_libs::asset::metadata::*;
+/// use std::string::String;
 ///
 /// storage {
 ///     metadata: StorageMetadata = StorageMetadata {}
 /// }
 ///
-/// fn foo(asset: AssetId, key: String, metadata: Metadata) {
-///     _set_metadata(storage.metadata, asset, key, metadata);
+/// fn foo(asset: AssetId, key: String, metadata: Option<Metadata>) {
+///     _set_metadata(storage.metadata, asset, metadata, key);
 /// }
 /// ```
 #[storage(read, write)]
@@ -190,6 +193,34 @@ pub fn _set_metadata(
     metadata_key.insert(asset, metadata, key);
 }
 
+/// Returns metadata for a specific asset and key pair.
+///
+/// # Arguments
+///
+/// * `metadata_key`: [StorageKey<StorageMetadata>] - The storage location for metadata.
+/// * `asset`: [AssetId] - The asset for the metadata to be read.
+/// * `metadata`: [Option<Metadata>] - The metadata which to be read.
+/// * `key`: [String] - The key for the metadata to be read.
+///
+/// # Number of Storage Accesses
+///
+/// * Reads: `2`
+///
+/// # Example
+///
+/// ```sway
+/// use standards::src7::Metadata;
+/// use sway_libs::asset::metadata::*;
+/// use std::string::String;
+///
+/// storage {
+///     metadata: StorageMetadata = StorageMetadata {}
+/// }
+///
+/// fn foo(asset: AssetId, key: String) {
+///     let result: Option<Metadata> = _metadata(storage.metadata, asset, key);
+/// }
+/// ```
 #[storage(read)]
 pub fn _metadata(
     metadata_key: StorageKey<StorageMetadata>, 
@@ -200,6 +231,27 @@ pub fn _metadata(
 } 
 
 abi SetAssetMetadata {
+    /// Stores metadata for a specific asset and key pair.
+    ///
+    /// # Arguments
+    ///
+    /// * `asset`: [AssetId] - The asset for the metadata to be stored.
+    /// * `metadata`: [Option<Metadata>] - The metadata which to be stored.
+    /// * `key`: [String] - The key for the metadata to be stored.
+    ///
+    /// # Example
+    ///
+    /// ```sway
+    /// use standards::src7::{SRC7, Metadata};
+    /// use sway_libs::asset::metadata::*;
+    /// use std::string::String;
+    ///
+    /// fn foo(contract_id: ContractId, asset: AssetId, metadata: Option<Metadata>, key: String) {
+    ///     let contract_abi = abi(SetAssetMetadata, contract_id.bits());
+    ///     contract_abi.set_metadata(asset, metadata, key);
+    ///     assert(contract_abi.metadata(asset, key).unwrap() == Metadata);
+    /// }
+    /// ```
     #[storage(read, write)]
     fn set_metadata(asset: AssetId, metadata: Option<Metadata>, key: String);
 }

--- a/libs/src/asset/metadata.sw
+++ b/libs/src/asset/metadata.sw
@@ -61,7 +61,12 @@ impl StorageKey<StorageMetadata> {
     /// }
     /// ```
     #[storage(read, write)]
-    pub fn insert(self, asset: AssetId, metadata: Option<Metadata>, key: String) {
+    pub fn insert(
+        self,
+        asset: AssetId,
+        metadata: Option<Metadata>,
+        key: String,
+) {
         let hashed_key = sha256((asset, key));
 
         match metadata {
@@ -223,13 +228,12 @@ pub fn _set_metadata(
 /// ```
 #[storage(read)]
 pub fn _metadata(
-    metadata_key: StorageKey<StorageMetadata>, 
-    asset: AssetId, 
-    key: String
+    metadata_key: StorageKey<StorageMetadata>,
+    asset: AssetId,
+    key: String,
 ) -> Option<Metadata> {
     metadata_key.get(asset, key)
-} 
-
+}
 abi SetAssetMetadata {
     /// Stores metadata for a specific asset and key pair.
     ///

--- a/tests/Forc.lock
+++ b/tests/Forc.lock
@@ -210,7 +210,7 @@ dependencies = ["std"]
 
 [[package]]
 name = "standards"
-source = "git+https://github.com/FuelLabs/sway-standards?tag=v0.5.2#270350e69bd7455b7e99f0aae2e29a94d42324bd"
+source = "git+https://github.com/FuelLabs/sway-standards?tag=v0.6.0#65e09f95ea8b9476b171a66c8a47108f352fa32c"
 dependencies = ["std"]
 
 [[package]]

--- a/tests/src/admin/Forc.toml
+++ b/tests/src/admin/Forc.toml
@@ -5,5 +5,5 @@ license = "Apache-2.0"
 name = "admin_test"
 
 [dependencies]
-standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.5.2" }
+standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.6.0" }
 sway_libs = { path = "../../../libs" }

--- a/tests/src/native_asset/Forc.toml
+++ b/tests/src/native_asset/Forc.toml
@@ -5,5 +5,5 @@ license = "Apache-2.0"
 name = "native_asset_lib"
 
 [dependencies]
-standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.5.2" }
+standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.6.0" }
 sway_libs = { path = "../../../libs" }

--- a/tests/src/native_asset/tests/functions/burn.rs
+++ b/tests/src/native_asset/tests/functions/burn.rs
@@ -1,7 +1,8 @@
 use crate::native_asset::tests::utils::{
     interface::{burn, mint, total_assets, total_supply},
-    setup::{defaults, get_wallet_balance, setup},
+    setup::{defaults, get_wallet_balance, setup, TotalSupplyEvent},
 };
+use fuels::types::Identity;
 
 mod success {
 
@@ -11,82 +12,203 @@ mod success {
     async fn burn_assets() {
         let (owner_wallet, other_wallet, id, instance_1, instance_2) = setup().await;
         let (asset_id_1, _asset_id_2, sub_id_1, _sub_id_2, _owner_identity, identity2) =
-            defaults(id, owner_wallet, other_wallet.clone());
+            defaults(id, owner_wallet.clone(), other_wallet.clone());
+        let mint_amount_1 = 100;
+        let burn_amount_1 = 25;
 
-        mint(&instance_1, identity2, sub_id_1, 100).await;
+        assert!(mint_amount_1 >= burn_amount_1);
 
-        assert_eq!(get_wallet_balance(&other_wallet, &asset_id_1).await, 100);
-        assert_eq!(total_supply(&instance_1, asset_id_1).await, Some(100));
+        mint(&instance_1, identity2, Some(sub_id_1), mint_amount_1).await;
+
+        assert_eq!(get_wallet_balance(&other_wallet, &asset_id_1).await, mint_amount_1);
+        assert_eq!(total_supply(&instance_1, asset_id_1).await, Some(mint_amount_1));
         assert_eq!(total_assets(&instance_1).await, 1);
 
-        burn(&instance_2, asset_id_1, sub_id_1, 50).await;
+        let response = burn(&instance_2, asset_id_1, sub_id_1, burn_amount_1).await;
 
-        assert_eq!(get_wallet_balance(&other_wallet, &asset_id_1).await, 50);
-        assert_eq!(total_supply(&instance_1, asset_id_1).await, Some(50));
+        assert_eq!(get_wallet_balance(&other_wallet, &asset_id_1).await, mint_amount_1 - burn_amount_1);
+        assert_eq!(total_supply(&instance_1, asset_id_1).await, Some(mint_amount_1 - burn_amount_1));
         assert_eq!(total_assets(&instance_1).await, 1);
+        let log = response
+            .decode_logs_with_type::<TotalSupplyEvent>()
+            .unwrap();
+        let event = log.first().unwrap();
+        assert_eq!(
+            *event,
+            TotalSupplyEvent {
+                asset: asset_id_1,
+                supply: mint_amount_1 - burn_amount_1,
+                sender: Identity::Address(other_wallet.address().into()),
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn burn_twice() {
+        let (owner_wallet, other_wallet, id, instance_1, instance_2) = setup().await;
+        let (asset_id_1, _asset_id_2, sub_id_1, _sub_id_2, _owner_identity, identity2) =
+            defaults(id, owner_wallet.clone(), other_wallet.clone());
+        let mint_amount_1 = 100;
+        let burn_amount_1 = 25;
+        let burn_amount_2 = 30;
+        let burn_amount_3 = 3;
+
+        assert!(mint_amount_1 >= burn_amount_1 + burn_amount_2 + burn_amount_3);
+
+        mint(&instance_1, identity2, Some(sub_id_1), mint_amount_1).await;
+
+        assert_eq!(get_wallet_balance(&other_wallet, &asset_id_1).await, mint_amount_1);
+        assert_eq!(total_supply(&instance_1, asset_id_1).await, Some(mint_amount_1));
+        assert_eq!(total_assets(&instance_1).await, 1);
+
+        let response = burn(&instance_2, asset_id_1, sub_id_1, burn_amount_1).await;
+        assert_eq!(get_wallet_balance(&other_wallet, &asset_id_1).await, mint_amount_1 - burn_amount_1);
+        assert_eq!(total_supply(&instance_1, asset_id_1).await, Some(mint_amount_1 - burn_amount_1));
+        assert_eq!(total_assets(&instance_1).await, 1);
+        let log = response
+            .decode_logs_with_type::<TotalSupplyEvent>()
+            .unwrap();
+        let event = log.first().unwrap();
+        assert_eq!(
+            *event,
+            TotalSupplyEvent {
+                asset: asset_id_1,
+                supply: mint_amount_1 - burn_amount_1,
+                sender: Identity::Address(other_wallet.address().into()),
+            }
+        );
+
+        let response = burn(&instance_2, asset_id_1, sub_id_1, burn_amount_2).await;
+        assert_eq!(get_wallet_balance(&other_wallet, &asset_id_1).await, mint_amount_1 - burn_amount_1 - burn_amount_2);
+        assert_eq!(total_supply(&instance_1, asset_id_1).await, Some(mint_amount_1 - burn_amount_1 - burn_amount_2));
+        assert_eq!(total_assets(&instance_1).await, 1);
+        let log = response
+            .decode_logs_with_type::<TotalSupplyEvent>()
+            .unwrap();
+        let event = log.first().unwrap();
+        assert_eq!(
+            *event,
+            TotalSupplyEvent {
+                asset: asset_id_1,
+                supply: mint_amount_1 - burn_amount_1 - burn_amount_2,
+                sender: Identity::Address(other_wallet.address().into()),
+            }
+        );
+
+        let response = burn(&instance_2, asset_id_1, sub_id_1, burn_amount_3).await;
+        assert_eq!(get_wallet_balance(&other_wallet, &asset_id_1).await, mint_amount_1 - burn_amount_1 - burn_amount_2 - burn_amount_3);
+        assert_eq!(total_supply(&instance_1, asset_id_1).await, Some(mint_amount_1 - burn_amount_1 - burn_amount_2 - burn_amount_3));
+        assert_eq!(total_assets(&instance_1).await, 1);
+        let log = response
+            .decode_logs_with_type::<TotalSupplyEvent>()
+            .unwrap();
+        let event = log.first().unwrap();
+        assert_eq!(
+            *event,
+            TotalSupplyEvent {
+                asset: asset_id_1,
+                supply: mint_amount_1 - burn_amount_1 - burn_amount_2 - burn_amount_3,
+                sender: Identity::Address(other_wallet.address().into()),
+            }
+        );
     }
 
     #[tokio::test]
     async fn burns_multiple_assets() {
         let (owner_wallet, other_wallet, id, instance_1, instance_2) = setup().await;
         let (asset_id_1, asset_id_2, sub_id_1, sub_id_2, _owner_identity, identity2) =
-            defaults(id, owner_wallet, other_wallet.clone());
+            defaults(id, owner_wallet.clone(), other_wallet.clone());
+        let mint_amount_1 = 100;
+        let mint_amount_2 = 200;
+        let burn_amount_1 = 25;
+        let burn_amount_2 = 150;
 
-        mint(&instance_1, identity2.clone(), sub_id_1, 100).await;
-        mint(&instance_1, identity2, sub_id_2, 200).await;
+        assert!(mint_amount_1 >= burn_amount_1);
+        assert!(mint_amount_2 >= burn_amount_2);
 
-        assert_eq!(get_wallet_balance(&other_wallet, &asset_id_1).await, 100);
-        assert_eq!(get_wallet_balance(&other_wallet, &asset_id_2).await, 200);
-        assert_eq!(total_supply(&instance_1, asset_id_1).await, Some(100));
-        assert_eq!(total_supply(&instance_1, asset_id_2).await, Some(200));
+        mint(&instance_1, identity2.clone(), Some(sub_id_1), mint_amount_1).await;
+        mint(&instance_1, identity2, Some(sub_id_2), mint_amount_2).await;
+
+        assert_eq!(get_wallet_balance(&other_wallet, &asset_id_1).await, mint_amount_1);
+        assert_eq!(get_wallet_balance(&other_wallet, &asset_id_2).await, mint_amount_2);
+        assert_eq!(total_supply(&instance_1, asset_id_1).await, Some(mint_amount_1));
+        assert_eq!(total_supply(&instance_1, asset_id_2).await, Some(mint_amount_2));
         assert_eq!(total_assets(&instance_1).await, 2);
 
-        burn(&instance_2, asset_id_1, sub_id_1, 50).await;
+        let response = burn(&instance_2, asset_id_1, sub_id_1, burn_amount_1).await;
 
-        assert_eq!(get_wallet_balance(&other_wallet, &asset_id_1).await, 50);
-        assert_eq!(get_wallet_balance(&other_wallet, &asset_id_2).await, 200);
-        assert_eq!(total_supply(&instance_1, asset_id_1).await, Some(50));
-        assert_eq!(total_supply(&instance_1, asset_id_2).await, Some(200));
+        assert_eq!(get_wallet_balance(&other_wallet, &asset_id_1).await, mint_amount_1 - burn_amount_1);
+        assert_eq!(get_wallet_balance(&other_wallet, &asset_id_2).await, mint_amount_2);
+        assert_eq!(total_supply(&instance_1, asset_id_1).await, Some(mint_amount_1 - burn_amount_1));
+        assert_eq!(total_supply(&instance_1, asset_id_2).await, Some(mint_amount_2));
         assert_eq!(total_assets(&instance_1).await, 2);
+        let log = response
+            .decode_logs_with_type::<TotalSupplyEvent>()
+            .unwrap();
+        let event = log.first().unwrap();
+        assert_eq!(
+            *event,
+            TotalSupplyEvent {
+                asset: asset_id_1,
+                supply: mint_amount_1 - burn_amount_1,
+                sender: Identity::Address(other_wallet.address().into()),
+            }
+        );
 
-        burn(&instance_2, asset_id_2, sub_id_2, 100).await;
+        let response = burn(&instance_2, asset_id_2, sub_id_2, burn_amount_2).await;
 
-        assert_eq!(get_wallet_balance(&other_wallet, &asset_id_1).await, 50);
-        assert_eq!(get_wallet_balance(&other_wallet, &asset_id_2).await, 100);
-        assert_eq!(total_supply(&instance_1, asset_id_1).await, Some(50));
-        assert_eq!(total_supply(&instance_1, asset_id_2).await, Some(100));
+        assert_eq!(get_wallet_balance(&other_wallet, &asset_id_1).await, mint_amount_1 - burn_amount_1);
+        assert_eq!(get_wallet_balance(&other_wallet, &asset_id_2).await, mint_amount_2 - burn_amount_2);
+        assert_eq!(total_supply(&instance_1, asset_id_1).await, Some(mint_amount_1 - burn_amount_1));
+        assert_eq!(total_supply(&instance_1, asset_id_2).await, Some(mint_amount_2 - burn_amount_2));
         assert_eq!(total_assets(&instance_1).await, 2);
+        let log = response
+            .decode_logs_with_type::<TotalSupplyEvent>()
+            .unwrap();
+        let event = log.first().unwrap();
+        assert_eq!(
+            *event,
+            TotalSupplyEvent {
+                asset: asset_id_2,
+                supply: mint_amount_2 - burn_amount_2,
+                sender: Identity::Address(other_wallet.address().into()),
+            }
+        );
     }
 
     #[tokio::test]
     async fn burn_to_zero() {
         let (owner_wallet, other_wallet, id, instance_1, instance_2) = setup().await;
         let (asset_id_1, _asset_id_2, sub_id_1, _sub_id_2, _owner_identity, identity2) =
-            defaults(id, owner_wallet, other_wallet.clone());
+            defaults(id, owner_wallet.clone(), other_wallet.clone());
+        let mint_amount_1 = 100;
+        let burn_amount_1 = 100;
 
-        mint(&instance_1, identity2, sub_id_1, 100).await;
+        assert!(mint_amount_1 == burn_amount_1);
 
-        assert_eq!(get_wallet_balance(&other_wallet, &asset_id_1).await, 100);
-        assert_eq!(total_supply(&instance_1, asset_id_1).await, Some(100));
+        mint(&instance_1, identity2, Some(sub_id_1), mint_amount_1).await;
+
+        assert_eq!(get_wallet_balance(&other_wallet, &asset_id_1).await, mint_amount_1);
+        assert_eq!(total_supply(&instance_1, asset_id_1).await, Some(mint_amount_1));
         assert_eq!(total_assets(&instance_1).await, 1);
 
-        burn(&instance_2, asset_id_1, sub_id_1, 50).await;
-
-        assert_eq!(get_wallet_balance(&other_wallet, &asset_id_1).await, 50);
-        assert_eq!(total_supply(&instance_1, asset_id_1).await, Some(50));
-        assert_eq!(total_assets(&instance_1).await, 1);
-
-        burn(&instance_2, asset_id_1, sub_id_1, 25).await;
-
-        assert_eq!(get_wallet_balance(&other_wallet, &asset_id_1).await, 25);
-        assert_eq!(total_supply(&instance_1, asset_id_1).await, Some(25));
-        assert_eq!(total_assets(&instance_1).await, 1);
-
-        burn(&instance_2, asset_id_1, sub_id_1, 25).await;
+        let response = burn(&instance_2, asset_id_1, sub_id_1, burn_amount_1).await;
 
         assert_eq!(get_wallet_balance(&other_wallet, &asset_id_1).await, 0);
         assert_eq!(total_supply(&instance_1, asset_id_1).await, Some(0));
         assert_eq!(total_assets(&instance_1).await, 1);
+        let log = response
+            .decode_logs_with_type::<TotalSupplyEvent>()
+            .unwrap();
+        let event = log.first().unwrap();
+        assert_eq!(
+            *event,
+            TotalSupplyEvent {
+                asset: asset_id_1,
+                supply: 0,
+                sender: Identity::Address(other_wallet.address().into()),
+            }
+        );
     }
 }
 
@@ -100,17 +222,48 @@ mod revert {
 
     #[tokio::test]
     #[should_panic(expected = "NotEnoughCoins")]
-    async fn when_not_enough_coins() {
+    async fn when_not_enough_coins_in_transaction() {
         let (owner_wallet, other_wallet, id, instance_1, instance_2) = setup().await;
         let (asset_id_1, _asset_id_2, sub_id_1, _sub_id_2, _identity1, identity2) =
             defaults(id, owner_wallet, other_wallet.clone());
+        let mint_amount = 100;
+        let sent_burn_amount = 50;
+        let claimed_burn_amount = 75;
 
-        mint(&instance_1, identity2, sub_id_1, 100).await;
+        assert!(sent_burn_amount < claimed_burn_amount);
 
-        let call_params = CallParameters::new(50, asset_id_1, 1_000_000);
+        mint(&instance_1, identity2, Some(sub_id_1), mint_amount).await;
+
+        let call_params = CallParameters::new(sent_burn_amount, asset_id_1, 1_000_000);
         instance_2
             .methods()
-            .burn(sub_id_1, 150)
+            .burn(sub_id_1, claimed_burn_amount)
+            .with_tx_policies(TxPolicies::default().with_script_gas_limit(2_000_000))
+            .call_params(call_params)
+            .unwrap()
+            .call()
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    #[should_panic(expected = "NotEnoughCoins")]
+    async fn when_greater_than_supply() {
+        let (owner_wallet, other_wallet, id, instance_1, instance_2) = setup().await;
+        let (asset_id_1, _asset_id_2, sub_id_1, _sub_id_2, _identity1, identity2) =
+            defaults(id, owner_wallet, other_wallet.clone());
+        let mint_amount = 100;
+        let sent_burn_amount = 100;
+        let claimed_burn_amount = 150;
+
+        assert!(mint_amount < claimed_burn_amount);
+
+        mint(&instance_1, identity2, Some(sub_id_1), mint_amount).await;
+
+        let call_params = CallParameters::new(sent_burn_amount, asset_id_1, 1_000_000);
+        instance_2
+            .methods()
+            .burn(sub_id_1, claimed_burn_amount)
             .with_tx_policies(TxPolicies::default().with_script_gas_limit(2_000_000))
             .call_params(call_params)
             .unwrap()
@@ -125,13 +278,18 @@ mod revert {
         let (owner_wallet, other_wallet, id, instance_1, instance_2) = setup().await;
         let (asset_id_1, _asset_id_2, sub_id_1, sub_id_2, _identity1, identity2) =
             defaults(id, owner_wallet, other_wallet.clone());
+        let mint_amount = 100;
+        let sent_burn_amount = 50;
+        let claimed_burn_amount = 50;
 
-        mint(&instance_1, identity2, sub_id_1, 100).await;
+        assert!(sent_burn_amount == claimed_burn_amount);
 
-        let call_params = CallParameters::new(50, asset_id_1, 1_000_000);
+        mint(&instance_1, identity2, Some(sub_id_1), mint_amount).await;
+
+        let call_params = CallParameters::new(sent_burn_amount, asset_id_1, 1_000_000);
         instance_2
             .methods()
-            .burn(sub_id_2, 50)
+            .burn(sub_id_2, claimed_burn_amount)
             .with_tx_policies(TxPolicies::default().with_script_gas_limit(2_000_000))
             .call_params(call_params)
             .unwrap()
@@ -146,18 +304,39 @@ mod revert {
         let (owner_wallet, other_wallet, id, instance_1, instance_2) = setup().await;
         let (_asset_id_1, _asset_id_2, sub_id_1, _sub_id_2, _identity1, identity2) =
             defaults(id, owner_wallet, other_wallet.clone());
+        let mint_amount = 100;
+        let sent_burn_amount = 50;
+        let claimed_burn_amount = 50;
 
-        mint(&instance_1, identity2, sub_id_1, 100).await;
+        assert!(sent_burn_amount == claimed_burn_amount);
 
-        let call_params = CallParameters::new(50, AssetId::zeroed(), 1_000_000);
+        mint(&instance_1, identity2, Some(sub_id_1), mint_amount).await;
+
+        let call_params = CallParameters::new(sent_burn_amount, AssetId::zeroed(), 1_000_000);
         instance_2
             .methods()
-            .burn(sub_id_1, 50)
+            .burn(sub_id_1, claimed_burn_amount)
             .with_tx_policies(TxPolicies::default().with_script_gas_limit(2_000_000))
             .call_params(call_params)
             .unwrap()
             .call()
             .await
             .unwrap();
+    }
+
+    #[tokio::test]
+    #[should_panic(expected = "ZeroAmount")]
+    async fn when_burn_zero() {
+        let (owner_wallet, other_wallet, id, instance_1, instance_2) = setup().await;
+        let (asset_id_1, _asset_id_2, sub_id_1, _sub_id_2, _owner_identity, identity2) =
+            defaults(id, owner_wallet.clone(), other_wallet.clone());
+        let mint_amount_1 = 100;
+        let burn_amount_1 = 0;
+
+        assert!(burn_amount_1 == 0);
+
+        mint(&instance_1, identity2, Some(sub_id_1), mint_amount_1).await;
+
+        burn(&instance_2, asset_id_1, sub_id_1, burn_amount_1).await;
     }
 }

--- a/tests/src/native_asset/tests/functions/burn.rs
+++ b/tests/src/native_asset/tests/functions/burn.rs
@@ -20,14 +20,26 @@ mod success {
 
         mint(&instance_1, identity2, Some(sub_id_1), mint_amount_1).await;
 
-        assert_eq!(get_wallet_balance(&other_wallet, &asset_id_1).await, mint_amount_1);
-        assert_eq!(total_supply(&instance_1, asset_id_1).await, Some(mint_amount_1));
+        assert_eq!(
+            get_wallet_balance(&other_wallet, &asset_id_1).await,
+            mint_amount_1
+        );
+        assert_eq!(
+            total_supply(&instance_1, asset_id_1).await,
+            Some(mint_amount_1)
+        );
         assert_eq!(total_assets(&instance_1).await, 1);
 
         let response = burn(&instance_2, asset_id_1, sub_id_1, burn_amount_1).await;
 
-        assert_eq!(get_wallet_balance(&other_wallet, &asset_id_1).await, mint_amount_1 - burn_amount_1);
-        assert_eq!(total_supply(&instance_1, asset_id_1).await, Some(mint_amount_1 - burn_amount_1));
+        assert_eq!(
+            get_wallet_balance(&other_wallet, &asset_id_1).await,
+            mint_amount_1 - burn_amount_1
+        );
+        assert_eq!(
+            total_supply(&instance_1, asset_id_1).await,
+            Some(mint_amount_1 - burn_amount_1)
+        );
         assert_eq!(total_assets(&instance_1).await, 1);
         let log = response
             .decode_logs_with_type::<TotalSupplyEvent>()
@@ -57,13 +69,25 @@ mod success {
 
         mint(&instance_1, identity2, Some(sub_id_1), mint_amount_1).await;
 
-        assert_eq!(get_wallet_balance(&other_wallet, &asset_id_1).await, mint_amount_1);
-        assert_eq!(total_supply(&instance_1, asset_id_1).await, Some(mint_amount_1));
+        assert_eq!(
+            get_wallet_balance(&other_wallet, &asset_id_1).await,
+            mint_amount_1
+        );
+        assert_eq!(
+            total_supply(&instance_1, asset_id_1).await,
+            Some(mint_amount_1)
+        );
         assert_eq!(total_assets(&instance_1).await, 1);
 
         let response = burn(&instance_2, asset_id_1, sub_id_1, burn_amount_1).await;
-        assert_eq!(get_wallet_balance(&other_wallet, &asset_id_1).await, mint_amount_1 - burn_amount_1);
-        assert_eq!(total_supply(&instance_1, asset_id_1).await, Some(mint_amount_1 - burn_amount_1));
+        assert_eq!(
+            get_wallet_balance(&other_wallet, &asset_id_1).await,
+            mint_amount_1 - burn_amount_1
+        );
+        assert_eq!(
+            total_supply(&instance_1, asset_id_1).await,
+            Some(mint_amount_1 - burn_amount_1)
+        );
         assert_eq!(total_assets(&instance_1).await, 1);
         let log = response
             .decode_logs_with_type::<TotalSupplyEvent>()
@@ -79,8 +103,14 @@ mod success {
         );
 
         let response = burn(&instance_2, asset_id_1, sub_id_1, burn_amount_2).await;
-        assert_eq!(get_wallet_balance(&other_wallet, &asset_id_1).await, mint_amount_1 - burn_amount_1 - burn_amount_2);
-        assert_eq!(total_supply(&instance_1, asset_id_1).await, Some(mint_amount_1 - burn_amount_1 - burn_amount_2));
+        assert_eq!(
+            get_wallet_balance(&other_wallet, &asset_id_1).await,
+            mint_amount_1 - burn_amount_1 - burn_amount_2
+        );
+        assert_eq!(
+            total_supply(&instance_1, asset_id_1).await,
+            Some(mint_amount_1 - burn_amount_1 - burn_amount_2)
+        );
         assert_eq!(total_assets(&instance_1).await, 1);
         let log = response
             .decode_logs_with_type::<TotalSupplyEvent>()
@@ -96,8 +126,14 @@ mod success {
         );
 
         let response = burn(&instance_2, asset_id_1, sub_id_1, burn_amount_3).await;
-        assert_eq!(get_wallet_balance(&other_wallet, &asset_id_1).await, mint_amount_1 - burn_amount_1 - burn_amount_2 - burn_amount_3);
-        assert_eq!(total_supply(&instance_1, asset_id_1).await, Some(mint_amount_1 - burn_amount_1 - burn_amount_2 - burn_amount_3));
+        assert_eq!(
+            get_wallet_balance(&other_wallet, &asset_id_1).await,
+            mint_amount_1 - burn_amount_1 - burn_amount_2 - burn_amount_3
+        );
+        assert_eq!(
+            total_supply(&instance_1, asset_id_1).await,
+            Some(mint_amount_1 - burn_amount_1 - burn_amount_2 - burn_amount_3)
+        );
         assert_eq!(total_assets(&instance_1).await, 1);
         let log = response
             .decode_logs_with_type::<TotalSupplyEvent>()
@@ -126,21 +162,51 @@ mod success {
         assert!(mint_amount_1 >= burn_amount_1);
         assert!(mint_amount_2 >= burn_amount_2);
 
-        mint(&instance_1, identity2.clone(), Some(sub_id_1), mint_amount_1).await;
+        mint(
+            &instance_1,
+            identity2.clone(),
+            Some(sub_id_1),
+            mint_amount_1,
+        )
+        .await;
         mint(&instance_1, identity2, Some(sub_id_2), mint_amount_2).await;
 
-        assert_eq!(get_wallet_balance(&other_wallet, &asset_id_1).await, mint_amount_1);
-        assert_eq!(get_wallet_balance(&other_wallet, &asset_id_2).await, mint_amount_2);
-        assert_eq!(total_supply(&instance_1, asset_id_1).await, Some(mint_amount_1));
-        assert_eq!(total_supply(&instance_1, asset_id_2).await, Some(mint_amount_2));
+        assert_eq!(
+            get_wallet_balance(&other_wallet, &asset_id_1).await,
+            mint_amount_1
+        );
+        assert_eq!(
+            get_wallet_balance(&other_wallet, &asset_id_2).await,
+            mint_amount_2
+        );
+        assert_eq!(
+            total_supply(&instance_1, asset_id_1).await,
+            Some(mint_amount_1)
+        );
+        assert_eq!(
+            total_supply(&instance_1, asset_id_2).await,
+            Some(mint_amount_2)
+        );
         assert_eq!(total_assets(&instance_1).await, 2);
 
         let response = burn(&instance_2, asset_id_1, sub_id_1, burn_amount_1).await;
 
-        assert_eq!(get_wallet_balance(&other_wallet, &asset_id_1).await, mint_amount_1 - burn_amount_1);
-        assert_eq!(get_wallet_balance(&other_wallet, &asset_id_2).await, mint_amount_2);
-        assert_eq!(total_supply(&instance_1, asset_id_1).await, Some(mint_amount_1 - burn_amount_1));
-        assert_eq!(total_supply(&instance_1, asset_id_2).await, Some(mint_amount_2));
+        assert_eq!(
+            get_wallet_balance(&other_wallet, &asset_id_1).await,
+            mint_amount_1 - burn_amount_1
+        );
+        assert_eq!(
+            get_wallet_balance(&other_wallet, &asset_id_2).await,
+            mint_amount_2
+        );
+        assert_eq!(
+            total_supply(&instance_1, asset_id_1).await,
+            Some(mint_amount_1 - burn_amount_1)
+        );
+        assert_eq!(
+            total_supply(&instance_1, asset_id_2).await,
+            Some(mint_amount_2)
+        );
         assert_eq!(total_assets(&instance_1).await, 2);
         let log = response
             .decode_logs_with_type::<TotalSupplyEvent>()
@@ -157,10 +223,22 @@ mod success {
 
         let response = burn(&instance_2, asset_id_2, sub_id_2, burn_amount_2).await;
 
-        assert_eq!(get_wallet_balance(&other_wallet, &asset_id_1).await, mint_amount_1 - burn_amount_1);
-        assert_eq!(get_wallet_balance(&other_wallet, &asset_id_2).await, mint_amount_2 - burn_amount_2);
-        assert_eq!(total_supply(&instance_1, asset_id_1).await, Some(mint_amount_1 - burn_amount_1));
-        assert_eq!(total_supply(&instance_1, asset_id_2).await, Some(mint_amount_2 - burn_amount_2));
+        assert_eq!(
+            get_wallet_balance(&other_wallet, &asset_id_1).await,
+            mint_amount_1 - burn_amount_1
+        );
+        assert_eq!(
+            get_wallet_balance(&other_wallet, &asset_id_2).await,
+            mint_amount_2 - burn_amount_2
+        );
+        assert_eq!(
+            total_supply(&instance_1, asset_id_1).await,
+            Some(mint_amount_1 - burn_amount_1)
+        );
+        assert_eq!(
+            total_supply(&instance_1, asset_id_2).await,
+            Some(mint_amount_2 - burn_amount_2)
+        );
         assert_eq!(total_assets(&instance_1).await, 2);
         let log = response
             .decode_logs_with_type::<TotalSupplyEvent>()
@@ -188,8 +266,14 @@ mod success {
 
         mint(&instance_1, identity2, Some(sub_id_1), mint_amount_1).await;
 
-        assert_eq!(get_wallet_balance(&other_wallet, &asset_id_1).await, mint_amount_1);
-        assert_eq!(total_supply(&instance_1, asset_id_1).await, Some(mint_amount_1));
+        assert_eq!(
+            get_wallet_balance(&other_wallet, &asset_id_1).await,
+            mint_amount_1
+        );
+        assert_eq!(
+            total_supply(&instance_1, asset_id_1).await,
+            Some(mint_amount_1)
+        );
         assert_eq!(total_assets(&instance_1).await, 1);
 
         let response = burn(&instance_2, asset_id_1, sub_id_1, burn_amount_1).await;

--- a/tests/src/native_asset/tests/functions/decimals.rs
+++ b/tests/src/native_asset/tests/functions/decimals.rs
@@ -32,7 +32,7 @@ mod success {
         let decimals_4 = 16u8;
         let decimals_5 = 9u8;
         let asset_id_3 = get_asset_id(Bytes32::from([3u8; 32]), id);
-        let asset_id_4 = get_asset_id(Bytes32::from([4u8; 32]), id);        
+        let asset_id_4 = get_asset_id(Bytes32::from([4u8; 32]), id);
         let asset_id_5 = get_asset_id(Bytes32::from([5u8; 32]), id);
 
         assert_eq!(decimals(&instance_1, asset_id_1).await, None);
@@ -46,7 +46,7 @@ mod success {
         set_decimals(&instance_1, asset_id_3, decimals_3).await;
         set_decimals(&instance_1, asset_id_4, decimals_4).await;
         set_decimals(&instance_1, asset_id_5, decimals_5).await;
-        
+
         assert_eq!(decimals(&instance_1, asset_id_1).await, Some(decimals_1));
         assert_eq!(decimals(&instance_1, asset_id_2).await, Some(decimals_2));
         assert_eq!(decimals(&instance_1, asset_id_3).await, Some(decimals_3));

--- a/tests/src/native_asset/tests/functions/decimals.rs
+++ b/tests/src/native_asset/tests/functions/decimals.rs
@@ -13,11 +13,12 @@ mod success {
         let (owner_wallet, other_wallet, id, instance_1, _instance_2) = setup().await;
         let (asset_id_1, _asset_id_2, _sub_id_1, _sub_id_2, _identity1, _other_identity) =
             defaults(id, owner_wallet, other_wallet.clone());
+        let decimals_1 = 9u8;
 
         assert_eq!(decimals(&instance_1, asset_id_1).await, None);
 
-        set_decimals(&instance_1, asset_id_1, 9u8).await;
-        assert_eq!(decimals(&instance_1, asset_id_1).await, Some(9u8));
+        set_decimals(&instance_1, asset_id_1, decimals_1).await;
+        assert_eq!(decimals(&instance_1, asset_id_1).await, Some(decimals_1));
     }
 
     #[tokio::test]
@@ -25,28 +26,31 @@ mod success {
         let (owner_wallet, other_wallet, id, instance_1, _instance_2) = setup().await;
         let (asset_id_1, asset_id_2, _sub_id_1, _sub_id_2, _identity1, _other_identity) =
             defaults(id, owner_wallet, other_wallet.clone());
+        let decimals_1 = 9u8;
+        let decimals_2 = u8::MIN;
+        let decimals_3 = u8::MAX;
+        let decimals_4 = 16u8;
+        let decimals_5 = 9u8;
+        let asset_id_3 = get_asset_id(Bytes32::from([3u8; 32]), id);
+        let asset_id_4 = get_asset_id(Bytes32::from([4u8; 32]), id);        
+        let asset_id_5 = get_asset_id(Bytes32::from([5u8; 32]), id);
 
         assert_eq!(decimals(&instance_1, asset_id_1).await, None);
-        set_decimals(&instance_1, asset_id_1, 9u8).await;
-        assert_eq!(decimals(&instance_1, asset_id_1).await, Some(9u8));
-
         assert_eq!(decimals(&instance_1, asset_id_2).await, None);
-        set_decimals(&instance_1, asset_id_2, 8u8).await;
-        assert_eq!(decimals(&instance_1, asset_id_2).await, Some(8u8));
-
-        let asset_id_3 = get_asset_id(Bytes32::from([3u8; 32]), id);
         assert_eq!(decimals(&instance_1, asset_id_3).await, None);
-        set_decimals(&instance_1, asset_id_3, 7u8).await;
-        assert_eq!(decimals(&instance_1, asset_id_3).await, Some(7u8));
-
-        let asset_id_4 = get_asset_id(Bytes32::from([4u8; 32]), id);
         assert_eq!(decimals(&instance_1, asset_id_4).await, None);
-        set_decimals(&instance_1, asset_id_4, 6u8).await;
-        assert_eq!(decimals(&instance_1, asset_id_4).await, Some(6u8));
-
-        let asset_id_5 = get_asset_id(Bytes32::from([5u8; 32]), id);
         assert_eq!(decimals(&instance_1, asset_id_5).await, None);
-        set_decimals(&instance_1, asset_id_5, 5u8).await;
-        assert_eq!(decimals(&instance_1, asset_id_5).await, Some(5u8));
+
+        set_decimals(&instance_1, asset_id_1, decimals_1).await;
+        set_decimals(&instance_1, asset_id_2, decimals_2).await;
+        set_decimals(&instance_1, asset_id_3, decimals_3).await;
+        set_decimals(&instance_1, asset_id_4, decimals_4).await;
+        set_decimals(&instance_1, asset_id_5, decimals_5).await;
+        
+        assert_eq!(decimals(&instance_1, asset_id_1).await, Some(decimals_1));
+        assert_eq!(decimals(&instance_1, asset_id_2).await, Some(decimals_2));
+        assert_eq!(decimals(&instance_1, asset_id_3).await, Some(decimals_3));
+        assert_eq!(decimals(&instance_1, asset_id_4).await, Some(decimals_4));
+        assert_eq!(decimals(&instance_1, asset_id_5).await, Some(decimals_5));
     }
 }

--- a/tests/src/native_asset/tests/functions/metadata.rs
+++ b/tests/src/native_asset/tests/functions/metadata.rs
@@ -2,11 +2,21 @@ use crate::native_asset::tests::utils::{
     interface::{metadata, set_metadata},
     setup::{defaults, get_asset_id, setup, Metadata},
 };
-use fuels::types::{Bytes, Bytes32};
+use fuels::types::{Bits256, Bytes, Bytes32};
 
 mod success {
 
     use super::*;
+
+    #[tokio::test]
+    async fn gets_none_set() {
+        let (owner_wallet, other_wallet, id, instance_1, _instance_2) = setup().await;
+        let (asset_id_1, _asset_id_2, _sub_id_1, _sub_id_2, _identity1, _other_identity) =
+            defaults(id, owner_wallet, other_wallet.clone());
+        let key = String::from("key1");
+
+        assert_eq!(metadata(&instance_1, asset_id_1, key.clone()).await, None);
+    }
 
     #[tokio::test]
     async fn gets_one_asset() {
@@ -18,7 +28,7 @@ mod success {
 
         assert_eq!(metadata(&instance_1, asset_id_1, key.clone()).await, None);
 
-        set_metadata(&instance_1, asset_id_1, key.clone(), metadata1.clone()).await;
+        set_metadata(&instance_1, asset_id_1, key.clone(), Some(metadata1.clone())).await;
         assert_eq!(
             metadata(&instance_1, asset_id_1, key).await,
             Some(metadata1)
@@ -33,25 +43,25 @@ mod success {
         let metadata1 = Metadata::String(String::from("Fuel NFT Metadata 1"));
         let metadata2 = Metadata::String(String::from("Fuel NFT Metadata 2"));
         let metadata3 = Metadata::String(String::from("Fuel NFT Metadata 3"));
+        let asset_id_3 = get_asset_id(Bytes32::from([3u8; 32]), id);
         let key = String::from("key1");
 
         assert_eq!(metadata(&instance_1, asset_id_1, key.clone()).await, None);
-        set_metadata(&instance_1, asset_id_1, key.clone(), metadata1.clone()).await;
+        assert_eq!(metadata(&instance_1, asset_id_2, key.clone()).await, None);
+        assert_eq!(metadata(&instance_1, asset_id_3, key.clone()).await, None);
+        
+        set_metadata(&instance_1, asset_id_1, key.clone(), Some(metadata1.clone())).await;
+        set_metadata(&instance_1, asset_id_2, key.clone(), Some(metadata2.clone())).await;
+        set_metadata(&instance_1, asset_id_3, key.clone(), Some(metadata3.clone())).await;
+
         assert_eq!(
             metadata(&instance_1, asset_id_1, key.clone()).await,
             Some(metadata1)
         );
-
-        assert_eq!(metadata(&instance_1, asset_id_2, key.clone()).await, None);
-        set_metadata(&instance_1, asset_id_2, key.clone(), metadata2.clone()).await;
         assert_eq!(
             metadata(&instance_1, asset_id_2, key.clone()).await,
             Some(metadata2)
         );
-
-        let asset_id_3 = get_asset_id(Bytes32::from([3u8; 32]), id);
-        assert_eq!(metadata(&instance_1, asset_id_3, key.clone()).await, None);
-        set_metadata(&instance_1, asset_id_3, key.clone(), metadata3.clone()).await;
         assert_eq!(
             metadata(&instance_1, asset_id_3, key).await,
             Some(metadata3)
@@ -69,41 +79,37 @@ mod success {
             Bytes::from_hex_str("0101010101010101010101010101010101010101010101010101010101010101")
                 .expect("failed to convert to bytes"),
         );
+        let metadata4 = Metadata::B256(Bits256([1u8; 32]));
         let key1 = String::from("key1");
         let key2 = String::from("key2");
         let key3 = String::from("key3");
+        let key4 = String::from("key4");
 
         assert_eq!(metadata(&instance_1, asset_id_1, key1.clone()).await, None);
-        set_metadata(&instance_1, asset_id_1, key1.clone(), metadata1.clone()).await;
-        assert_eq!(
-            metadata(&instance_1, asset_id_1, key1.clone()).await,
-            Some(metadata1.clone())
-        );
-
         assert_eq!(metadata(&instance_1, asset_id_1, key2.clone()).await, None);
-        set_metadata(&instance_1, asset_id_1, key2.clone(), metadata2.clone()).await;
-        assert_eq!(
-            metadata(&instance_1, asset_id_1, key2.clone()).await,
-            Some(metadata2.clone())
-        );
+        assert_eq!(metadata(&instance_1, asset_id_1, key3.clone()).await, None);
+        assert_eq!(metadata(&instance_1, asset_id_1, key4.clone()).await, None);
+
+        set_metadata(&instance_1, asset_id_1, key1.clone(), Some(metadata1.clone())).await;
+        set_metadata(&instance_1, asset_id_1, key2.clone(), Some(metadata2.clone())).await;
+        set_metadata(&instance_1, asset_id_1, key3.clone(), Some(metadata3.clone())).await;
+        set_metadata(&instance_1, asset_id_1, key4.clone(), Some(metadata4.clone())).await;
+
         assert_eq!(
             metadata(&instance_1, asset_id_1, key1.clone()).await,
-            Some(metadata1.clone())
-        );
-
-        assert_eq!(metadata(&instance_1, asset_id_1, key3.clone()).await, None);
-        set_metadata(&instance_1, asset_id_1, key3.clone(), metadata3.clone()).await;
-        assert_eq!(
-            metadata(&instance_1, asset_id_1, key3).await,
-            Some(metadata3)
+            Some(metadata1)
         );
         assert_eq!(
             metadata(&instance_1, asset_id_1, key2.clone()).await,
             Some(metadata2)
         );
         assert_eq!(
-            metadata(&instance_1, asset_id_1, key1.clone()).await,
-            Some(metadata1)
+            metadata(&instance_1, asset_id_1, key3).await,
+            Some(metadata3)
+        );
+        assert_eq!(
+            metadata(&instance_1, asset_id_1, key4).await,
+            Some(metadata4)
         );
     }
 }

--- a/tests/src/native_asset/tests/functions/metadata.rs
+++ b/tests/src/native_asset/tests/functions/metadata.rs
@@ -28,7 +28,13 @@ mod success {
 
         assert_eq!(metadata(&instance_1, asset_id_1, key.clone()).await, None);
 
-        set_metadata(&instance_1, asset_id_1, key.clone(), Some(metadata1.clone())).await;
+        set_metadata(
+            &instance_1,
+            asset_id_1,
+            key.clone(),
+            Some(metadata1.clone()),
+        )
+        .await;
         assert_eq!(
             metadata(&instance_1, asset_id_1, key).await,
             Some(metadata1)
@@ -49,10 +55,28 @@ mod success {
         assert_eq!(metadata(&instance_1, asset_id_1, key.clone()).await, None);
         assert_eq!(metadata(&instance_1, asset_id_2, key.clone()).await, None);
         assert_eq!(metadata(&instance_1, asset_id_3, key.clone()).await, None);
-        
-        set_metadata(&instance_1, asset_id_1, key.clone(), Some(metadata1.clone())).await;
-        set_metadata(&instance_1, asset_id_2, key.clone(), Some(metadata2.clone())).await;
-        set_metadata(&instance_1, asset_id_3, key.clone(), Some(metadata3.clone())).await;
+
+        set_metadata(
+            &instance_1,
+            asset_id_1,
+            key.clone(),
+            Some(metadata1.clone()),
+        )
+        .await;
+        set_metadata(
+            &instance_1,
+            asset_id_2,
+            key.clone(),
+            Some(metadata2.clone()),
+        )
+        .await;
+        set_metadata(
+            &instance_1,
+            asset_id_3,
+            key.clone(),
+            Some(metadata3.clone()),
+        )
+        .await;
 
         assert_eq!(
             metadata(&instance_1, asset_id_1, key.clone()).await,
@@ -90,10 +114,34 @@ mod success {
         assert_eq!(metadata(&instance_1, asset_id_1, key3.clone()).await, None);
         assert_eq!(metadata(&instance_1, asset_id_1, key4.clone()).await, None);
 
-        set_metadata(&instance_1, asset_id_1, key1.clone(), Some(metadata1.clone())).await;
-        set_metadata(&instance_1, asset_id_1, key2.clone(), Some(metadata2.clone())).await;
-        set_metadata(&instance_1, asset_id_1, key3.clone(), Some(metadata3.clone())).await;
-        set_metadata(&instance_1, asset_id_1, key4.clone(), Some(metadata4.clone())).await;
+        set_metadata(
+            &instance_1,
+            asset_id_1,
+            key1.clone(),
+            Some(metadata1.clone()),
+        )
+        .await;
+        set_metadata(
+            &instance_1,
+            asset_id_1,
+            key2.clone(),
+            Some(metadata2.clone()),
+        )
+        .await;
+        set_metadata(
+            &instance_1,
+            asset_id_1,
+            key3.clone(),
+            Some(metadata3.clone()),
+        )
+        .await;
+        set_metadata(
+            &instance_1,
+            asset_id_1,
+            key4.clone(),
+            Some(metadata4.clone()),
+        )
+        .await;
 
         assert_eq!(
             metadata(&instance_1, asset_id_1, key1.clone()).await,

--- a/tests/src/native_asset/tests/functions/mint.rs
+++ b/tests/src/native_asset/tests/functions/mint.rs
@@ -1,7 +1,8 @@
 use crate::native_asset::tests::utils::{
     interface::{mint, total_assets, total_supply},
-    setup::{defaults, get_wallet_balance, setup},
+    setup::{defaults, get_asset_id, get_wallet_balance, setup, TotalSupplyEvent},
 };
+use fuels::types::{Bytes32, Identity};
 
 mod success {
 
@@ -11,39 +12,199 @@ mod success {
     async fn mints_assets() {
         let (owner_wallet, other_wallet, id, instance_1, _instance_2) = setup().await;
         let (asset_id_1, _asset_id_2, sub_id_1, _sub_id_2, _identity1, identity2) =
-            defaults(id, owner_wallet, other_wallet.clone());
+            defaults(id, owner_wallet.clone(), other_wallet.clone());
+        let mint_amount = 100;
 
         assert_eq!(get_wallet_balance(&other_wallet, &asset_id_1).await, 0);
         assert_eq!(total_supply(&instance_1, asset_id_1).await, None);
         assert_eq!(total_assets(&instance_1).await, 0);
 
-        mint(&instance_1, identity2, sub_id_1, 100).await;
+        let response = mint(&instance_1, identity2, Some(sub_id_1), mint_amount).await;
 
-        assert_eq!(get_wallet_balance(&other_wallet, &asset_id_1).await, 100);
-        assert_eq!(total_supply(&instance_1, asset_id_1).await, Some(100));
+        assert_eq!(get_wallet_balance(&other_wallet, &asset_id_1).await, mint_amount);
+        assert_eq!(total_supply(&instance_1, asset_id_1).await, Some(mint_amount));
         assert_eq!(total_assets(&instance_1).await, 1);
+        let log = response
+            .decode_logs_with_type::<TotalSupplyEvent>()
+            .unwrap();
+        let event = log.first().unwrap();
+        assert_eq!(
+            *event,
+            TotalSupplyEvent {
+                asset: asset_id_1,
+                supply: mint_amount,
+                sender: Identity::Address(owner_wallet.address().into()),
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn mints_twice() {
+        let (owner_wallet, other_wallet, id, instance_1, _instance_2) = setup().await;
+        let (asset_id_1, _asset_id_2, sub_id_1, _sub_id_2, _identity1, identity2) =
+            defaults(id, owner_wallet.clone(), other_wallet.clone());
+        let mint_amount_1 = 100;
+        let mint_amount_2 = 200;
+
+        let response = mint(&instance_1, identity2, Some(sub_id_1), mint_amount_1).await;
+
+        assert_eq!(get_wallet_balance(&other_wallet, &asset_id_1).await, mint_amount_1);
+        assert_eq!(total_supply(&instance_1, asset_id_1).await, Some(mint_amount_1));
+        assert_eq!(total_assets(&instance_1).await, 1);
+        let log = response
+            .decode_logs_with_type::<TotalSupplyEvent>()
+            .unwrap();
+        let event = log.first().unwrap();
+        assert_eq!(
+            *event,
+            TotalSupplyEvent {
+                asset: asset_id_1,
+                supply: mint_amount_1,
+                sender: Identity::Address(owner_wallet.address().into()),
+            }
+        );
+
+        let response = mint(&instance_1, identity2, Some(sub_id_1), mint_amount_2).await;
+        assert_eq!(get_wallet_balance(&other_wallet, &asset_id_1).await, mint_amount_1 + mint_amount_2);
+        assert_eq!(total_supply(&instance_1, asset_id_1).await, Some(mint_amount_1 + mint_amount_2));
+        assert_eq!(total_assets(&instance_1).await, 1);
+        let log = response
+            .decode_logs_with_type::<TotalSupplyEvent>()
+            .unwrap();
+        let event = log.first().unwrap();
+        assert_eq!(
+            *event,
+            TotalSupplyEvent {
+                asset: asset_id_1,
+                supply: mint_amount_1 + mint_amount_2,
+                sender: Identity::Address(owner_wallet.address().into()),
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn mints_max() {
+        let (owner_wallet, other_wallet, id, instance_1, _instance_2) = setup().await;
+        let (asset_id_1, _asset_id_2, sub_id_1, _sub_id_2, _identity1, identity2) =
+            defaults(id, owner_wallet.clone(), other_wallet.clone());
+        let mint_amount = u64::MAX;
+
+        assert_eq!(get_wallet_balance(&other_wallet, &asset_id_1).await, 0);
+        assert_eq!(total_supply(&instance_1, asset_id_1).await, None);
+        assert_eq!(total_assets(&instance_1).await, 0);
+
+        let response = mint(&instance_1, identity2, Some(sub_id_1), mint_amount).await;
+
+        assert_eq!(get_wallet_balance(&other_wallet, &asset_id_1).await, mint_amount);
+        assert_eq!(total_supply(&instance_1, asset_id_1).await, Some(mint_amount));
+        assert_eq!(total_assets(&instance_1).await, 1);
+        let log = response
+            .decode_logs_with_type::<TotalSupplyEvent>()
+            .unwrap();
+        let event = log.first().unwrap();
+        assert_eq!(
+            *event,
+            TotalSupplyEvent {
+                asset: asset_id_1,
+                supply: mint_amount,
+                sender: Identity::Address(owner_wallet.address().into()),
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn mints_sub_id_none_assets() {
+        let (owner_wallet, other_wallet, id, instance_1, _instance_2) = setup().await;
+        let (_asset_id_1, _asset_id_2, _sub_id_1, _sub_id_2, _identity1, identity2) =
+            defaults(id, owner_wallet.clone(), other_wallet.clone());
+        let mint_amount = 100;
+        let asset_id = get_asset_id(Bytes32::zeroed(), id);
+
+        assert_eq!(get_wallet_balance(&other_wallet, &asset_id).await, 0);
+        assert_eq!(total_supply(&instance_1, asset_id).await, None);
+        assert_eq!(total_assets(&instance_1).await, 0);
+
+        let response = mint(&instance_1, identity2, None, mint_amount).await;
+
+        assert_eq!(get_wallet_balance(&other_wallet, &asset_id).await, mint_amount);
+        assert_eq!(total_supply(&instance_1, asset_id).await, Some(mint_amount));
+        assert_eq!(total_assets(&instance_1).await, 1);
+        let log = response
+            .decode_logs_with_type::<TotalSupplyEvent>()
+            .unwrap();
+        let event = log.first().unwrap();
+        assert_eq!(
+            *event,
+            TotalSupplyEvent {
+                asset: asset_id,
+                supply: mint_amount,
+                sender: Identity::Address(owner_wallet.address().into()),
+            }
+        );
     }
 
     #[tokio::test]
     async fn mints_multiple_assets() {
         let (owner_wallet, other_wallet, id, instance_1, _instance_2) = setup().await;
         let (asset_id_1, asset_id_2, sub_id_1, sub_id_2, _identity1, identity2) =
-            defaults(id, owner_wallet, other_wallet.clone());
+            defaults(id, owner_wallet.clone(), other_wallet.clone());
+        let mint_amount_1 = 100;
+        let mint_amount_2 = 200;
 
-        mint(&instance_1, identity2.clone(), sub_id_1, 100).await;
+        let response = mint(&instance_1, identity2.clone(), Some(sub_id_1), mint_amount_1).await;
 
-        assert_eq!(get_wallet_balance(&other_wallet, &asset_id_1).await, 100);
+        assert_eq!(get_wallet_balance(&other_wallet, &asset_id_1).await, mint_amount_1);
         assert_eq!(get_wallet_balance(&other_wallet, &asset_id_2).await, 0);
-        assert_eq!(total_supply(&instance_1, asset_id_1).await, Some(100));
+        assert_eq!(total_supply(&instance_1, asset_id_1).await, Some(mint_amount_1));
         assert_eq!(total_supply(&instance_1, asset_id_2).await, None);
         assert_eq!(total_assets(&instance_1).await, 1);
+        let log = response
+            .decode_logs_with_type::<TotalSupplyEvent>()
+            .unwrap();
+        let event = log.first().unwrap();
+        assert_eq!(
+            *event,
+            TotalSupplyEvent {
+                asset: asset_id_1,
+                supply: mint_amount_1,
+                sender: Identity::Address(owner_wallet.address().into()),
+            }
+        );
 
-        mint(&instance_1, identity2, sub_id_2, 200).await;
+        let response = mint(&instance_1, identity2, Some(sub_id_2), mint_amount_2).await;
 
-        assert_eq!(get_wallet_balance(&other_wallet, &asset_id_1).await, 100);
-        assert_eq!(get_wallet_balance(&other_wallet, &asset_id_2).await, 200);
-        assert_eq!(total_supply(&instance_1, asset_id_1).await, Some(100));
-        assert_eq!(total_supply(&instance_1, asset_id_2).await, Some(200));
+        assert_eq!(get_wallet_balance(&other_wallet, &asset_id_1).await, mint_amount_1);
+        assert_eq!(get_wallet_balance(&other_wallet, &asset_id_2).await, mint_amount_2);
+        assert_eq!(total_supply(&instance_1, asset_id_1).await, Some(mint_amount_1));
+        assert_eq!(total_supply(&instance_1, asset_id_2).await, Some(mint_amount_2));
         assert_eq!(total_assets(&instance_1).await, 2);
+        let log = response
+            .decode_logs_with_type::<TotalSupplyEvent>()
+            .unwrap();
+        let event = log.first().unwrap();
+        assert_eq!(
+            *event,
+            TotalSupplyEvent {
+                asset: asset_id_2,
+                supply: mint_amount_2,
+                sender: Identity::Address(owner_wallet.address().into()),
+            }
+        );
+    }
+}
+
+mod revert {
+
+    use super::*;
+
+    #[tokio::test]
+    #[should_panic(expected = "ZeroAmount")]
+    async fn mints_zero() {
+        let (owner_wallet, other_wallet, id, instance_1, _instance_2) = setup().await;
+        let (_asset_id_1, _asset_id_2, sub_id_1, _sub_id_2, _identity1, identity2) =
+            defaults(id, owner_wallet, other_wallet);
+        let mint_amount = 0;
+
+        mint(&instance_1, identity2, Some(sub_id_1), mint_amount).await;
     }
 }

--- a/tests/src/native_asset/tests/functions/mint.rs
+++ b/tests/src/native_asset/tests/functions/mint.rs
@@ -21,8 +21,14 @@ mod success {
 
         let response = mint(&instance_1, identity2, Some(sub_id_1), mint_amount).await;
 
-        assert_eq!(get_wallet_balance(&other_wallet, &asset_id_1).await, mint_amount);
-        assert_eq!(total_supply(&instance_1, asset_id_1).await, Some(mint_amount));
+        assert_eq!(
+            get_wallet_balance(&other_wallet, &asset_id_1).await,
+            mint_amount
+        );
+        assert_eq!(
+            total_supply(&instance_1, asset_id_1).await,
+            Some(mint_amount)
+        );
         assert_eq!(total_assets(&instance_1).await, 1);
         let log = response
             .decode_logs_with_type::<TotalSupplyEvent>()
@@ -48,8 +54,14 @@ mod success {
 
         let response = mint(&instance_1, identity2, Some(sub_id_1), mint_amount_1).await;
 
-        assert_eq!(get_wallet_balance(&other_wallet, &asset_id_1).await, mint_amount_1);
-        assert_eq!(total_supply(&instance_1, asset_id_1).await, Some(mint_amount_1));
+        assert_eq!(
+            get_wallet_balance(&other_wallet, &asset_id_1).await,
+            mint_amount_1
+        );
+        assert_eq!(
+            total_supply(&instance_1, asset_id_1).await,
+            Some(mint_amount_1)
+        );
         assert_eq!(total_assets(&instance_1).await, 1);
         let log = response
             .decode_logs_with_type::<TotalSupplyEvent>()
@@ -65,8 +77,14 @@ mod success {
         );
 
         let response = mint(&instance_1, identity2, Some(sub_id_1), mint_amount_2).await;
-        assert_eq!(get_wallet_balance(&other_wallet, &asset_id_1).await, mint_amount_1 + mint_amount_2);
-        assert_eq!(total_supply(&instance_1, asset_id_1).await, Some(mint_amount_1 + mint_amount_2));
+        assert_eq!(
+            get_wallet_balance(&other_wallet, &asset_id_1).await,
+            mint_amount_1 + mint_amount_2
+        );
+        assert_eq!(
+            total_supply(&instance_1, asset_id_1).await,
+            Some(mint_amount_1 + mint_amount_2)
+        );
         assert_eq!(total_assets(&instance_1).await, 1);
         let log = response
             .decode_logs_with_type::<TotalSupplyEvent>()
@@ -95,8 +113,14 @@ mod success {
 
         let response = mint(&instance_1, identity2, Some(sub_id_1), mint_amount).await;
 
-        assert_eq!(get_wallet_balance(&other_wallet, &asset_id_1).await, mint_amount);
-        assert_eq!(total_supply(&instance_1, asset_id_1).await, Some(mint_amount));
+        assert_eq!(
+            get_wallet_balance(&other_wallet, &asset_id_1).await,
+            mint_amount
+        );
+        assert_eq!(
+            total_supply(&instance_1, asset_id_1).await,
+            Some(mint_amount)
+        );
         assert_eq!(total_assets(&instance_1).await, 1);
         let log = response
             .decode_logs_with_type::<TotalSupplyEvent>()
@@ -126,7 +150,10 @@ mod success {
 
         let response = mint(&instance_1, identity2, None, mint_amount).await;
 
-        assert_eq!(get_wallet_balance(&other_wallet, &asset_id).await, mint_amount);
+        assert_eq!(
+            get_wallet_balance(&other_wallet, &asset_id).await,
+            mint_amount
+        );
         assert_eq!(total_supply(&instance_1, asset_id).await, Some(mint_amount));
         assert_eq!(total_assets(&instance_1).await, 1);
         let log = response
@@ -151,11 +178,23 @@ mod success {
         let mint_amount_1 = 100;
         let mint_amount_2 = 200;
 
-        let response = mint(&instance_1, identity2.clone(), Some(sub_id_1), mint_amount_1).await;
+        let response = mint(
+            &instance_1,
+            identity2.clone(),
+            Some(sub_id_1),
+            mint_amount_1,
+        )
+        .await;
 
-        assert_eq!(get_wallet_balance(&other_wallet, &asset_id_1).await, mint_amount_1);
+        assert_eq!(
+            get_wallet_balance(&other_wallet, &asset_id_1).await,
+            mint_amount_1
+        );
         assert_eq!(get_wallet_balance(&other_wallet, &asset_id_2).await, 0);
-        assert_eq!(total_supply(&instance_1, asset_id_1).await, Some(mint_amount_1));
+        assert_eq!(
+            total_supply(&instance_1, asset_id_1).await,
+            Some(mint_amount_1)
+        );
         assert_eq!(total_supply(&instance_1, asset_id_2).await, None);
         assert_eq!(total_assets(&instance_1).await, 1);
         let log = response
@@ -173,10 +212,22 @@ mod success {
 
         let response = mint(&instance_1, identity2, Some(sub_id_2), mint_amount_2).await;
 
-        assert_eq!(get_wallet_balance(&other_wallet, &asset_id_1).await, mint_amount_1);
-        assert_eq!(get_wallet_balance(&other_wallet, &asset_id_2).await, mint_amount_2);
-        assert_eq!(total_supply(&instance_1, asset_id_1).await, Some(mint_amount_1));
-        assert_eq!(total_supply(&instance_1, asset_id_2).await, Some(mint_amount_2));
+        assert_eq!(
+            get_wallet_balance(&other_wallet, &asset_id_1).await,
+            mint_amount_1
+        );
+        assert_eq!(
+            get_wallet_balance(&other_wallet, &asset_id_2).await,
+            mint_amount_2
+        );
+        assert_eq!(
+            total_supply(&instance_1, asset_id_1).await,
+            Some(mint_amount_1)
+        );
+        assert_eq!(
+            total_supply(&instance_1, asset_id_2).await,
+            Some(mint_amount_2)
+        );
         assert_eq!(total_assets(&instance_1).await, 2);
         let log = response
             .decode_logs_with_type::<TotalSupplyEvent>()

--- a/tests/src/native_asset/tests/functions/name.rs
+++ b/tests/src/native_asset/tests/functions/name.rs
@@ -9,88 +9,76 @@ mod success {
     use super::*;
 
     #[tokio::test]
-    async fn one_asset() {
+    async fn get_none_asset_name() {
         let (owner_wallet, other_wallet, id, instance_1, _instance_2) = setup().await;
         let (asset_id_1, _asset_id_2, _sub_id_1, _sub_id_2, _identity1, _other_identity) =
-            defaults(id, owner_wallet, other_wallet.clone());
+            defaults(id, owner_wallet.clone(), other_wallet.clone());
+
+        assert_eq!(name(&instance_1, asset_id_1).await, None);
+    }
+
+    #[tokio::test]
+    async fn get_one_asset_name() {
+        let (owner_wallet, other_wallet, id, instance_1, _instance_2) = setup().await;
+        let (asset_id_1, _asset_id_2, _sub_id_1, _sub_id_2, _identity1, _other_identity) =
+            defaults(id, owner_wallet.clone(), other_wallet.clone());
+        let name_1 = String::from("Fuel Asset 1");
 
         assert_eq!(name(&instance_1, asset_id_1).await, None);
 
-        set_name(&instance_1, asset_id_1, String::from("Fuel Asset 1")).await;
+        set_name(&instance_1, asset_id_1, Some(name_1.clone())).await;
         assert_eq!(
             name(&instance_1, asset_id_1).await,
-            Some(String::from("Fuel Asset 1"))
+            Some(name_1)
         );
     }
 
     #[tokio::test]
-    async fn multiple_assets() {
+    async fn get_multiple_assets_name() {
         let (owner_wallet, other_wallet, id, instance_1, _instance_2) = setup().await;
         let (asset_id_1, asset_id_2, _sub_id_1, _sub_id_2, _identity1, _other_identity) =
-            defaults(id, owner_wallet, other_wallet.clone());
+            defaults(id, owner_wallet.clone(), other_wallet.clone());
+        let name_1 = String::from("Fuel Asset 1");
+        let name_2 = String::from("Fuel Asset 2");
+        let name_3 = String::from("Fuel Asset 3 Fuel Asset 3 Fuel Asset 3 Fuel Asset 3 Fuel Asset 3 Fuel Asset 3 Fuel Asset 3 Fuel Asset 3 Fuel Asset 3 Fuel Asset 3 Fuel Asset 3 Fuel Asset 3 Fuel Asset 3 Fuel Asset 3 Fuel Asset 3");
+        let name_4 = String::from("4");
+        let name_5 = String::from("Fuel Asset 1");
+        let asset_id_3 = get_asset_id(Bytes32::from([3u8; 32]), id);
+        let asset_id_4 = get_asset_id(Bytes32::from([4u8; 32]), id);
+        let asset_id_5 = get_asset_id(Bytes32::from([5u8; 32]), id);
+
 
         assert_eq!(name(&instance_1, asset_id_1).await, None);
-        set_name(&instance_1, asset_id_1, String::from("Fuel Asset 1")).await;
+        assert_eq!(name(&instance_1, asset_id_2).await, None);
+        assert_eq!(name(&instance_1, asset_id_3).await, None);
+        assert_eq!(name(&instance_1, asset_id_4).await, None);
+        assert_eq!(name(&instance_1, asset_id_5).await, None);
+
+        set_name(&instance_1, asset_id_1, Some(name_1.clone())).await;
+        set_name(&instance_1, asset_id_2, Some(name_2.clone())).await;
+        set_name(&instance_1, asset_id_3, Some(name_3.clone())).await;
+        set_name(&instance_1, asset_id_4, Some(name_4.clone())).await;
+        set_name(&instance_1, asset_id_5, Some(name_5.clone())).await;
+
         assert_eq!(
             name(&instance_1, asset_id_1).await,
-            Some(String::from("Fuel Asset 1"))
+            Some(name_1)
         );
-
-        assert_eq!(name(&instance_1, asset_id_2).await, None);
-        set_name(&instance_1, asset_id_2, String::from("Fuel Asset 2")).await;
         assert_eq!(
             name(&instance_1, asset_id_2).await,
-            Some(String::from("Fuel Asset 2"))
+            Some(name_2)
         );
-
-        let asset_id_3 = get_asset_id(Bytes32::from([3u8; 32]), id);
-        assert_eq!(name(&instance_1, asset_id_3).await, None);
-        set_name(&instance_1, asset_id_3, String::from("Fuel Asset 3")).await;
         assert_eq!(
             name(&instance_1, asset_id_3).await,
-            Some(String::from("Fuel Asset 3"))
+            Some(name_3)
         );
-
-        let asset_id_4 = get_asset_id(Bytes32::from([4u8; 32]), id);
-        assert_eq!(name(&instance_1, asset_id_4).await, None);
-        set_name(&instance_1, asset_id_4, String::from("Fuel Asset 4")).await;
         assert_eq!(
             name(&instance_1, asset_id_4).await,
-            Some(String::from("Fuel Asset 4"))
+            Some(name_4)
         );
-
-        let asset_id_5 = get_asset_id(Bytes32::from([5u8; 32]), id);
-        assert_eq!(name(&instance_1, asset_id_5).await, None);
-        set_name(&instance_1, asset_id_5, String::from("Fuel Asset 5")).await;
         assert_eq!(
             name(&instance_1, asset_id_5).await,
-            Some(String::from("Fuel Asset 5"))
-        );
-    }
-
-    #[tokio::test]
-    async fn does_not_overwrite_other_names() {
-        let (owner_wallet, other_wallet, id, instance_1, _instance_2) = setup().await;
-        let (asset_id_1, asset_id_2, _sub_id_1, _sub_id_2, _identity1, _other_identity) =
-            defaults(id, owner_wallet, other_wallet.clone());
-
-        assert_eq!(name(&instance_1, asset_id_1).await, None);
-        set_name(&instance_1, asset_id_1, String::from("Fuel Asset 1")).await;
-        assert_eq!(
-            name(&instance_1, asset_id_1).await,
-            Some(String::from("Fuel Asset 1"))
-        );
-
-        assert_eq!(name(&instance_1, asset_id_2).await, None);
-        set_name(&instance_1, asset_id_2, String::from("Fuel Asset 2")).await;
-
-        assert_eq!(
-            name(&instance_1, asset_id_1).await,
-            Some(String::from("Fuel Asset 1"))
-        );
-        assert_eq!(
-            name(&instance_1, asset_id_2).await,
-            Some(String::from("Fuel Asset 2"))
+            Some(name_5)
         );
     }
 }

--- a/tests/src/native_asset/tests/functions/name.rs
+++ b/tests/src/native_asset/tests/functions/name.rs
@@ -27,10 +27,7 @@ mod success {
         assert_eq!(name(&instance_1, asset_id_1).await, None);
 
         set_name(&instance_1, asset_id_1, Some(name_1.clone())).await;
-        assert_eq!(
-            name(&instance_1, asset_id_1).await,
-            Some(name_1)
-        );
+        assert_eq!(name(&instance_1, asset_id_1).await, Some(name_1));
     }
 
     #[tokio::test]
@@ -47,7 +44,6 @@ mod success {
         let asset_id_4 = get_asset_id(Bytes32::from([4u8; 32]), id);
         let asset_id_5 = get_asset_id(Bytes32::from([5u8; 32]), id);
 
-
         assert_eq!(name(&instance_1, asset_id_1).await, None);
         assert_eq!(name(&instance_1, asset_id_2).await, None);
         assert_eq!(name(&instance_1, asset_id_3).await, None);
@@ -60,25 +56,10 @@ mod success {
         set_name(&instance_1, asset_id_4, Some(name_4.clone())).await;
         set_name(&instance_1, asset_id_5, Some(name_5.clone())).await;
 
-        assert_eq!(
-            name(&instance_1, asset_id_1).await,
-            Some(name_1)
-        );
-        assert_eq!(
-            name(&instance_1, asset_id_2).await,
-            Some(name_2)
-        );
-        assert_eq!(
-            name(&instance_1, asset_id_3).await,
-            Some(name_3)
-        );
-        assert_eq!(
-            name(&instance_1, asset_id_4).await,
-            Some(name_4)
-        );
-        assert_eq!(
-            name(&instance_1, asset_id_5).await,
-            Some(name_5)
-        );
+        assert_eq!(name(&instance_1, asset_id_1).await, Some(name_1));
+        assert_eq!(name(&instance_1, asset_id_2).await, Some(name_2));
+        assert_eq!(name(&instance_1, asset_id_3).await, Some(name_3));
+        assert_eq!(name(&instance_1, asset_id_4).await, Some(name_4));
+        assert_eq!(name(&instance_1, asset_id_5).await, Some(name_5));
     }
 }

--- a/tests/src/native_asset/tests/functions/set_decimals.rs
+++ b/tests/src/native_asset/tests/functions/set_decimals.rs
@@ -1,8 +1,8 @@
 use crate::native_asset::tests::utils::{
     interface::{decimals, set_decimals},
-    setup::{defaults, get_asset_id, setup},
+    setup::{defaults, get_asset_id, setup, SetDecimalsEvent},
 };
-use fuels::types::Bytes32;
+use fuels::types::{Bytes32, Identity};
 
 mod success {
 
@@ -12,58 +12,201 @@ mod success {
     async fn sets_one_asset() {
         let (owner_wallet, other_wallet, id, instance_1, _instance_2) = setup().await;
         let (asset_id_1, _asset_id_2, _sub_id_1, _sub_id_2, _identity1, _other_identity) =
-            defaults(id, owner_wallet, other_wallet.clone());
+            defaults(id, owner_wallet.clone(), other_wallet.clone());
+        let decimals_1 = 9u8;
 
         assert_eq!(decimals(&instance_1, asset_id_1).await, None);
 
-        set_decimals(&instance_1, asset_id_1, 9u8).await;
-        assert_eq!(decimals(&instance_1, asset_id_1).await, Some(9u8));
+        let response = set_decimals(&instance_1, asset_id_1, decimals_1).await;
+        assert_eq!(decimals(&instance_1, asset_id_1).await, Some(decimals_1));
+        let log = response
+            .decode_logs_with_type::<SetDecimalsEvent>()
+            .unwrap();
+        let event = log.first().unwrap();
+        assert_eq!(
+            *event,
+            SetDecimalsEvent {
+                asset: asset_id_1,
+                decimals: decimals_1,
+                sender: Identity::Address(owner_wallet.address().into()),
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn sets_decimals_twice() {
+        let (owner_wallet, other_wallet, id, instance_1, _instance_2) = setup().await;
+        let (asset_id_1, _asset_id_2, _sub_id_1, _sub_id_2, _identity1, _other_identity) =
+            defaults(id, owner_wallet.clone(), other_wallet.clone());
+        let decimals_1 = 9u8;
+        let decimals_2 = 8u8;
+
+        let response = set_decimals(&instance_1, asset_id_1, decimals_1).await;
+        assert_eq!(decimals(&instance_1, asset_id_1).await, Some(decimals_1));
+        let log = response
+            .decode_logs_with_type::<SetDecimalsEvent>()
+            .unwrap();
+        let event = log.first().unwrap();
+        assert_eq!(
+            *event,
+            SetDecimalsEvent {
+                asset: asset_id_1,
+                decimals: decimals_1,
+                sender: Identity::Address(owner_wallet.address().into()),
+            }
+        );
+
+        let response = set_decimals(&instance_1, asset_id_1, decimals_2).await;
+        assert_eq!(decimals(&instance_1, asset_id_1).await, Some(decimals_2));
+        let log = response
+            .decode_logs_with_type::<SetDecimalsEvent>()
+            .unwrap();
+        let event = log.first().unwrap();
+        assert_eq!(
+            *event,
+            SetDecimalsEvent {
+                asset: asset_id_1,
+                decimals: decimals_2,
+                sender: Identity::Address(owner_wallet.address().into()),
+            }
+        );
     }
 
     #[tokio::test]
     async fn sets_multiple_assets() {
         let (owner_wallet, other_wallet, id, instance_1, _instance_2) = setup().await;
         let (asset_id_1, asset_id_2, _sub_id_1, _sub_id_2, _identity1, _other_identity) =
-            defaults(id, owner_wallet, other_wallet.clone());
+            defaults(id, owner_wallet.clone(), other_wallet.clone());
+        let decimals_1 = 9u8;
+        let decimals_2 = u8::MIN;
+        let decimals_3 = u8::MAX;
+        let decimals_4 = 16u8;
+        let decimals_5 = 9u8;
+        let asset_id_3 = get_asset_id(Bytes32::from([3u8; 32]), id);
+        let asset_id_4 = get_asset_id(Bytes32::from([4u8; 32]), id);
+        let asset_id_5 = get_asset_id(Bytes32::from([5u8; 32]), id);
 
         assert_eq!(decimals(&instance_1, asset_id_1).await, None);
-        set_decimals(&instance_1, asset_id_1, 9u8).await;
-        assert_eq!(decimals(&instance_1, asset_id_1).await, Some(9u8));
+        let response = set_decimals(&instance_1, asset_id_1, decimals_1).await;
+        assert_eq!(decimals(&instance_1, asset_id_1).await, Some(decimals_1));
+        let log = response
+            .decode_logs_with_type::<SetDecimalsEvent>()
+            .unwrap();
+        let event = log.first().unwrap();
+        assert_eq!(
+            *event,
+            SetDecimalsEvent {
+                asset: asset_id_1,
+                decimals: decimals_1,
+                sender: Identity::Address(owner_wallet.address().into()),
+            }
+        );
 
         assert_eq!(decimals(&instance_1, asset_id_2).await, None);
-        set_decimals(&instance_1, asset_id_2, 8u8).await;
-        assert_eq!(decimals(&instance_1, asset_id_2).await, Some(8u8));
+        let response = set_decimals(&instance_1, asset_id_2, decimals_2).await;
+        assert_eq!(decimals(&instance_1, asset_id_2).await, Some(decimals_2));
+        let log = response
+            .decode_logs_with_type::<SetDecimalsEvent>()
+            .unwrap();
+        let event = log.first().unwrap();
+        assert_eq!(
+            *event,
+            SetDecimalsEvent {
+                asset: asset_id_2,
+                decimals: decimals_2,
+                sender: Identity::Address(owner_wallet.address().into()),
+            }
+        );
 
-        let asset_id_3 = get_asset_id(Bytes32::from([3u8; 32]), id);
         assert_eq!(decimals(&instance_1, asset_id_3).await, None);
-        set_decimals(&instance_1, asset_id_3, 7u8).await;
-        assert_eq!(decimals(&instance_1, asset_id_3).await, Some(7u8));
+        let response = set_decimals(&instance_1, asset_id_3, decimals_3).await;
+        assert_eq!(decimals(&instance_1, asset_id_3).await, Some(decimals_3));
+        let log = response
+            .decode_logs_with_type::<SetDecimalsEvent>()
+            .unwrap();
+        let event = log.first().unwrap();
+        assert_eq!(
+            *event,
+            SetDecimalsEvent {
+                asset: asset_id_3,
+                decimals: decimals_3,
+                sender: Identity::Address(owner_wallet.address().into()),
+            }
+        );
 
-        let asset_id_4 = get_asset_id(Bytes32::from([4u8; 32]), id);
         assert_eq!(decimals(&instance_1, asset_id_4).await, None);
-        set_decimals(&instance_1, asset_id_4, 6u8).await;
-        assert_eq!(decimals(&instance_1, asset_id_4).await, Some(6u8));
+        let response = set_decimals(&instance_1, asset_id_4, decimals_4).await;
+        assert_eq!(decimals(&instance_1, asset_id_4).await, Some(decimals_4));
+        let log = response
+            .decode_logs_with_type::<SetDecimalsEvent>()
+            .unwrap();
+        let event = log.first().unwrap();
+        assert_eq!(
+            *event,
+            SetDecimalsEvent {
+                asset: asset_id_4,
+                decimals: decimals_4,
+                sender: Identity::Address(owner_wallet.address().into()),
+            }
+        );
 
-        let asset_id_5 = get_asset_id(Bytes32::from([5u8; 32]), id);
         assert_eq!(decimals(&instance_1, asset_id_5).await, None);
-        set_decimals(&instance_1, asset_id_5, 5u8).await;
-        assert_eq!(decimals(&instance_1, asset_id_5).await, Some(5u8));
+        let response = set_decimals(&instance_1, asset_id_5, decimals_5).await;
+        assert_eq!(decimals(&instance_1, asset_id_5).await, Some(decimals_5));
+        let log = response
+            .decode_logs_with_type::<SetDecimalsEvent>()
+            .unwrap();
+        let event = log.first().unwrap();
+        assert_eq!(
+            *event,
+            SetDecimalsEvent {
+                asset: asset_id_5,
+                decimals: decimals_5,
+                sender: Identity::Address(owner_wallet.address().into()),
+            }
+        );
     }
 
     #[tokio::test]
-    async fn does_not_overwrite_other_decimals() {
+    async fn does_not_overwrite_other_assets() {
         let (owner_wallet, other_wallet, id, instance_1, _instance_2) = setup().await;
         let (asset_id_1, asset_id_2, _sub_id_1, _sub_id_2, _identity1, _other_identity) =
-            defaults(id, owner_wallet, other_wallet.clone());
+            defaults(id, owner_wallet.clone(), other_wallet.clone());
+        let decimals_1 = 9u8;
+        let decimals_2 = 8u8;
 
         assert_eq!(decimals(&instance_1, asset_id_1).await, None);
-        set_decimals(&instance_1, asset_id_1, 9u8).await;
-        assert_eq!(decimals(&instance_1, asset_id_1).await, Some(9u8));
+        let response = set_decimals(&instance_1, asset_id_1, decimals_1).await;
+        assert_eq!(decimals(&instance_1, asset_id_1).await, Some(decimals_1));
+        let log = response
+            .decode_logs_with_type::<SetDecimalsEvent>()
+            .unwrap();
+        let event = log.first().unwrap();
+        assert_eq!(
+            *event,
+            SetDecimalsEvent {
+                asset: asset_id_1,
+                decimals: decimals_1,
+                sender: Identity::Address(owner_wallet.address().into()),
+            }
+        );
 
         assert_eq!(decimals(&instance_1, asset_id_2).await, None);
-        set_decimals(&instance_1, asset_id_2, 8u8).await;
+        let response = set_decimals(&instance_1, asset_id_2, decimals_2).await;
+        let log = response
+            .decode_logs_with_type::<SetDecimalsEvent>()
+            .unwrap();
+        let event = log.first().unwrap();
+        assert_eq!(
+            *event,
+            SetDecimalsEvent {
+                asset: asset_id_2,
+                decimals: decimals_2,
+                sender: Identity::Address(owner_wallet.address().into()),
+            }
+        );
 
-        assert_eq!(decimals(&instance_1, asset_id_1).await, Some(9u8));
-        assert_eq!(decimals(&instance_1, asset_id_2).await, Some(8u8));
+        assert_eq!(decimals(&instance_1, asset_id_1).await, Some(decimals_1));
+        assert_eq!(decimals(&instance_1, asset_id_2).await, Some(decimals_2));
     }
 }

--- a/tests/src/native_asset/tests/functions/set_metadata.rs
+++ b/tests/src/native_asset/tests/functions/set_metadata.rs
@@ -2,7 +2,7 @@ use crate::native_asset::tests::utils::{
     interface::{metadata, set_metadata},
     setup::{defaults, get_asset_id, setup, Metadata, SetMetadataEvent},
 };
-use fuels::types::{Bytes, Bytes32, Identity};
+use fuels::types::{Bits256, Bytes, Bytes32, Identity};
 
 mod success {
 
@@ -18,7 +18,7 @@ mod success {
 
         assert_eq!(metadata(&instance_1, asset_id_1, key.clone()).await, None);
 
-        let response = set_metadata(&instance_1, asset_id_1, key.clone(), metadata1.clone()).await;
+        let response = set_metadata(&instance_1, asset_id_1, key.clone(), Some(metadata1.clone())).await;
         assert_eq!(
             metadata(&instance_1, asset_id_1, key.clone()).await,
             Some(metadata1.clone())
@@ -33,9 +33,41 @@ mod success {
             *event,
             SetMetadataEvent {
                 asset: asset_id_1,
+                metadata: Some(metadata1),
+                key: key,
                 sender: Identity::Address(owner_wallet.address().into()),
-                metadata: metadata1,
-                key: key
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn sets_none() {
+        let (owner_wallet, other_wallet, id, instance_1, _instance_2) = setup().await;
+        let (asset_id_1, _asset_id_2, _sub_id_1, _sub_id_2, _identity1, _other_identity) =
+            defaults(id, owner_wallet.clone(), other_wallet.clone());
+        let metadata1 = Metadata::String(String::from("Fuel NFT Metadata"));
+        let key = String::from("key1");
+
+        set_metadata(&instance_1, asset_id_1, key.clone(), Some(metadata1.clone())).await;
+        assert_eq!(
+            metadata(&instance_1, asset_id_1, key.clone()).await,
+            Some(metadata1.clone())
+        );
+
+        let response = set_metadata(&instance_1, asset_id_1, key.clone(), None).await;
+        assert_eq!(metadata(&instance_1, asset_id_1, key.clone()).await, None);
+        let log = response
+            .decode_logs_with_type::<SetMetadataEvent>()
+            .unwrap();
+        let event = log.first().unwrap();
+
+        assert_eq!(
+            *event,
+            SetMetadataEvent {
+                asset: asset_id_1,
+                metadata: None,
+                key: key,
+                sender: Identity::Address(owner_wallet.address().into()),
             }
         );
     }
@@ -51,7 +83,7 @@ mod success {
         let key = String::from("key1");
 
         assert_eq!(metadata(&instance_1, asset_id_1, key.clone()).await, None);
-        let response = set_metadata(&instance_1, asset_id_1, key.clone(), metadata1.clone()).await;
+        let response = set_metadata(&instance_1, asset_id_1, key.clone(), Some(metadata1.clone())).await;
         assert_eq!(
             metadata(&instance_1, asset_id_1, key.clone()).await,
             Some(metadata1.clone())
@@ -66,14 +98,14 @@ mod success {
             *event,
             SetMetadataEvent {
                 asset: asset_id_1,
+                metadata: Some(metadata1),
+                key: key.clone(),
                 sender: Identity::Address(owner_wallet.address().into()),
-                metadata: metadata1,
-                key: key.clone()
             }
         );
 
         assert_eq!(metadata(&instance_1, asset_id_2, key.clone()).await, None);
-        let response = set_metadata(&instance_1, asset_id_2, key.clone(), metadata2.clone()).await;
+        let response = set_metadata(&instance_1, asset_id_2, key.clone(), Some(metadata2.clone())).await;
         assert_eq!(
             metadata(&instance_1, asset_id_2, key.clone()).await,
             Some(metadata2.clone())
@@ -88,15 +120,15 @@ mod success {
             *event,
             SetMetadataEvent {
                 asset: asset_id_2,
+                metadata: Some(metadata2),
+                key: key.clone(),
                 sender: Identity::Address(owner_wallet.address().into()),
-                metadata: metadata2,
-                key: key.clone()
             }
         );
 
         let asset_id_3 = get_asset_id(Bytes32::from([3u8; 32]), id);
         assert_eq!(metadata(&instance_1, asset_id_3, key.clone()).await, None);
-        let response = set_metadata(&instance_1, asset_id_3, key.clone(), metadata3.clone()).await;
+        let response = set_metadata(&instance_1, asset_id_3, key.clone(), Some(metadata3.clone())).await;
         assert_eq!(
             metadata(&instance_1, asset_id_3, key.clone()).await,
             Some(metadata3.clone())
@@ -111,15 +143,15 @@ mod success {
             *event,
             SetMetadataEvent {
                 asset: asset_id_3,
+                metadata: Some(metadata3),
+                key: key,
                 sender: Identity::Address(owner_wallet.address().into()),
-                metadata: metadata3,
-                key: key
             }
         );
     }
 
     #[tokio::test]
-    async fn does_not_overwrite_other_names() {
+    async fn does_not_overwrite_other_assets_with_same_key() {
         let (owner_wallet, other_wallet, id, instance_1, _instance_2) = setup().await;
         let (asset_id_1, asset_id_2, _sub_id_1, _sub_id_2, _identity1, _other_identity) =
             defaults(id, owner_wallet.clone(), other_wallet.clone());
@@ -127,32 +159,30 @@ mod success {
         let metadata2 = Metadata::String(String::from("Fuel NFT Metadata 2"));
         let metadata3 = Metadata::String(String::from("Fuel NFT Metadata 3"));
         let key = String::from("key1");
+        let asset_id_3 = get_asset_id(Bytes32::from([3u8; 32]), id);
 
         assert_eq!(metadata(&instance_1, asset_id_1, key.clone()).await, None);
-        let response = set_metadata(&instance_1, asset_id_1, key.clone(), metadata1.clone()).await;
+        let response = set_metadata(&instance_1, asset_id_1, key.clone(), Some(metadata1.clone())).await;
         assert_eq!(
             metadata(&instance_1, asset_id_1.clone(), key.clone()).await,
             Some(metadata1.clone())
         );
-
         let log = response
             .decode_logs_with_type::<SetMetadataEvent>()
             .unwrap();
         let event = log.first().unwrap();
-
         assert_eq!(
             *event,
             SetMetadataEvent {
                 asset: asset_id_1,
+                metadata: Some(metadata1.clone()),
+                key: key.clone(),
                 sender: Identity::Address(owner_wallet.address().into()),
-                metadata: metadata1.clone(),
-                key: key.clone()
             }
         );
 
         assert_eq!(metadata(&instance_1, asset_id_2, key.clone()).await, None);
-        let response = set_metadata(&instance_1, asset_id_2, key.clone(), metadata2.clone()).await;
-
+        let response = set_metadata(&instance_1, asset_id_2, key.clone(), Some(metadata2.clone())).await;
         assert_eq!(
             metadata(&instance_1, asset_id_1, key.clone()).await,
             Some(metadata1.clone())
@@ -161,26 +191,22 @@ mod success {
             metadata(&instance_1, asset_id_2, key.clone()).await,
             Some(metadata2.clone())
         );
-
         let log = response
             .decode_logs_with_type::<SetMetadataEvent>()
             .unwrap();
         let event = log.first().unwrap();
-
         assert_eq!(
             *event,
             SetMetadataEvent {
                 asset: asset_id_2,
+                metadata: Some(metadata2.clone()),
+                key: key.clone(),
                 sender: Identity::Address(owner_wallet.address().into()),
-                metadata: metadata2.clone(),
-                key: key.clone()
             }
         );
 
-        let asset_id_3 = get_asset_id(Bytes32::from([3u8; 32]), id);
         assert_eq!(metadata(&instance_1, asset_id_3, key.clone()).await, None);
-        let response = set_metadata(&instance_1, asset_id_3, key.clone(), metadata3.clone()).await;
-
+        let response = set_metadata(&instance_1, asset_id_3, key.clone(), Some(metadata3.clone())).await;
         assert_eq!(
             metadata(&instance_1, asset_id_1, key.clone()).await,
             Some(metadata1)
@@ -193,19 +219,17 @@ mod success {
             metadata(&instance_1, asset_id_3, key.clone()).await,
             Some(metadata3.clone())
         );
-
         let log = response
             .decode_logs_with_type::<SetMetadataEvent>()
             .unwrap();
         let event = log.first().unwrap();
-
         assert_eq!(
             *event,
             SetMetadataEvent {
                 asset: asset_id_3,
+                metadata: Some(metadata3),
+                key: key,
                 sender: Identity::Address(owner_wallet.address().into()),
-                metadata: metadata3,
-                key: key
             }
         );
     }
@@ -221,34 +245,34 @@ mod success {
             Bytes::from_hex_str("0101010101010101010101010101010101010101010101010101010101010101")
                 .expect("failed to convert to bytes"),
         );
+        let metadata4 = Metadata::B256(Bits256([1u8; 32]));
         let key1 = String::from("key1");
         let key2 = String::from("key2");
         let key3 = String::from("key3");
+        let key4 = String::from("key4");
 
         assert_eq!(metadata(&instance_1, asset_id_1, key1.clone()).await, None);
-        let response = set_metadata(&instance_1, asset_id_1, key1.clone(), metadata1.clone()).await;
+        let response = set_metadata(&instance_1, asset_id_1, key1.clone(), Some(metadata1.clone())).await;
         assert_eq!(
             metadata(&instance_1, asset_id_1, key1.clone()).await,
             Some(metadata1.clone())
         );
-
         let log = response
             .decode_logs_with_type::<SetMetadataEvent>()
             .unwrap();
         let event = log.first().unwrap();
-
         assert_eq!(
             *event,
             SetMetadataEvent {
                 asset: asset_id_1,
+                metadata: Some(metadata1.clone()),
+                key: key1.clone(),
                 sender: Identity::Address(owner_wallet.address().into()),
-                metadata: metadata1.clone(),
-                key: key1.clone()
             }
         );
 
         assert_eq!(metadata(&instance_1, asset_id_1, key2.clone()).await, None);
-        let response = set_metadata(&instance_1, asset_id_1, key2.clone(), metadata2.clone()).await;
+        let response = set_metadata(&instance_1, asset_id_1, key2.clone(), Some(metadata2.clone())).await;
         assert_eq!(
             metadata(&instance_1, asset_id_1, key2.clone()).await,
             Some(metadata2.clone())
@@ -257,50 +281,111 @@ mod success {
             metadata(&instance_1, asset_id_1, key1.clone()).await,
             Some(metadata1.clone())
         );
-
         let log = response
             .decode_logs_with_type::<SetMetadataEvent>()
             .unwrap();
         let event = log.first().unwrap();
-
         assert_eq!(
             *event,
             SetMetadataEvent {
                 asset: asset_id_1,
+                metadata: Some(metadata2.clone()),
+                key: key2.clone(),
                 sender: Identity::Address(owner_wallet.address().into()),
-                metadata: metadata2.clone(),
-                key: key2.clone()
             }
         );
 
         assert_eq!(metadata(&instance_1, asset_id_1, key3.clone()).await, None);
-        let response = set_metadata(&instance_1, asset_id_1, key3.clone(), metadata3.clone()).await;
+        let response = set_metadata(&instance_1, asset_id_1, key3.clone(), Some(metadata3.clone())).await;
         assert_eq!(
             metadata(&instance_1, asset_id_1, key3.clone()).await,
             Some(metadata3.clone())
         );
         assert_eq!(
             metadata(&instance_1, asset_id_1, key2.clone()).await,
-            Some(metadata2)
+            Some(metadata2.clone())
         );
         assert_eq!(
             metadata(&instance_1, asset_id_1, key1.clone()).await,
-            Some(metadata1)
+            Some(metadata1.clone())
         );
-
         let log = response
             .decode_logs_with_type::<SetMetadataEvent>()
             .unwrap();
         let event = log.first().unwrap();
-
         assert_eq!(
             *event,
             SetMetadataEvent {
                 asset: asset_id_1,
+                metadata: Some(metadata3.clone()),
+                key: key3.clone(),
                 sender: Identity::Address(owner_wallet.address().into()),
-                metadata: metadata3,
-                key: key3
+            }
+        );
+
+        assert_eq!(metadata(&instance_1, asset_id_1, key4.clone()).await, None);
+        let response = set_metadata(&instance_1, asset_id_1, key4.clone(), Some(metadata4.clone())).await;
+        assert_eq!(
+            metadata(&instance_1, asset_id_1, key4.clone()).await,
+            Some(metadata4.clone())
+        );
+        assert_eq!(
+            metadata(&instance_1, asset_id_1, key3).await,
+            Some(metadata3)
+        );
+        assert_eq!(
+            metadata(&instance_1, asset_id_1, key2).await,
+            Some(metadata2)
+        );
+        assert_eq!(
+            metadata(&instance_1, asset_id_1, key1).await,
+            Some(metadata1)
+        );
+        let log = response
+            .decode_logs_with_type::<SetMetadataEvent>()
+            .unwrap();
+        let event = log.first().unwrap();
+        assert_eq!(
+            *event,
+            SetMetadataEvent {
+                asset: asset_id_1,
+                metadata: Some(metadata4),
+                key: key4,
+                sender: Identity::Address(owner_wallet.address().into()),
             }
         );
     }
+}
+
+mod revert {
+
+    use super::*;
+
+    #[tokio::test]
+    #[should_panic(expected = "EmptyString")]
+    async fn when_empty_string() {
+        let (owner_wallet, other_wallet, id, instance_1, _instance_2) = setup().await;
+        let (asset_id_1, _asset_id_2, _sub_id_1, _sub_id_2, _identity1, _other_identity) =
+            defaults(id, owner_wallet.clone(), other_wallet.clone());
+        let metadata1 = Metadata::String(String::from(""));
+        let key = String::from("key1");
+
+        set_metadata(&instance_1, asset_id_1, key.clone(), Some(metadata1.clone())).await;
+    }
+
+    #[tokio::test]
+    #[should_panic(expected = "EmptyBytes")]
+    async fn when_empty_bytes() {
+        let (owner_wallet, other_wallet, id, instance_1, _instance_2) = setup().await;
+        let (asset_id_1, _asset_id_2, _sub_id_1, _sub_id_2, _identity1, _other_identity) =
+            defaults(id, owner_wallet.clone(), other_wallet.clone());
+        let metadata1 = Metadata::Bytes(
+            Bytes::from_hex_str("")
+                .expect("failed to convert to bytes"),
+        );        
+        let key = String::from("key1");
+
+        set_metadata(&instance_1, asset_id_1, key.clone(), Some(metadata1.clone())).await;
+    }
+
 }

--- a/tests/src/native_asset/tests/functions/set_metadata.rs
+++ b/tests/src/native_asset/tests/functions/set_metadata.rs
@@ -18,7 +18,13 @@ mod success {
 
         assert_eq!(metadata(&instance_1, asset_id_1, key.clone()).await, None);
 
-        let response = set_metadata(&instance_1, asset_id_1, key.clone(), Some(metadata1.clone())).await;
+        let response = set_metadata(
+            &instance_1,
+            asset_id_1,
+            key.clone(),
+            Some(metadata1.clone()),
+        )
+        .await;
         assert_eq!(
             metadata(&instance_1, asset_id_1, key.clone()).await,
             Some(metadata1.clone())
@@ -48,7 +54,13 @@ mod success {
         let metadata1 = Metadata::String(String::from("Fuel NFT Metadata"));
         let key = String::from("key1");
 
-        set_metadata(&instance_1, asset_id_1, key.clone(), Some(metadata1.clone())).await;
+        set_metadata(
+            &instance_1,
+            asset_id_1,
+            key.clone(),
+            Some(metadata1.clone()),
+        )
+        .await;
         assert_eq!(
             metadata(&instance_1, asset_id_1, key.clone()).await,
             Some(metadata1.clone())
@@ -83,7 +95,13 @@ mod success {
         let key = String::from("key1");
 
         assert_eq!(metadata(&instance_1, asset_id_1, key.clone()).await, None);
-        let response = set_metadata(&instance_1, asset_id_1, key.clone(), Some(metadata1.clone())).await;
+        let response = set_metadata(
+            &instance_1,
+            asset_id_1,
+            key.clone(),
+            Some(metadata1.clone()),
+        )
+        .await;
         assert_eq!(
             metadata(&instance_1, asset_id_1, key.clone()).await,
             Some(metadata1.clone())
@@ -105,7 +123,13 @@ mod success {
         );
 
         assert_eq!(metadata(&instance_1, asset_id_2, key.clone()).await, None);
-        let response = set_metadata(&instance_1, asset_id_2, key.clone(), Some(metadata2.clone())).await;
+        let response = set_metadata(
+            &instance_1,
+            asset_id_2,
+            key.clone(),
+            Some(metadata2.clone()),
+        )
+        .await;
         assert_eq!(
             metadata(&instance_1, asset_id_2, key.clone()).await,
             Some(metadata2.clone())
@@ -128,7 +152,13 @@ mod success {
 
         let asset_id_3 = get_asset_id(Bytes32::from([3u8; 32]), id);
         assert_eq!(metadata(&instance_1, asset_id_3, key.clone()).await, None);
-        let response = set_metadata(&instance_1, asset_id_3, key.clone(), Some(metadata3.clone())).await;
+        let response = set_metadata(
+            &instance_1,
+            asset_id_3,
+            key.clone(),
+            Some(metadata3.clone()),
+        )
+        .await;
         assert_eq!(
             metadata(&instance_1, asset_id_3, key.clone()).await,
             Some(metadata3.clone())
@@ -162,7 +192,13 @@ mod success {
         let asset_id_3 = get_asset_id(Bytes32::from([3u8; 32]), id);
 
         assert_eq!(metadata(&instance_1, asset_id_1, key.clone()).await, None);
-        let response = set_metadata(&instance_1, asset_id_1, key.clone(), Some(metadata1.clone())).await;
+        let response = set_metadata(
+            &instance_1,
+            asset_id_1,
+            key.clone(),
+            Some(metadata1.clone()),
+        )
+        .await;
         assert_eq!(
             metadata(&instance_1, asset_id_1.clone(), key.clone()).await,
             Some(metadata1.clone())
@@ -182,7 +218,13 @@ mod success {
         );
 
         assert_eq!(metadata(&instance_1, asset_id_2, key.clone()).await, None);
-        let response = set_metadata(&instance_1, asset_id_2, key.clone(), Some(metadata2.clone())).await;
+        let response = set_metadata(
+            &instance_1,
+            asset_id_2,
+            key.clone(),
+            Some(metadata2.clone()),
+        )
+        .await;
         assert_eq!(
             metadata(&instance_1, asset_id_1, key.clone()).await,
             Some(metadata1.clone())
@@ -206,7 +248,13 @@ mod success {
         );
 
         assert_eq!(metadata(&instance_1, asset_id_3, key.clone()).await, None);
-        let response = set_metadata(&instance_1, asset_id_3, key.clone(), Some(metadata3.clone())).await;
+        let response = set_metadata(
+            &instance_1,
+            asset_id_3,
+            key.clone(),
+            Some(metadata3.clone()),
+        )
+        .await;
         assert_eq!(
             metadata(&instance_1, asset_id_1, key.clone()).await,
             Some(metadata1)
@@ -252,7 +300,13 @@ mod success {
         let key4 = String::from("key4");
 
         assert_eq!(metadata(&instance_1, asset_id_1, key1.clone()).await, None);
-        let response = set_metadata(&instance_1, asset_id_1, key1.clone(), Some(metadata1.clone())).await;
+        let response = set_metadata(
+            &instance_1,
+            asset_id_1,
+            key1.clone(),
+            Some(metadata1.clone()),
+        )
+        .await;
         assert_eq!(
             metadata(&instance_1, asset_id_1, key1.clone()).await,
             Some(metadata1.clone())
@@ -272,7 +326,13 @@ mod success {
         );
 
         assert_eq!(metadata(&instance_1, asset_id_1, key2.clone()).await, None);
-        let response = set_metadata(&instance_1, asset_id_1, key2.clone(), Some(metadata2.clone())).await;
+        let response = set_metadata(
+            &instance_1,
+            asset_id_1,
+            key2.clone(),
+            Some(metadata2.clone()),
+        )
+        .await;
         assert_eq!(
             metadata(&instance_1, asset_id_1, key2.clone()).await,
             Some(metadata2.clone())
@@ -296,7 +356,13 @@ mod success {
         );
 
         assert_eq!(metadata(&instance_1, asset_id_1, key3.clone()).await, None);
-        let response = set_metadata(&instance_1, asset_id_1, key3.clone(), Some(metadata3.clone())).await;
+        let response = set_metadata(
+            &instance_1,
+            asset_id_1,
+            key3.clone(),
+            Some(metadata3.clone()),
+        )
+        .await;
         assert_eq!(
             metadata(&instance_1, asset_id_1, key3.clone()).await,
             Some(metadata3.clone())
@@ -324,7 +390,13 @@ mod success {
         );
 
         assert_eq!(metadata(&instance_1, asset_id_1, key4.clone()).await, None);
-        let response = set_metadata(&instance_1, asset_id_1, key4.clone(), Some(metadata4.clone())).await;
+        let response = set_metadata(
+            &instance_1,
+            asset_id_1,
+            key4.clone(),
+            Some(metadata4.clone()),
+        )
+        .await;
         assert_eq!(
             metadata(&instance_1, asset_id_1, key4.clone()).await,
             Some(metadata4.clone())
@@ -370,7 +442,13 @@ mod revert {
         let metadata1 = Metadata::String(String::from(""));
         let key = String::from("key1");
 
-        set_metadata(&instance_1, asset_id_1, key.clone(), Some(metadata1.clone())).await;
+        set_metadata(
+            &instance_1,
+            asset_id_1,
+            key.clone(),
+            Some(metadata1.clone()),
+        )
+        .await;
     }
 
     #[tokio::test]
@@ -379,13 +457,16 @@ mod revert {
         let (owner_wallet, other_wallet, id, instance_1, _instance_2) = setup().await;
         let (asset_id_1, _asset_id_2, _sub_id_1, _sub_id_2, _identity1, _other_identity) =
             defaults(id, owner_wallet.clone(), other_wallet.clone());
-        let metadata1 = Metadata::Bytes(
-            Bytes::from_hex_str("")
-                .expect("failed to convert to bytes"),
-        );        
+        let metadata1 =
+            Metadata::Bytes(Bytes::from_hex_str("").expect("failed to convert to bytes"));
         let key = String::from("key1");
 
-        set_metadata(&instance_1, asset_id_1, key.clone(), Some(metadata1.clone())).await;
+        set_metadata(
+            &instance_1,
+            asset_id_1,
+            key.clone(),
+            Some(metadata1.clone()),
+        )
+        .await;
     }
-
 }

--- a/tests/src/native_asset/tests/functions/set_name.rs
+++ b/tests/src/native_asset/tests/functions/set_name.rs
@@ -1,8 +1,8 @@
 use crate::native_asset::tests::utils::{
     interface::{name, set_name},
-    setup::{defaults, get_asset_id, setup},
+    setup::{defaults, get_asset_id, setup, SetNameEvent},
 };
-use fuels::types::Bytes32;
+use fuels::types::{Bytes32, Identity};
 
 mod success {
 
@@ -12,14 +12,101 @@ mod success {
     async fn sets_one_asset() {
         let (owner_wallet, other_wallet, id, instance_1, _instance_2) = setup().await;
         let (asset_id_1, _asset_id_2, _sub_id_1, _sub_id_2, _identity1, _other_identity) =
-            defaults(id, owner_wallet, other_wallet.clone());
+            defaults(id, owner_wallet.clone(), other_wallet.clone());
+        let name_1 = String::from("Fuel Asset 1");
 
         assert_eq!(name(&instance_1, asset_id_1).await, None);
 
-        set_name(&instance_1, asset_id_1, String::from("Fuel Asset 1")).await;
+        let response = set_name(&instance_1, asset_id_1, Some(name_1.clone())).await;
         assert_eq!(
             name(&instance_1, asset_id_1).await,
-            Some(String::from("Fuel Asset 1"))
+            Some(name_1.clone())
+        );
+        let log = response
+            .decode_logs_with_type::<SetNameEvent>()
+            .unwrap();
+        let event = log.first().unwrap();
+        assert_eq!(
+            *event,
+            SetNameEvent {
+                asset: asset_id_1,
+                name: Some(name_1),
+                sender: Identity::Address(owner_wallet.address().into()),
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn sets_none() {
+        let (owner_wallet, other_wallet, id, instance_1, _instance_2) = setup().await;
+        let (asset_id_1, _asset_id_2, _sub_id_1, _sub_id_2, _identity1, _other_identity) =
+            defaults(id, owner_wallet.clone(), other_wallet.clone());
+        let name_1 = String::from("Fuel Asset 1");
+
+        set_name(&instance_1, asset_id_1, Some(name_1.clone())).await;
+        assert_eq!(
+            name(&instance_1, asset_id_1).await,
+            Some(name_1.clone())
+        );
+
+        let response = set_name(&instance_1, asset_id_1, None).await;
+        assert_eq!(name(&instance_1, asset_id_1).await, None);
+        let log = response
+            .decode_logs_with_type::<SetNameEvent>()
+            .unwrap();
+        let event = log.first().unwrap();
+        assert_eq!(
+            *event,
+            SetNameEvent {
+                asset: asset_id_1,
+                name: None,
+                sender: Identity::Address(owner_wallet.address().into()),
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn sets_name_twice() {
+        let (owner_wallet, other_wallet, id, instance_1, _instance_2) = setup().await;
+        let (asset_id_1, _asset_id_2, _sub_id_1, _sub_id_2, _identity1, _other_identity) =
+            defaults(id, owner_wallet.clone(), other_wallet.clone());
+        let name_1 = String::from("Fuel Asset 1");
+        let name_2 = String::from("Fuel Asset 2");
+
+        let response = set_name(&instance_1, asset_id_1, Some(name_1.clone())).await;
+        assert_eq!(
+            name(&instance_1, asset_id_1).await,
+            Some(name_1.clone())
+        );
+        let log = response
+            .decode_logs_with_type::<SetNameEvent>()
+            .unwrap();
+        let event = log.first().unwrap();
+        assert_eq!(
+            *event,
+            SetNameEvent {
+                asset: asset_id_1,
+                name: Some(name_1),
+                sender: Identity::Address(owner_wallet.address().into()),
+            }
+        );
+
+        let response = set_name(&instance_1, asset_id_1, Some(name_2.clone())).await;
+        assert_eq!(
+            name(&instance_1, asset_id_1).await,
+            Some(name_2.clone())
+        );
+        let log = response
+            .decode_logs_with_type::<SetNameEvent>()
+            .unwrap();
+        let event = log.first().unwrap();
+        assert_eq!(
+            *event,
+            SetNameEvent {
+                asset: asset_id_1,
+                name: Some(name_2),
+                sender: Identity::Address(owner_wallet.address().into()),
+            }
         );
     }
 
@@ -27,70 +114,177 @@ mod success {
     async fn sets_multiple_assets() {
         let (owner_wallet, other_wallet, id, instance_1, _instance_2) = setup().await;
         let (asset_id_1, asset_id_2, _sub_id_1, _sub_id_2, _identity1, _other_identity) =
-            defaults(id, owner_wallet, other_wallet.clone());
+            defaults(id, owner_wallet.clone(), other_wallet.clone());
+        let name_1 = String::from("Fuel Asset 1");
+        let name_2 = String::from("Fuel Asset 2");
+        let name_3 = String::from("Fuel Asset 3 Fuel Asset 3 Fuel Asset 3 Fuel Asset 3 Fuel Asset 3 Fuel Asset 3 Fuel Asset 3 Fuel Asset 3 Fuel Asset 3 Fuel Asset 3 Fuel Asset 3 Fuel Asset 3 Fuel Asset 3 Fuel Asset 3 Fuel Asset 3");
+        let name_4 = String::from("4");
+        let name_5 = String::from("Fuel Asset 1");
+        let asset_id_3 = get_asset_id(Bytes32::from([3u8; 32]), id);
+        let asset_id_4 = get_asset_id(Bytes32::from([4u8; 32]), id);
+        let asset_id_5 = get_asset_id(Bytes32::from([5u8; 32]), id);
 
         assert_eq!(name(&instance_1, asset_id_1).await, None);
-        set_name(&instance_1, asset_id_1, String::from("Fuel Asset 1")).await;
+        let response = set_name(&instance_1, asset_id_1, Some(name_1.clone())).await;
         assert_eq!(
             name(&instance_1, asset_id_1).await,
-            Some(String::from("Fuel Asset 1"))
+            Some(name_1.clone())
+        );
+        let log = response
+            .decode_logs_with_type::<SetNameEvent>()
+            .unwrap();
+        let event = log.first().unwrap();
+        assert_eq!(
+            *event,
+            SetNameEvent {
+                asset: asset_id_1,
+                name: Some(name_1),
+                sender: Identity::Address(owner_wallet.address().into()),
+            }
         );
 
         assert_eq!(name(&instance_1, asset_id_2).await, None);
-        set_name(&instance_1, asset_id_2, String::from("Fuel Asset 2")).await;
+        let response = set_name(&instance_1, asset_id_2, Some(name_2.clone())).await;
         assert_eq!(
             name(&instance_1, asset_id_2).await,
-            Some(String::from("Fuel Asset 2"))
+            Some(name_2.clone())
+        );
+        let log = response
+            .decode_logs_with_type::<SetNameEvent>()
+            .unwrap();
+        let event = log.first().unwrap();
+        assert_eq!(
+            *event,
+            SetNameEvent {
+                asset: asset_id_2,
+                name: Some(name_2),
+                sender: Identity::Address(owner_wallet.address().into()),
+            }
         );
 
-        let asset_id_3 = get_asset_id(Bytes32::from([3u8; 32]), id);
         assert_eq!(name(&instance_1, asset_id_3).await, None);
-        set_name(&instance_1, asset_id_3, String::from("Fuel Asset 3")).await;
+        let response = set_name(&instance_1, asset_id_3, Some(name_3.clone())).await;
         assert_eq!(
             name(&instance_1, asset_id_3).await,
-            Some(String::from("Fuel Asset 3"))
+            Some(name_3.clone())
+        );
+        let log = response
+            .decode_logs_with_type::<SetNameEvent>()
+            .unwrap();
+        let event = log.first().unwrap();
+        assert_eq!(
+            *event,
+            SetNameEvent {
+                asset: asset_id_3,
+                name: Some(name_3),
+                sender: Identity::Address(owner_wallet.address().into()),
+            }
         );
 
-        let asset_id_4 = get_asset_id(Bytes32::from([4u8; 32]), id);
         assert_eq!(name(&instance_1, asset_id_4).await, None);
-        set_name(&instance_1, asset_id_4, String::from("Fuel Asset 4")).await;
+        let response = set_name(&instance_1, asset_id_4, Some(name_4.clone())).await;
         assert_eq!(
             name(&instance_1, asset_id_4).await,
-            Some(String::from("Fuel Asset 4"))
+            Some(name_4.clone())
+        );
+        let log = response
+            .decode_logs_with_type::<SetNameEvent>()
+            .unwrap();
+        let event = log.first().unwrap();
+        assert_eq!(
+            *event,
+            SetNameEvent {
+                asset: asset_id_4,
+                name: Some(name_4),
+                sender: Identity::Address(owner_wallet.address().into()),
+            }
         );
 
-        let asset_id_5 = get_asset_id(Bytes32::from([5u8; 32]), id);
         assert_eq!(name(&instance_1, asset_id_5).await, None);
-        set_name(&instance_1, asset_id_5, String::from("Fuel Asset 5")).await;
+        let response = set_name(&instance_1, asset_id_5, Some(name_5.clone())).await;
         assert_eq!(
             name(&instance_1, asset_id_5).await,
-            Some(String::from("Fuel Asset 5"))
+            Some(name_5.clone())
+        );
+        let log = response
+            .decode_logs_with_type::<SetNameEvent>()
+            .unwrap();
+        let event = log.first().unwrap();
+        assert_eq!(
+            *event,
+            SetNameEvent {
+                asset: asset_id_5,
+                name: Some(name_5),
+                sender: Identity::Address(owner_wallet.address().into()),
+            }
         );
     }
 
     #[tokio::test]
-    async fn does_not_overwrite_other_names() {
+    async fn does_not_overwrite_other_assets() {
         let (owner_wallet, other_wallet, id, instance_1, _instance_2) = setup().await;
         let (asset_id_1, asset_id_2, _sub_id_1, _sub_id_2, _identity1, _other_identity) =
-            defaults(id, owner_wallet, other_wallet.clone());
-
+            defaults(id, owner_wallet.clone(), other_wallet.clone());
+        let name_1 = String::from("Fuel Asset 1");
+        let name_2 = String::from("Fuel Asset 2");
+        
         assert_eq!(name(&instance_1, asset_id_1).await, None);
-        set_name(&instance_1, asset_id_1, String::from("Fuel Asset 1")).await;
+        let response = set_name(&instance_1, asset_id_1, Some(name_1.clone())).await;
         assert_eq!(
             name(&instance_1, asset_id_1).await,
-            Some(String::from("Fuel Asset 1"))
+            Some(name_1.clone())
+        );
+        let log = response
+            .decode_logs_with_type::<SetNameEvent>()
+            .unwrap();
+        let event = log.first().unwrap();
+        assert_eq!(
+            *event,
+            SetNameEvent {
+                asset: asset_id_1,
+                name: Some(name_1.clone()),
+                sender: Identity::Address(owner_wallet.address().into()),
+            }
         );
 
         assert_eq!(name(&instance_1, asset_id_2).await, None);
-        set_name(&instance_1, asset_id_2, String::from("Fuel Asset 2")).await;
+        let response = set_name(&instance_1, asset_id_2, Some(name_2.clone())).await;
+        let log = response
+            .decode_logs_with_type::<SetNameEvent>()
+            .unwrap();
+        let event = log.first().unwrap();
+        assert_eq!(
+            *event,
+            SetNameEvent {
+                asset: asset_id_2,
+                name: Some(name_2.clone()),
+                sender: Identity::Address(owner_wallet.address().into()),
+            }
+        );
 
         assert_eq!(
             name(&instance_1, asset_id_1).await,
-            Some(String::from("Fuel Asset 1"))
+            Some(name_1)
         );
         assert_eq!(
             name(&instance_1, asset_id_2).await,
-            Some(String::from("Fuel Asset 2"))
+            Some(name_2)
         );
+    }
+}
+
+mod revert {
+
+    use super::*;
+
+    #[tokio::test]
+    #[should_panic(expected = "EmptyString")]
+    async fn when_empty_string() {
+        let (owner_wallet, other_wallet, id, instance_1, _instance_2) = setup().await;
+        let (asset_id_1, _asset_id_2, _sub_id_1, _sub_id_2, _identity1, _other_identity) =
+            defaults(id, owner_wallet, other_wallet);
+        let name_1 = String::from("");
+
+        set_name(&instance_1, asset_id_1, Some(name_1)).await;
     }
 }

--- a/tests/src/native_asset/tests/functions/set_name.rs
+++ b/tests/src/native_asset/tests/functions/set_name.rs
@@ -18,13 +18,8 @@ mod success {
         assert_eq!(name(&instance_1, asset_id_1).await, None);
 
         let response = set_name(&instance_1, asset_id_1, Some(name_1.clone())).await;
-        assert_eq!(
-            name(&instance_1, asset_id_1).await,
-            Some(name_1.clone())
-        );
-        let log = response
-            .decode_logs_with_type::<SetNameEvent>()
-            .unwrap();
+        assert_eq!(name(&instance_1, asset_id_1).await, Some(name_1.clone()));
+        let log = response.decode_logs_with_type::<SetNameEvent>().unwrap();
         let event = log.first().unwrap();
         assert_eq!(
             *event,
@@ -44,16 +39,11 @@ mod success {
         let name_1 = String::from("Fuel Asset 1");
 
         set_name(&instance_1, asset_id_1, Some(name_1.clone())).await;
-        assert_eq!(
-            name(&instance_1, asset_id_1).await,
-            Some(name_1.clone())
-        );
+        assert_eq!(name(&instance_1, asset_id_1).await, Some(name_1.clone()));
 
         let response = set_name(&instance_1, asset_id_1, None).await;
         assert_eq!(name(&instance_1, asset_id_1).await, None);
-        let log = response
-            .decode_logs_with_type::<SetNameEvent>()
-            .unwrap();
+        let log = response.decode_logs_with_type::<SetNameEvent>().unwrap();
         let event = log.first().unwrap();
         assert_eq!(
             *event,
@@ -74,13 +64,8 @@ mod success {
         let name_2 = String::from("Fuel Asset 2");
 
         let response = set_name(&instance_1, asset_id_1, Some(name_1.clone())).await;
-        assert_eq!(
-            name(&instance_1, asset_id_1).await,
-            Some(name_1.clone())
-        );
-        let log = response
-            .decode_logs_with_type::<SetNameEvent>()
-            .unwrap();
+        assert_eq!(name(&instance_1, asset_id_1).await, Some(name_1.clone()));
+        let log = response.decode_logs_with_type::<SetNameEvent>().unwrap();
         let event = log.first().unwrap();
         assert_eq!(
             *event,
@@ -92,13 +77,8 @@ mod success {
         );
 
         let response = set_name(&instance_1, asset_id_1, Some(name_2.clone())).await;
-        assert_eq!(
-            name(&instance_1, asset_id_1).await,
-            Some(name_2.clone())
-        );
-        let log = response
-            .decode_logs_with_type::<SetNameEvent>()
-            .unwrap();
+        assert_eq!(name(&instance_1, asset_id_1).await, Some(name_2.clone()));
+        let log = response.decode_logs_with_type::<SetNameEvent>().unwrap();
         let event = log.first().unwrap();
         assert_eq!(
             *event,
@@ -126,13 +106,8 @@ mod success {
 
         assert_eq!(name(&instance_1, asset_id_1).await, None);
         let response = set_name(&instance_1, asset_id_1, Some(name_1.clone())).await;
-        assert_eq!(
-            name(&instance_1, asset_id_1).await,
-            Some(name_1.clone())
-        );
-        let log = response
-            .decode_logs_with_type::<SetNameEvent>()
-            .unwrap();
+        assert_eq!(name(&instance_1, asset_id_1).await, Some(name_1.clone()));
+        let log = response.decode_logs_with_type::<SetNameEvent>().unwrap();
         let event = log.first().unwrap();
         assert_eq!(
             *event,
@@ -145,13 +120,8 @@ mod success {
 
         assert_eq!(name(&instance_1, asset_id_2).await, None);
         let response = set_name(&instance_1, asset_id_2, Some(name_2.clone())).await;
-        assert_eq!(
-            name(&instance_1, asset_id_2).await,
-            Some(name_2.clone())
-        );
-        let log = response
-            .decode_logs_with_type::<SetNameEvent>()
-            .unwrap();
+        assert_eq!(name(&instance_1, asset_id_2).await, Some(name_2.clone()));
+        let log = response.decode_logs_with_type::<SetNameEvent>().unwrap();
         let event = log.first().unwrap();
         assert_eq!(
             *event,
@@ -164,13 +134,8 @@ mod success {
 
         assert_eq!(name(&instance_1, asset_id_3).await, None);
         let response = set_name(&instance_1, asset_id_3, Some(name_3.clone())).await;
-        assert_eq!(
-            name(&instance_1, asset_id_3).await,
-            Some(name_3.clone())
-        );
-        let log = response
-            .decode_logs_with_type::<SetNameEvent>()
-            .unwrap();
+        assert_eq!(name(&instance_1, asset_id_3).await, Some(name_3.clone()));
+        let log = response.decode_logs_with_type::<SetNameEvent>().unwrap();
         let event = log.first().unwrap();
         assert_eq!(
             *event,
@@ -183,13 +148,8 @@ mod success {
 
         assert_eq!(name(&instance_1, asset_id_4).await, None);
         let response = set_name(&instance_1, asset_id_4, Some(name_4.clone())).await;
-        assert_eq!(
-            name(&instance_1, asset_id_4).await,
-            Some(name_4.clone())
-        );
-        let log = response
-            .decode_logs_with_type::<SetNameEvent>()
-            .unwrap();
+        assert_eq!(name(&instance_1, asset_id_4).await, Some(name_4.clone()));
+        let log = response.decode_logs_with_type::<SetNameEvent>().unwrap();
         let event = log.first().unwrap();
         assert_eq!(
             *event,
@@ -202,13 +162,8 @@ mod success {
 
         assert_eq!(name(&instance_1, asset_id_5).await, None);
         let response = set_name(&instance_1, asset_id_5, Some(name_5.clone())).await;
-        assert_eq!(
-            name(&instance_1, asset_id_5).await,
-            Some(name_5.clone())
-        );
-        let log = response
-            .decode_logs_with_type::<SetNameEvent>()
-            .unwrap();
+        assert_eq!(name(&instance_1, asset_id_5).await, Some(name_5.clone()));
+        let log = response.decode_logs_with_type::<SetNameEvent>().unwrap();
         let event = log.first().unwrap();
         assert_eq!(
             *event,
@@ -227,16 +182,11 @@ mod success {
             defaults(id, owner_wallet.clone(), other_wallet.clone());
         let name_1 = String::from("Fuel Asset 1");
         let name_2 = String::from("Fuel Asset 2");
-        
+
         assert_eq!(name(&instance_1, asset_id_1).await, None);
         let response = set_name(&instance_1, asset_id_1, Some(name_1.clone())).await;
-        assert_eq!(
-            name(&instance_1, asset_id_1).await,
-            Some(name_1.clone())
-        );
-        let log = response
-            .decode_logs_with_type::<SetNameEvent>()
-            .unwrap();
+        assert_eq!(name(&instance_1, asset_id_1).await, Some(name_1.clone()));
+        let log = response.decode_logs_with_type::<SetNameEvent>().unwrap();
         let event = log.first().unwrap();
         assert_eq!(
             *event,
@@ -249,9 +199,7 @@ mod success {
 
         assert_eq!(name(&instance_1, asset_id_2).await, None);
         let response = set_name(&instance_1, asset_id_2, Some(name_2.clone())).await;
-        let log = response
-            .decode_logs_with_type::<SetNameEvent>()
-            .unwrap();
+        let log = response.decode_logs_with_type::<SetNameEvent>().unwrap();
         let event = log.first().unwrap();
         assert_eq!(
             *event,
@@ -262,14 +210,8 @@ mod success {
             }
         );
 
-        assert_eq!(
-            name(&instance_1, asset_id_1).await,
-            Some(name_1)
-        );
-        assert_eq!(
-            name(&instance_1, asset_id_2).await,
-            Some(name_2)
-        );
+        assert_eq!(name(&instance_1, asset_id_1).await, Some(name_1));
+        assert_eq!(name(&instance_1, asset_id_2).await, Some(name_2));
     }
 }
 

--- a/tests/src/native_asset/tests/functions/set_symbol.rs
+++ b/tests/src/native_asset/tests/functions/set_symbol.rs
@@ -22,9 +22,7 @@ mod success {
             symbol(&instance_1, asset_id_1).await,
             Some(symbol_1.clone())
         );
-        let log = response
-            .decode_logs_with_type::<SetSymbolEvent>()
-            .unwrap();
+        let log = response.decode_logs_with_type::<SetSymbolEvent>().unwrap();
         let event = log.first().unwrap();
         assert_eq!(
             *event,
@@ -51,9 +49,7 @@ mod success {
 
         let response = set_symbol(&instance_1, asset_id_1, None).await;
         assert_eq!(symbol(&instance_1, asset_id_1).await, None);
-        let log = response
-            .decode_logs_with_type::<SetSymbolEvent>()
-            .unwrap();
+        let log = response.decode_logs_with_type::<SetSymbolEvent>().unwrap();
         let event = log.first().unwrap();
         assert_eq!(
             *event,
@@ -73,15 +69,12 @@ mod success {
         let symbol_1 = String::from("FA1");
         let symbol_2 = String::from("FA2");
 
-
         let response = set_symbol(&instance_1, asset_id_1, Some(symbol_1.clone())).await;
         assert_eq!(
             symbol(&instance_1, asset_id_1).await,
             Some(symbol_1.clone())
         );
-        let log = response
-            .decode_logs_with_type::<SetSymbolEvent>()
-            .unwrap();
+        let log = response.decode_logs_with_type::<SetSymbolEvent>().unwrap();
         let event = log.first().unwrap();
         assert_eq!(
             *event,
@@ -97,9 +90,7 @@ mod success {
             symbol(&instance_1, asset_id_1).await,
             Some(symbol_2.clone())
         );
-        let log = response
-            .decode_logs_with_type::<SetSymbolEvent>()
-            .unwrap();
+        let log = response.decode_logs_with_type::<SetSymbolEvent>().unwrap();
         let event = log.first().unwrap();
         assert_eq!(
             *event,
@@ -131,9 +122,7 @@ mod success {
             symbol(&instance_1, asset_id_1).await,
             Some(symbol_1.clone())
         );
-        let log = response
-            .decode_logs_with_type::<SetSymbolEvent>()
-            .unwrap();
+        let log = response.decode_logs_with_type::<SetSymbolEvent>().unwrap();
         let event = log.first().unwrap();
         assert_eq!(
             *event,
@@ -150,9 +139,7 @@ mod success {
             symbol(&instance_1, asset_id_2).await,
             Some(symbol_2.clone())
         );
-        let log = response
-            .decode_logs_with_type::<SetSymbolEvent>()
-            .unwrap();
+        let log = response.decode_logs_with_type::<SetSymbolEvent>().unwrap();
         let event = log.first().unwrap();
         assert_eq!(
             *event,
@@ -169,9 +156,7 @@ mod success {
             symbol(&instance_1, asset_id_3).await,
             Some(symbol_3.clone())
         );
-        let log = response
-            .decode_logs_with_type::<SetSymbolEvent>()
-            .unwrap();
+        let log = response.decode_logs_with_type::<SetSymbolEvent>().unwrap();
         let event = log.first().unwrap();
         assert_eq!(
             *event,
@@ -188,9 +173,7 @@ mod success {
             symbol(&instance_1, asset_id_4).await,
             Some(symbol_4.clone())
         );
-        let log = response
-            .decode_logs_with_type::<SetSymbolEvent>()
-            .unwrap();
+        let log = response.decode_logs_with_type::<SetSymbolEvent>().unwrap();
         let event = log.first().unwrap();
         assert_eq!(
             *event,
@@ -207,9 +190,7 @@ mod success {
             symbol(&instance_1, asset_id_5).await,
             Some(symbol_5.clone())
         );
-        let log = response
-            .decode_logs_with_type::<SetSymbolEvent>()
-            .unwrap();
+        let log = response.decode_logs_with_type::<SetSymbolEvent>().unwrap();
         let event = log.first().unwrap();
         assert_eq!(
             *event,
@@ -235,9 +216,7 @@ mod success {
             symbol(&instance_1, asset_id_1).await,
             Some(symbol_1.clone())
         );
-        let log = response
-            .decode_logs_with_type::<SetSymbolEvent>()
-            .unwrap();
+        let log = response.decode_logs_with_type::<SetSymbolEvent>().unwrap();
         let event = log.first().unwrap();
         assert_eq!(
             *event,
@@ -250,9 +229,7 @@ mod success {
 
         assert_eq!(symbol(&instance_1, asset_id_2).await, None);
         let response = set_symbol(&instance_1, asset_id_2, Some(symbol_2.clone())).await;
-        let log = response
-            .decode_logs_with_type::<SetSymbolEvent>()
-            .unwrap();
+        let log = response.decode_logs_with_type::<SetSymbolEvent>().unwrap();
         let event = log.first().unwrap();
         assert_eq!(
             *event,
@@ -263,14 +240,8 @@ mod success {
             }
         );
 
-        assert_eq!(
-            symbol(&instance_1, asset_id_1).await,
-            Some(symbol_1)
-        );
-        assert_eq!(
-            symbol(&instance_1, asset_id_2).await,
-            Some(symbol_2)
-        );
+        assert_eq!(symbol(&instance_1, asset_id_1).await, Some(symbol_1));
+        assert_eq!(symbol(&instance_1, asset_id_2).await, Some(symbol_2));
     }
 }
 

--- a/tests/src/native_asset/tests/functions/set_symbol.rs
+++ b/tests/src/native_asset/tests/functions/set_symbol.rs
@@ -1,8 +1,8 @@
 use crate::native_asset::tests::utils::{
     interface::{set_symbol, symbol},
-    setup::{defaults, get_asset_id, setup},
+    setup::{defaults, get_asset_id, setup, SetSymbolEvent},
 };
-use fuels::types::Bytes32;
+use fuels::types::{Bytes32, Identity};
 
 mod success {
 
@@ -12,14 +12,102 @@ mod success {
     async fn sets_one_asset() {
         let (owner_wallet, other_wallet, id, instance_1, _instance_2) = setup().await;
         let (asset_id_1, _asset_id_2, _sub_id_1, _sub_id_2, _identity1, _other_identity) =
-            defaults(id, owner_wallet, other_wallet.clone());
+            defaults(id, owner_wallet.clone(), other_wallet.clone());
+        let symbol_1 = String::from("FA1");
 
         assert_eq!(symbol(&instance_1, asset_id_1).await, None);
 
-        set_symbol(&instance_1, asset_id_1, String::from("FA1")).await;
+        let response = set_symbol(&instance_1, asset_id_1, Some(symbol_1.clone())).await;
         assert_eq!(
             symbol(&instance_1, asset_id_1).await,
-            Some(String::from("FA1"))
+            Some(symbol_1.clone())
+        );
+        let log = response
+            .decode_logs_with_type::<SetSymbolEvent>()
+            .unwrap();
+        let event = log.first().unwrap();
+        assert_eq!(
+            *event,
+            SetSymbolEvent {
+                asset: asset_id_1,
+                symbol: Some(symbol_1),
+                sender: Identity::Address(owner_wallet.address().into()),
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn sets_none() {
+        let (owner_wallet, other_wallet, id, instance_1, _instance_2) = setup().await;
+        let (asset_id_1, _asset_id_2, _sub_id_1, _sub_id_2, _identity1, _other_identity) =
+            defaults(id, owner_wallet.clone(), other_wallet.clone());
+        let symbol_1 = String::from("FA1");
+
+        set_symbol(&instance_1, asset_id_1, Some(symbol_1.clone())).await;
+        assert_eq!(
+            symbol(&instance_1, asset_id_1).await,
+            Some(symbol_1.clone())
+        );
+
+        let response = set_symbol(&instance_1, asset_id_1, None).await;
+        assert_eq!(symbol(&instance_1, asset_id_1).await, None);
+        let log = response
+            .decode_logs_with_type::<SetSymbolEvent>()
+            .unwrap();
+        let event = log.first().unwrap();
+        assert_eq!(
+            *event,
+            SetSymbolEvent {
+                asset: asset_id_1,
+                symbol: None,
+                sender: Identity::Address(owner_wallet.address().into()),
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn sets_symbol_twice() {
+        let (owner_wallet, other_wallet, id, instance_1, _instance_2) = setup().await;
+        let (asset_id_1, _asset_id_2, _sub_id_1, _sub_id_2, _identity1, _other_identity) =
+            defaults(id, owner_wallet.clone(), other_wallet.clone());
+        let symbol_1 = String::from("FA1");
+        let symbol_2 = String::from("FA2");
+
+
+        let response = set_symbol(&instance_1, asset_id_1, Some(symbol_1.clone())).await;
+        assert_eq!(
+            symbol(&instance_1, asset_id_1).await,
+            Some(symbol_1.clone())
+        );
+        let log = response
+            .decode_logs_with_type::<SetSymbolEvent>()
+            .unwrap();
+        let event = log.first().unwrap();
+        assert_eq!(
+            *event,
+            SetSymbolEvent {
+                asset: asset_id_1,
+                symbol: Some(symbol_1),
+                sender: Identity::Address(owner_wallet.address().into()),
+            }
+        );
+
+        let response = set_symbol(&instance_1, asset_id_1, Some(symbol_2.clone())).await;
+        assert_eq!(
+            symbol(&instance_1, asset_id_1).await,
+            Some(symbol_2.clone())
+        );
+        let log = response
+            .decode_logs_with_type::<SetSymbolEvent>()
+            .unwrap();
+        let event = log.first().unwrap();
+        assert_eq!(
+            *event,
+            SetSymbolEvent {
+                asset: asset_id_1,
+                symbol: Some(symbol_2),
+                sender: Identity::Address(owner_wallet.address().into()),
+            }
         );
     }
 
@@ -27,70 +115,177 @@ mod success {
     async fn sets_multiple_assets() {
         let (owner_wallet, other_wallet, id, instance_1, _instance_2) = setup().await;
         let (asset_id_1, asset_id_2, _sub_id_1, _sub_id_2, _identity1, _other_identity) =
-            defaults(id, owner_wallet, other_wallet.clone());
+            defaults(id, owner_wallet.clone(), other_wallet.clone());
+        let symbol_1 = String::from("FA1");
+        let symbol_2 = String::from("FA2");
+        let symbol_3 = String::from("FA1FA1FA1FA1FA1FA1FA1FA1FA1FA1FA1FA1FA1FA1FA1FA1FA1FA1FA1FA1FA1FA1FA1FA1FA1FA1FA1FA1FA1FA1FA1FA1FA1FA1FA1FA1FA1FA1FA1FA1FA1FA1FA1FA1FA1FA1FA1FA1FA1FA1FA1FA1FA1FA1FA1FA1FA1FA1FA1FA1FA1");
+        let symbol_4 = String::from("F");
+        let symbol_5 = String::from("FA1");
+        let asset_id_3 = get_asset_id(Bytes32::from([3u8; 32]), id);
+        let asset_id_4 = get_asset_id(Bytes32::from([4u8; 32]), id);
+        let asset_id_5 = get_asset_id(Bytes32::from([5u8; 32]), id);
 
         assert_eq!(symbol(&instance_1, asset_id_1).await, None);
-        set_symbol(&instance_1, asset_id_1, String::from("FA1")).await;
+        let response = set_symbol(&instance_1, asset_id_1, Some(symbol_1.clone())).await;
         assert_eq!(
             symbol(&instance_1, asset_id_1).await,
-            Some(String::from("FA1"))
+            Some(symbol_1.clone())
+        );
+        let log = response
+            .decode_logs_with_type::<SetSymbolEvent>()
+            .unwrap();
+        let event = log.first().unwrap();
+        assert_eq!(
+            *event,
+            SetSymbolEvent {
+                asset: asset_id_1,
+                symbol: Some(symbol_1),
+                sender: Identity::Address(owner_wallet.address().into()),
+            }
         );
 
         assert_eq!(symbol(&instance_1, asset_id_2).await, None);
-        set_symbol(&instance_1, asset_id_2, String::from("FA2")).await;
+        let response = set_symbol(&instance_1, asset_id_2, Some(symbol_2.clone())).await;
         assert_eq!(
             symbol(&instance_1, asset_id_2).await,
-            Some(String::from("FA2"))
+            Some(symbol_2.clone())
+        );
+        let log = response
+            .decode_logs_with_type::<SetSymbolEvent>()
+            .unwrap();
+        let event = log.first().unwrap();
+        assert_eq!(
+            *event,
+            SetSymbolEvent {
+                asset: asset_id_2,
+                symbol: Some(symbol_2),
+                sender: Identity::Address(owner_wallet.address().into()),
+            }
         );
 
-        let asset_id_3 = get_asset_id(Bytes32::from([3u8; 32]), id);
         assert_eq!(symbol(&instance_1, asset_id_3).await, None);
-        set_symbol(&instance_1, asset_id_3, String::from("FA3")).await;
+        let response = set_symbol(&instance_1, asset_id_3, Some(symbol_3.clone())).await;
         assert_eq!(
             symbol(&instance_1, asset_id_3).await,
-            Some(String::from("FA3"))
+            Some(symbol_3.clone())
+        );
+        let log = response
+            .decode_logs_with_type::<SetSymbolEvent>()
+            .unwrap();
+        let event = log.first().unwrap();
+        assert_eq!(
+            *event,
+            SetSymbolEvent {
+                asset: asset_id_3,
+                symbol: Some(symbol_3),
+                sender: Identity::Address(owner_wallet.address().into()),
+            }
         );
 
-        let asset_id_4 = get_asset_id(Bytes32::from([4u8; 32]), id);
         assert_eq!(symbol(&instance_1, asset_id_4).await, None);
-        set_symbol(&instance_1, asset_id_4, String::from("FA4")).await;
+        let response = set_symbol(&instance_1, asset_id_4, Some(symbol_4.clone())).await;
         assert_eq!(
             symbol(&instance_1, asset_id_4).await,
-            Some(String::from("FA4"))
+            Some(symbol_4.clone())
+        );
+        let log = response
+            .decode_logs_with_type::<SetSymbolEvent>()
+            .unwrap();
+        let event = log.first().unwrap();
+        assert_eq!(
+            *event,
+            SetSymbolEvent {
+                asset: asset_id_4,
+                symbol: Some(symbol_4),
+                sender: Identity::Address(owner_wallet.address().into()),
+            }
         );
 
-        let asset_id_5 = get_asset_id(Bytes32::from([5u8; 32]), id);
         assert_eq!(symbol(&instance_1, asset_id_5).await, None);
-        set_symbol(&instance_1, asset_id_5, String::from("FA5")).await;
+        let response = set_symbol(&instance_1, asset_id_5, Some(symbol_5.clone())).await;
         assert_eq!(
             symbol(&instance_1, asset_id_5).await,
-            Some(String::from("FA5"))
+            Some(symbol_5.clone())
+        );
+        let log = response
+            .decode_logs_with_type::<SetSymbolEvent>()
+            .unwrap();
+        let event = log.first().unwrap();
+        assert_eq!(
+            *event,
+            SetSymbolEvent {
+                asset: asset_id_5,
+                symbol: Some(symbol_5),
+                sender: Identity::Address(owner_wallet.address().into()),
+            }
         );
     }
 
     #[tokio::test]
-    async fn does_not_overwrite_other_symbols() {
+    async fn does_not_overwrite_other_assets() {
         let (owner_wallet, other_wallet, id, instance_1, _instance_2) = setup().await;
         let (asset_id_1, asset_id_2, _sub_id_1, _sub_id_2, _identity1, _other_identity) =
-            defaults(id, owner_wallet, other_wallet.clone());
+            defaults(id, owner_wallet.clone(), other_wallet.clone());
+        let symbol_1 = String::from("FA1");
+        let symbol_2 = String::from("FA2");
 
         assert_eq!(symbol(&instance_1, asset_id_1).await, None);
-        set_symbol(&instance_1, asset_id_1, String::from("FA1")).await;
+        let response = set_symbol(&instance_1, asset_id_1, Some(symbol_1.clone())).await;
         assert_eq!(
             symbol(&instance_1, asset_id_1).await,
-            Some(String::from("FA1"))
+            Some(symbol_1.clone())
+        );
+        let log = response
+            .decode_logs_with_type::<SetSymbolEvent>()
+            .unwrap();
+        let event = log.first().unwrap();
+        assert_eq!(
+            *event,
+            SetSymbolEvent {
+                asset: asset_id_1,
+                symbol: Some(symbol_1.clone()),
+                sender: Identity::Address(owner_wallet.address().into()),
+            }
         );
 
         assert_eq!(symbol(&instance_1, asset_id_2).await, None);
-        set_symbol(&instance_1, asset_id_2, String::from("FA2")).await;
+        let response = set_symbol(&instance_1, asset_id_2, Some(symbol_2.clone())).await;
+        let log = response
+            .decode_logs_with_type::<SetSymbolEvent>()
+            .unwrap();
+        let event = log.first().unwrap();
+        assert_eq!(
+            *event,
+            SetSymbolEvent {
+                asset: asset_id_2,
+                symbol: Some(symbol_2.clone()),
+                sender: Identity::Address(owner_wallet.address().into()),
+            }
+        );
 
         assert_eq!(
             symbol(&instance_1, asset_id_1).await,
-            Some(String::from("FA1"))
+            Some(symbol_1)
         );
         assert_eq!(
             symbol(&instance_1, asset_id_2).await,
-            Some(String::from("FA2"))
+            Some(symbol_2)
         );
+    }
+}
+
+mod revert {
+
+    use super::*;
+
+    #[tokio::test]
+    #[should_panic(expected = "EmptyString")]
+    async fn when_empty_string() {
+        let (owner_wallet, other_wallet, id, instance_1, _instance_2) = setup().await;
+        let (asset_id_1, _asset_id_2, _sub_id_1, _sub_id_2, _identity1, _other_identity) =
+            defaults(id, owner_wallet, other_wallet);
+        let symbol_1 = String::from("");
+
+        set_symbol(&instance_1, asset_id_1, Some(symbol_1)).await;
     }
 }

--- a/tests/src/native_asset/tests/functions/symbol.rs
+++ b/tests/src/native_asset/tests/functions/symbol.rs
@@ -26,12 +26,8 @@ mod success {
 
         assert_eq!(symbol(&instance_1, asset_id_1).await, None);
 
-
         set_symbol(&instance_1, asset_id_1, Some(symbol_1.clone())).await;
-        assert_eq!(
-            symbol(&instance_1, asset_id_1).await,
-            Some(symbol_1)
-        );
+        assert_eq!(symbol(&instance_1, asset_id_1).await, Some(symbol_1));
     }
 
     #[tokio::test]
@@ -60,25 +56,10 @@ mod success {
         set_symbol(&instance_1, asset_id_4, Some(symbol_4.clone())).await;
         set_symbol(&instance_1, asset_id_5, Some(symbol_5.clone())).await;
 
-        assert_eq!(
-            symbol(&instance_1, asset_id_1).await,
-            Some(symbol_1)
-        );
-        assert_eq!(
-            symbol(&instance_1, asset_id_2).await,
-            Some(symbol_2)
-        );
-        assert_eq!(
-            symbol(&instance_1, asset_id_3).await,
-            Some(symbol_3)
-        );
-        assert_eq!(
-            symbol(&instance_1, asset_id_4).await,
-            Some(symbol_4)
-        );
-        assert_eq!(
-            symbol(&instance_1, asset_id_5).await,
-            Some(symbol_5)
-        );
+        assert_eq!(symbol(&instance_1, asset_id_1).await, Some(symbol_1));
+        assert_eq!(symbol(&instance_1, asset_id_2).await, Some(symbol_2));
+        assert_eq!(symbol(&instance_1, asset_id_3).await, Some(symbol_3));
+        assert_eq!(symbol(&instance_1, asset_id_4).await, Some(symbol_4));
+        assert_eq!(symbol(&instance_1, asset_id_5).await, Some(symbol_5));
     }
 }

--- a/tests/src/native_asset/tests/functions/symbol.rs
+++ b/tests/src/native_asset/tests/functions/symbol.rs
@@ -9,88 +9,76 @@ mod success {
     use super::*;
 
     #[tokio::test]
-    async fn one_asset() {
+    async fn get_none_symbol() {
         let (owner_wallet, other_wallet, id, instance_1, _instance_2) = setup().await;
         let (asset_id_1, _asset_id_2, _sub_id_1, _sub_id_2, _identity1, _other_identity) =
             defaults(id, owner_wallet, other_wallet.clone());
 
         assert_eq!(symbol(&instance_1, asset_id_1).await, None);
+    }
 
-        set_symbol(&instance_1, asset_id_1, String::from("FA1")).await;
+    #[tokio::test]
+    async fn get_one_asset_symbol() {
+        let (owner_wallet, other_wallet, id, instance_1, _instance_2) = setup().await;
+        let (asset_id_1, _asset_id_2, _sub_id_1, _sub_id_2, _identity1, _other_identity) =
+            defaults(id, owner_wallet, other_wallet.clone());
+        let symbol_1 = String::from("FA1");
+
+        assert_eq!(symbol(&instance_1, asset_id_1).await, None);
+
+
+        set_symbol(&instance_1, asset_id_1, Some(symbol_1.clone())).await;
         assert_eq!(
             symbol(&instance_1, asset_id_1).await,
-            Some(String::from("FA1"))
+            Some(symbol_1)
         );
     }
 
     #[tokio::test]
-    async fn multiple_assets() {
+    async fn get_multiple_assets_symbols() {
         let (owner_wallet, other_wallet, id, instance_1, _instance_2) = setup().await;
         let (asset_id_1, asset_id_2, _sub_id_1, _sub_id_2, _identity1, _other_identity) =
             defaults(id, owner_wallet, other_wallet.clone());
+        let symbol_1 = String::from("FA1");
+        let symbol_2 = String::from("FA2");
+        let symbol_3 = String::from("FA1FA1FA1FA1FA1FA1FA1FA1FA1FA1FA1FA1FA1FA1FA1FA1FA1FA1FA1FA1FA1FA1FA1FA1FA1FA1FA1FA1FA1FA1FA1FA1FA1FA1FA1FA1FA1FA1FA1FA1FA1FA1FA1FA1FA1FA1FA1FA1FA1FA1FA1FA1FA1FA1FA1FA1FA1FA1FA1FA1FA1");
+        let symbol_4 = String::from("F");
+        let symbol_5 = String::from("FA1");
+        let asset_id_3 = get_asset_id(Bytes32::from([3u8; 32]), id);
+        let asset_id_4 = get_asset_id(Bytes32::from([4u8; 32]), id);
+        let asset_id_5 = get_asset_id(Bytes32::from([5u8; 32]), id);
 
         assert_eq!(symbol(&instance_1, asset_id_1).await, None);
-        set_symbol(&instance_1, asset_id_1, String::from("FA1")).await;
+        assert_eq!(symbol(&instance_1, asset_id_2).await, None);
+        assert_eq!(symbol(&instance_1, asset_id_3).await, None);
+        assert_eq!(symbol(&instance_1, asset_id_4).await, None);
+        assert_eq!(symbol(&instance_1, asset_id_5).await, None);
+
+        set_symbol(&instance_1, asset_id_1, Some(symbol_1.clone())).await;
+        set_symbol(&instance_1, asset_id_2, Some(symbol_2.clone())).await;
+        set_symbol(&instance_1, asset_id_3, Some(symbol_3.clone())).await;
+        set_symbol(&instance_1, asset_id_4, Some(symbol_4.clone())).await;
+        set_symbol(&instance_1, asset_id_5, Some(symbol_5.clone())).await;
+
         assert_eq!(
             symbol(&instance_1, asset_id_1).await,
-            Some(String::from("FA1"))
+            Some(symbol_1)
         );
-
-        assert_eq!(symbol(&instance_1, asset_id_2).await, None);
-        set_symbol(&instance_1, asset_id_2, String::from("FA2")).await;
         assert_eq!(
             symbol(&instance_1, asset_id_2).await,
-            Some(String::from("FA2"))
+            Some(symbol_2)
         );
-
-        let asset_id_3 = get_asset_id(Bytes32::from([3u8; 32]), id);
-        assert_eq!(symbol(&instance_1, asset_id_3).await, None);
-        set_symbol(&instance_1, asset_id_3, String::from("FA3")).await;
         assert_eq!(
             symbol(&instance_1, asset_id_3).await,
-            Some(String::from("FA3"))
+            Some(symbol_3)
         );
-
-        let asset_id_4 = get_asset_id(Bytes32::from([4u8; 32]), id);
-        assert_eq!(symbol(&instance_1, asset_id_4).await, None);
-        set_symbol(&instance_1, asset_id_4, String::from("FA4")).await;
         assert_eq!(
             symbol(&instance_1, asset_id_4).await,
-            Some(String::from("FA4"))
+            Some(symbol_4)
         );
-
-        let asset_id_5 = get_asset_id(Bytes32::from([5u8; 32]), id);
-        assert_eq!(symbol(&instance_1, asset_id_5).await, None);
-        set_symbol(&instance_1, asset_id_5, String::from("FA5")).await;
         assert_eq!(
             symbol(&instance_1, asset_id_5).await,
-            Some(String::from("FA5"))
-        );
-    }
-
-    #[tokio::test]
-    async fn does_not_overwrite_other_symbols() {
-        let (owner_wallet, other_wallet, id, instance_1, _instance_2) = setup().await;
-        let (asset_id_1, asset_id_2, _sub_id_1, _sub_id_2, _identity1, _other_identity) =
-            defaults(id, owner_wallet, other_wallet.clone());
-
-        assert_eq!(symbol(&instance_1, asset_id_1).await, None);
-        set_symbol(&instance_1, asset_id_1, String::from("FA1")).await;
-        assert_eq!(
-            symbol(&instance_1, asset_id_1).await,
-            Some(String::from("FA1"))
-        );
-
-        assert_eq!(symbol(&instance_1, asset_id_2).await, None);
-        set_symbol(&instance_1, asset_id_2, String::from("FA2")).await;
-
-        assert_eq!(
-            symbol(&instance_1, asset_id_1).await,
-            Some(String::from("FA1"))
-        );
-        assert_eq!(
-            symbol(&instance_1, asset_id_2).await,
-            Some(String::from("FA2"))
+            Some(symbol_5)
         );
     }
 }

--- a/tests/src/native_asset/tests/functions/total_assets.rs
+++ b/tests/src/native_asset/tests/functions/total_assets.rs
@@ -16,7 +16,7 @@ mod success {
 
         assert_eq!(total_assets(&instance_1).await, 0);
 
-        mint(&instance_1, identity2, sub_id_1, 100).await;
+        mint(&instance_1, identity2, Some(sub_id_1), 100).await;
         assert_eq!(total_assets(&instance_1).await, 1);
     }
 
@@ -28,19 +28,19 @@ mod success {
 
         assert_eq!(total_assets(&instance_1).await, 0);
 
-        mint(&instance_1, identity2.clone(), sub_id_1, 100).await;
+        mint(&instance_1, identity2.clone(), Some(sub_id_1), 100).await;
         assert_eq!(total_assets(&instance_1).await, 1);
 
-        mint(&instance_1, identity2.clone(), sub_id_2, 200).await;
+        mint(&instance_1, identity2.clone(), Some(sub_id_2), 200).await;
         assert_eq!(total_assets(&instance_1).await, 2);
 
-        mint(&instance_1, identity2.clone(), Bits256([3u8; 32]), 300).await;
+        mint(&instance_1, identity2.clone(), Some(Bits256([3u8; 32])), 300).await;
         assert_eq!(total_assets(&instance_1).await, 3);
 
-        mint(&instance_1, identity2.clone(), Bits256([4u8; 32]), 400).await;
+        mint(&instance_1, identity2.clone(), Some(Bits256([4u8; 32])), 400).await;
         assert_eq!(total_assets(&instance_1).await, 4);
 
-        mint(&instance_1, identity2, Bits256([5u8; 32]), 200).await;
+        mint(&instance_1, identity2, Some(Bits256([5u8; 32])), 200).await;
         assert_eq!(total_assets(&instance_1).await, 5);
     }
 
@@ -52,13 +52,13 @@ mod success {
 
         assert_eq!(total_assets(&instance_1).await, 0);
 
-        mint(&instance_1, identity2.clone(), sub_id_1, 100).await;
+        mint(&instance_1, identity2.clone(), Some(sub_id_1), 100).await;
         assert_eq!(total_assets(&instance_1).await, 1);
 
-        mint(&instance_1, identity2.clone(), sub_id_1, 100).await;
+        mint(&instance_1, identity2.clone(), Some(sub_id_1), 100).await;
         assert_eq!(total_assets(&instance_1).await, 1);
 
-        mint(&instance_1, identity2.clone(), sub_id_1, 100).await;
+        mint(&instance_1, identity2.clone(), Some(sub_id_1), 100).await;
         assert_eq!(total_assets(&instance_1).await, 1);
     }
 }

--- a/tests/src/native_asset/tests/functions/total_assets.rs
+++ b/tests/src/native_asset/tests/functions/total_assets.rs
@@ -34,10 +34,22 @@ mod success {
         mint(&instance_1, identity2.clone(), Some(sub_id_2), 200).await;
         assert_eq!(total_assets(&instance_1).await, 2);
 
-        mint(&instance_1, identity2.clone(), Some(Bits256([3u8; 32])), 300).await;
+        mint(
+            &instance_1,
+            identity2.clone(),
+            Some(Bits256([3u8; 32])),
+            300,
+        )
+        .await;
         assert_eq!(total_assets(&instance_1).await, 3);
 
-        mint(&instance_1, identity2.clone(), Some(Bits256([4u8; 32])), 400).await;
+        mint(
+            &instance_1,
+            identity2.clone(),
+            Some(Bits256([4u8; 32])),
+            400,
+        )
+        .await;
         assert_eq!(total_assets(&instance_1).await, 4);
 
         mint(&instance_1, identity2, Some(Bits256([5u8; 32])), 200).await;

--- a/tests/src/native_asset/tests/functions/total_supply.rs
+++ b/tests/src/native_asset/tests/functions/total_supply.rs
@@ -35,12 +35,24 @@ mod success {
 
         let asset_id_3 = get_asset_id(Bytes32::from([3u8; 32]), id);
         assert_eq!(total_supply(&instance_1, asset_id_3).await, None);
-        mint(&instance_1, identity2.clone(), Some(Bits256([3u8; 32])), 300).await;
+        mint(
+            &instance_1,
+            identity2.clone(),
+            Some(Bits256([3u8; 32])),
+            300,
+        )
+        .await;
         assert_eq!(total_supply(&instance_1, asset_id_3).await, Some(300));
 
         let asset_id_4 = get_asset_id(Bytes32::from([4u8; 32]), id);
         assert_eq!(total_supply(&instance_1, asset_id_4).await, None);
-        mint(&instance_1, identity2.clone(), Some(Bits256([4u8; 32])), 400).await;
+        mint(
+            &instance_1,
+            identity2.clone(),
+            Some(Bits256([4u8; 32])),
+            400,
+        )
+        .await;
         assert_eq!(total_supply(&instance_1, asset_id_4).await, Some(400));
 
         let asset_id_5 = get_asset_id(Bytes32::from([5u8; 32]), id);

--- a/tests/src/native_asset/tests/functions/total_supply.rs
+++ b/tests/src/native_asset/tests/functions/total_supply.rs
@@ -15,7 +15,7 @@ mod success {
             defaults(id, owner_wallet, other_wallet.clone());
 
         assert_eq!(total_supply(&instance_1, asset_id_1).await, None);
-        mint(&instance_1, identity2, sub_id_1, 100).await;
+        mint(&instance_1, identity2, Some(sub_id_1), 100).await;
         assert_eq!(total_supply(&instance_1, asset_id_1).await, Some(100));
     }
 
@@ -26,26 +26,26 @@ mod success {
             defaults(id, owner_wallet, other_wallet.clone());
 
         assert_eq!(total_supply(&instance_1, asset_id_1).await, None);
-        mint(&instance_1, identity2.clone(), sub_id_1, 100).await;
+        mint(&instance_1, identity2.clone(), Some(sub_id_1), 100).await;
         assert_eq!(total_supply(&instance_1, asset_id_1).await, Some(100));
 
         assert_eq!(total_supply(&instance_1, asset_id_2).await, None);
-        mint(&instance_1, identity2.clone(), sub_id_2, 200).await;
+        mint(&instance_1, identity2.clone(), Some(sub_id_2), 200).await;
         assert_eq!(total_supply(&instance_1, asset_id_2).await, Some(200));
 
         let asset_id_3 = get_asset_id(Bytes32::from([3u8; 32]), id);
         assert_eq!(total_supply(&instance_1, asset_id_3).await, None);
-        mint(&instance_1, identity2.clone(), Bits256([3u8; 32]), 300).await;
+        mint(&instance_1, identity2.clone(), Some(Bits256([3u8; 32])), 300).await;
         assert_eq!(total_supply(&instance_1, asset_id_3).await, Some(300));
 
         let asset_id_4 = get_asset_id(Bytes32::from([4u8; 32]), id);
         assert_eq!(total_supply(&instance_1, asset_id_4).await, None);
-        mint(&instance_1, identity2.clone(), Bits256([4u8; 32]), 400).await;
+        mint(&instance_1, identity2.clone(), Some(Bits256([4u8; 32])), 400).await;
         assert_eq!(total_supply(&instance_1, asset_id_4).await, Some(400));
 
         let asset_id_5 = get_asset_id(Bytes32::from([5u8; 32]), id);
         assert_eq!(total_supply(&instance_1, asset_id_5).await, None);
-        mint(&instance_1, identity2, Bits256([5u8; 32]), 500).await;
+        mint(&instance_1, identity2, Some(Bits256([5u8; 32])), 500).await;
         assert_eq!(total_supply(&instance_1, asset_id_5).await, Some(500));
     }
 
@@ -56,13 +56,13 @@ mod success {
             defaults(id, owner_wallet, other_wallet.clone());
 
         assert_eq!(total_supply(&instance_1, asset_id_1).await, None);
-        mint(&instance_1, identity2.clone(), sub_id_1, 100).await;
+        mint(&instance_1, identity2.clone(), Some(sub_id_1), 100).await;
         assert_eq!(total_supply(&instance_1, asset_id_1).await, Some(100));
 
-        mint(&instance_1, identity2.clone(), sub_id_2, 200).await;
+        mint(&instance_1, identity2.clone(), Some(sub_id_2), 200).await;
         assert_eq!(total_supply(&instance_1, asset_id_1).await, Some(100));
 
-        mint(&instance_1, identity2.clone(), sub_id_2, 300).await;
+        mint(&instance_1, identity2.clone(), Some(sub_id_2), 300).await;
         assert_eq!(total_supply(&instance_1, asset_id_1).await, Some(100));
     }
 
@@ -73,7 +73,7 @@ mod success {
             defaults(id, owner_wallet, other_wallet.clone());
 
         assert_eq!(total_supply(&instance_1, asset_id_1).await, None);
-        mint(&instance_1, identity2.clone(), sub_id_1, 100).await;
+        mint(&instance_1, identity2.clone(), Some(sub_id_1), 100).await;
         assert_eq!(total_supply(&instance_1, asset_id_1).await, Some(100));
 
         burn(&instance_2, asset_id_1, sub_id_1, 50).await;

--- a/tests/src/native_asset/tests/utils/interface.rs
+++ b/tests/src/native_asset/tests/utils/interface.rs
@@ -49,7 +49,7 @@ pub(crate) async fn decimals(contract: &AssetLib<WalletUnlocked>, asset: AssetId
 pub(crate) async fn mint(
     contract: &AssetLib<WalletUnlocked>,
     recipient: Identity,
-    sub_id: Bits256,
+    sub_id: Option<Bits256>,
     amount: u64,
 ) -> FuelCallResponse<()> {
     contract
@@ -83,7 +83,7 @@ pub(crate) async fn burn(
 pub(crate) async fn set_name(
     contract: &AssetLib<WalletUnlocked>,
     asset: AssetId,
-    name: String,
+    name: Option<String>,
 ) -> FuelCallResponse<()> {
     contract
         .methods()
@@ -96,7 +96,7 @@ pub(crate) async fn set_name(
 pub(crate) async fn set_symbol(
     contract: &AssetLib<WalletUnlocked>,
     asset: AssetId,
-    name: String,
+    name: Option<String>,
 ) -> FuelCallResponse<()> {
     contract
         .methods()
@@ -137,11 +137,11 @@ pub(crate) async fn set_metadata(
     contract: &AssetLib<WalletUnlocked>,
     asset: AssetId,
     key: String,
-    metadata: Metadata,
+    metadata: Option<Metadata>,
 ) -> FuelCallResponse<()> {
     contract
         .methods()
-        .set_metadata(asset, key, metadata)
+        .set_metadata(asset, metadata, key)
         .call()
         .await
         .unwrap()

--- a/tests/src/ownership/Forc.toml
+++ b/tests/src/ownership/Forc.toml
@@ -5,5 +5,5 @@ license = "Apache-2.0"
 name = "ownership_test"
 
 [dependencies]
-standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.5.2" }
+standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.6.0" }
 sway_libs = { path = "../../../libs" }

--- a/tests/src/upgradability/Forc.toml
+++ b/tests/src/upgradability/Forc.toml
@@ -5,5 +5,5 @@ license = "Apache-2.0"
 name = "upgradability_test"
 
 [dependencies]
-standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.5.2" }
+standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.6.0" }
 sway_libs = { path = "../../../libs" }


### PR DESCRIPTION
## Type of change

<!--Delete points that do not apply-->

- Breaking
- New feature
- Improvement (refactoring, restructuring repository, cleaning tech debt, ...)

## Breaking

The following breaking changes have been made:

1. The support functions for `Metadata` have been removed. They have been moved to sway-standards.

Before:

```sway
use sway_libs::asset::metadata::*;

fn foo(my_metadata: Metadata) {
     let res: bool = my_metadata.is_b256(); 
     let res: bool = my_metadata.is_string(); 
     let res: bool = my_metadata.is_bytes(); 
     let res: bool = my_metadata.is_uint();
}
```

After: 

```sway
use standards::src7::*;

fn foo(my_metadata: Metadata) {
     let res: bool = my_metadata.is_b256(); 
     let res: bool = my_metadata.is_string(); 
     let res: bool = my_metadata.is_bytes(); 
     let res: bool = my_metadata.is_uint();
}
```

2. The `SetMetadata` and `_set_metadata` function definitions have changed. The `metadata` argument is now an `Option<Metadata>` and the argument order has changed.

Before:

```sway
impl SetAssetMetadata for Contract {
    #[storage(read, write)]
    fn set_metadata(asset: AssetId, key: String, metadata: Metadata) {
        _set_metadata(storage.metadata, asset, key, metadata);
    }
}
```

After:

```sway
impl SetAssetMetadata for Contract {
    #[storage(read, write)]
    fn set_metadata(asset: AssetId, metadata: Option<Metadata>, key: String) {
        _set_metadata(storage.metadata, asset, metadata, key);
    }
}
```

3. The `_set_name()` function's `name` argument is now an `Option<String>`

Before: 

```sway
fn foo(asset: AssetId) {
    _set_name(storage.name, asset, String::from_ascii_str("Ether"));
}
```

After: 

```sway
fn foo(asset: AssetId) {
    _set_name(storage.name, asset, Some(String::from_ascii_str("Ether")));
}
```

3. The `_set_symbol()` function's `name` argument is now an `Option<String>`

Before: 

```sway
fn foo(asset: AssetId) {
    _set_symbol(storage.name, asset, String::from_ascii_str("ETH"));
}
```

After: 

```sway
fn foo(asset: AssetId) {
    _set_symbol(storage.name, asset, Some(String::from_ascii_str("ETH")));
}
```

4. The `_mint()` function's `sub_id` argument is now an `Option<SubId>`

Before:

```sway
fn foo(recipient: Identity, amount: u64) {
    let asset_id = _mint(storage.total_assets, storage.total_supply, recipient, SubId::zero(), amount);
}
```

After:

```sway
fn foo(recipient: Identity, amount: u64) {
    let asset_id = _mint(storage.total_assets, storage.total_supply, recipient, Some(SubId::zero()), amount);
}
```

## Changes

The following changes have been made:

- Updated all `Forc.toml` files to use sway-standards `v0.6.0`
- Updated docs to mention logging
- Removed `Metadata` convenience functions
- The `_metadata()` function has been added
- The `_set_metadata()` function's `metadata` argument is now an `Option<Metadata>` and the argument order has changed
- The `SetMetadata` abi's `set_metadata()` `metadata` argument is now an `Option<Metadata>` and the argument order has changed
- `_set_metadata()` now reverts if the metadata is an empty string
- `_set_metadata()` now reverts if the metadata are empty bytes
- The `_set_name()` function's `name` argument is now an `Option<String>`
- `_set_name()` now reverts if the `name` argument is an empty string
- The `_set_symbol()` function's `name` argument is now an `Option<String>`
- `_set_symbol()` now reverts if the `symbol` argument is an empty string
- The `_mint()` function's `sub_id` argument is now an `Option<SubId>`
- `_mint()` now reverts if the `amount` argument is zero
- `_burn()` now reverts if the `amount` argument is zero
- Test edge cases for `_mint()` have been added
- Test edge cases for `_burn()` have been added
- Test edge cases for `_set_name()` have been added
- Test edge cases for `_set_symbol()` have been added
- Test edge cases for `_set_decimals()` have been added

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
- [x] I have updated the changelog to reflect the changes on this PR.
