### PR TITLE
Typo fix in specification.md

### DIFF
--- a/docs/contributing-book/src/code_docs/specification.md
+++ b/docs/contributing-book/src/code_docs/specification.md
@@ -2,7 +2,7 @@
 
 A specification is a document which outlines the requirements and design of the library. There are many ways to structure a specification and this number only grows when considering the industry and target audience.
 
-For simplicity, a specification can be broken into two levels of detail and the one you choose depends on your target audiance.
+For simplicity, a specification can be broken into two levels of detail and the one you choose depends on your target audience.
 
 ## Non-technical specification
 


### PR DESCRIPTION
# Pull Request: Typo Fix in `specification.md`

## Description

This pull request addresses a minor typo in the `specification.md` file. The word **"audiance"** has been corrected to **"audience"** for clarity and professionalism.

## Changes Made

- Fixed the typo in the sentence:
  > _For simplicity, a specification can be broken into two levels of detail and the one you choose depends on your target audiance._
  - Updated to:
  > _For simplicity, a specification can be broken into two levels of detail and the one you choose depends on your target audience._

- [x] The change is a typo fix
