### PR TITLE
Add fallback tests to reentrancy guard library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,7 @@ Description of the upcoming release here.
 
 ### Added
 
-- Something new here 1
-- Something new here 2
+- [#309](https://github.com/FuelLabs/sway-libs/pull/309) Adds fallback function test cases to the Reentrancy Guard Library.
 
 ### Changed
 

--- a/tests/Forc.lock
+++ b/tests/Forc.lock
@@ -184,6 +184,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "reentrancy_fallback_abi"
+source = "path+from-root-F53252C7DB7025EE"
+dependencies = ["std"]
+
+[[package]]
 name = "reentrancy_target_abi"
 source = "member"
 dependencies = ["std"]
@@ -193,6 +198,7 @@ name = "reentrancy_target_contract"
 source = "member"
 dependencies = [
     "reentrancy_attacker_abi",
+    "reentrancy_fallback_abi",
     "reentrancy_target_abi",
     "std",
     "sway_libs",

--- a/tests/src/reentrancy/mod.rs
+++ b/tests/src/reentrancy/mod.rs
@@ -161,4 +161,20 @@ mod revert {
             .await
             .unwrap();
     }
+
+    #[tokio::test]
+    #[should_panic(expected = "NonReentrant")]
+    async fn can_block_fallback_reentrancy() {
+        let wallet = launch_provider_and_get_wallet().await.unwrap();
+        let (attacker_instance, _) = get_attacker_instance(wallet.clone()).await;
+        let (instance, target_id) = get_target_instance(wallet).await;
+
+        attacker_instance
+            .methods()
+            .launch_thwarted_attack_4(target_id)
+            .with_contracts(&[&instance])
+            .call()
+            .await
+            .unwrap();
+    }
 }

--- a/tests/src/reentrancy/reentrancy_attack_fallback_abi/Forc.toml
+++ b/tests/src/reentrancy/reentrancy_attack_fallback_abi/Forc.toml
@@ -1,0 +1,7 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "reentrancy_fallback_abi"
+
+[dependencies]

--- a/tests/src/reentrancy/reentrancy_attack_fallback_abi/src/main.sw
+++ b/tests/src/reentrancy/reentrancy_attack_fallback_abi/src/main.sw
@@ -1,0 +1,5 @@
+library;
+
+abi FallbackAttack {
+    fn nonexistant_function(contract_id: ContractId);
+}

--- a/tests/src/reentrancy/reentrancy_attacker_abi/src/main.sw
+++ b/tests/src/reentrancy/reentrancy_attacker_abi/src/main.sw
@@ -6,6 +6,7 @@ abi Attacker {
     fn launch_thwarted_attack_2(target: ContractId);
     #[storage(write)]
     fn launch_thwarted_attack_3(target: ContractId, helper: ContractId);
+    fn launch_thwarted_attack_4(target: ContractId);
     fn innocent_call(target: ContractId);
     fn evil_callback_1() -> bool;
     fn evil_callback_2();

--- a/tests/src/reentrancy/reentrancy_attacker_contract/src/main.sw
+++ b/tests/src/reentrancy/reentrancy_attacker_contract/src/main.sw
@@ -1,6 +1,9 @@
 contract;
 
-use std::auth::*;
+use std::{
+    auth::*,
+    call_frames::*,
+};
 
 use reentrancy_target_abi::Target;
 use reentrancy_attacker_abi::Attacker;
@@ -41,6 +44,10 @@ impl Attacker for Contract {
             .cross_contract_reentrancy_denied();
     }
 
+    fn launch_thwarted_attack_4(target: ContractId) {
+        abi(Target, target.bits()).fallback_contract_call();
+    }
+
     fn innocent_call(target: ContractId) {
         abi(Target, target.bits()).guarded_function_is_callable();
     }
@@ -70,4 +77,12 @@ impl Attacker for Contract {
     }
 
     fn innocent_callback() {}
+}
+
+#[fallback]
+fn fallback() {
+    let call_args = called_args::<ContractId>();
+
+    let target_abi = abi(Target, call_args.bits());
+    target_abi.fallback_contract_call();
 }

--- a/tests/src/reentrancy/reentrancy_attacker_contract/src/main.sw
+++ b/tests/src/reentrancy/reentrancy_attacker_contract/src/main.sw
@@ -1,9 +1,6 @@
 contract;
 
-use std::{
-    auth::*,
-    call_frames::*,
-};
+use std::{auth::*, call_frames::*,};
 
 use reentrancy_target_abi::Target;
 use reentrancy_attacker_abi::Attacker;

--- a/tests/src/reentrancy/reentrancy_target_abi/src/main.sw
+++ b/tests/src/reentrancy/reentrancy_target_abi/src/main.sw
@@ -7,4 +7,5 @@ abi Target {
     fn intra_contract_call();
     fn guarded_function_is_callable();
     fn cross_contract_reentrancy_denied();
+    fn fallback_contract_call();
 }

--- a/tests/src/reentrancy/reentrancy_target_contract/Forc.toml
+++ b/tests/src/reentrancy/reentrancy_target_contract/Forc.toml
@@ -6,6 +6,6 @@ name = "reentrancy_target_contract"
 
 [dependencies]
 reentrancy_attacker_abi = { path = "../reentrancy_attacker_abi" }
-reentrancy_target_abi = { path = "../reentrancy_target_abi" }
 reentrancy_fallback_abi = { path = "../reentrancy_attack_fallback_abi" }
+reentrancy_target_abi = { path = "../reentrancy_target_abi" }
 sway_libs = { path = "../../../../libs" }

--- a/tests/src/reentrancy/reentrancy_target_contract/Forc.toml
+++ b/tests/src/reentrancy/reentrancy_target_contract/Forc.toml
@@ -7,4 +7,5 @@ name = "reentrancy_target_contract"
 [dependencies]
 reentrancy_attacker_abi = { path = "../reentrancy_attacker_abi" }
 reentrancy_target_abi = { path = "../reentrancy_target_abi" }
+reentrancy_fallback_abi = { path = "../reentrancy_attack_fallback_abi" }
 sway_libs = { path = "../../../../libs" }

--- a/tests/src/reentrancy/reentrancy_target_contract/src/main.sw
+++ b/tests/src/reentrancy/reentrancy_target_contract/src/main.sw
@@ -5,6 +5,7 @@ use sway_libs::reentrancy::*;
 
 use reentrancy_attacker_abi::Attacker;
 use reentrancy_target_abi::Target;
+use reentrancy_fallback_abi::FallbackAttack;
 
 // Return the sender as a ContractId or panic:
 pub fn get_msg_sender_id_or_panic() -> ContractId {
@@ -62,5 +63,15 @@ impl Target for Contract {
         abi(Attacker, get_msg_sender_id_or_panic()
             .bits())
             .evil_callback_4();
+    }
+
+    fn fallback_contract_call() {
+        // panic if reentrancy detected
+        reentrancy_guard();
+
+        // this call transfers control to the attacker contract, allowing it to execute arbitrary code.
+        abi(FallbackAttack, get_msg_sender_id_or_panic()
+            .bits())
+            .nonexistant_function(ContractId::this());
     }
 }


### PR DESCRIPTION
## Type of change

<!--Delete points that do not apply-->

- New feature

## Changes

The following changes have been made:

- Adds tests to the reentrancy guard library using the `fallback` function, ensuring the reentrancy guard still works

## Notes

- This Pr compliments #307 

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [x] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
- [x] I have updated the changelog to reflect the changes on this PR.
