### PR TITLE
Release `v0.24.2`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ env:
   CARGO_TERM_COLOR: always
   REGISTRY: ghcr.io
   RUST_VERSION: 1.83.0
-  FORC_VERSION: 0.66.2
+  FORC_VERSION: 0.66.6
   CORE_VERSION: 0.40.0
 
 jobs:

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   RUST_VERSION: 1.83.0
-  FORC_VERSION: 0.66.2
+  FORC_VERSION: 0.66.6
   CORE_VERSION: 0.40.0
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,27 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Unreleased]
+## [Version v0.24.2]
 
-### Added
+### Added v0.24.2
 
-- Something new here 1
-- Something new here 2
+- [#318](https://github.com/FuelLabs/sway-libs/pull/318) Adds further documentation and examples for the `signed_integers` library.
+- [#319](https://github.com/FuelLabs/sway-libs/pull/319) Adds further documentation and examples for the ownership library.
+- [#322](https://github.com/FuelLabs/sway-libs/pull/320) Adds further documentation and examples for the asset metadata library.
 
-### Changed
+### Changed v0.24.2
 
-- Something changed here 1
-- Something changed here 2
+- [#323](https://github.com/FuelLabs/sway-libs/pull/323) Updates the repository to forc `v0.66.6`.
+- [#324](https://github.com/FuelLabs/sway-libs/pull/324) Prepares for the `v0.24.2` release.
 
-### Fixed
+### Fixed v0.24.2
 
-- Some fix here 1
-- Some fix here 2
+- None
 
-### Breaking
+### Breaking v0.24.2
 
-- Some breaking change here 1
-- Some breaking change here 2
+- None
 
 ## [Version 0.24.1]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,4 @@
 [package]
 name = "sway-libs"
-version = "0.24.1"
+version = "0.24.2"
 edition = "2021"

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
     <a href="https://github.com/FuelLabs/sway-libs/actions/workflows/ci.yml" alt="CI">
         <img src="https://github.com/FuelLabs/sway-libs/actions/workflows/ci.yml/badge.svg" />
     </a>
-    <a href="https://crates.io/crates/forc/0.63.3" alt="forc">
-        <img src="https://img.shields.io/badge/forc-v0.63.3-orange" />
+    <a href="https://crates.io/crates/forc/0.66.6" alt="forc">
+        <img src="https://img.shields.io/badge/forc-v0.66.6-orange" />
     </a>
     <a href="./LICENSE" alt="forc">
         <img src="https://img.shields.io/github/license/FuelLabs/sway-libs" />
@@ -75,7 +75,7 @@ For implementation details on the libraries please see the [Sway Libs Docs](http
 To import a library, the following dependency should be added to the project's `Forc.toml` file under `[dependencies]`.
 
 ```rust
-sway_libs = { git = "https://github.com/FuelLabs/sway-libs", tag = "v0.24.1" }
+sway_libs = { git = "https://github.com/FuelLabs/sway-libs", tag = "v0.24.2" }
 ```
 
 > **NOTE:**
@@ -97,7 +97,7 @@ For more information about implementation please refer to the [Sway Libs Docs Hu
 
 ## Running Tests
 
-There are two sets of tests that should be run: inline tests and sdk-harness tests. Please make sure you are using `forc v0.66.2` and `fuel-core v0.40.0`. You can check what version you are using by running the `fuelup show` command.
+There are two sets of tests that should be run: inline tests and sdk-harness tests. Please make sure you are using `forc v0.66.6` and `fuel-core v0.40.0`. You can check what version you are using by running the `fuelup show` command.
 
 Make sure you are in the source directory of this repository `sway-libs/<you are here>`.
 
@@ -119,7 +119,7 @@ forc test --path tests --release --locked && cargo test --manifest-path tests/Ca
 Any instructions related to using a specific library should be found within the README.md of that library.
 
 > **NOTE:**
-> All projects currently use `forc v0.66.2`, `fuels-rs v0.66.9` and `fuel-core v0.40.0`.
+> All projects currently use `forc v0.66.6`, `fuels-rs v0.66.9` and `fuel-core v0.40.0`.
 
 ## Contributing
 

--- a/docs/book/spell-check-custom-words.txt
+++ b/docs/book/spell-check-custom-words.txt
@@ -211,3 +211,4 @@ verifiably
 upgradable
 upgradability
 Onchain
+representable

--- a/docs/book/src/asset/metadata.md
+++ b/docs/book/src/asset/metadata.md
@@ -36,12 +36,27 @@ Once imported, the Asset Library's metadata functionality should be available. T
 
 ### Setting Metadata
 
-To set some metadata for an Asset, use the `SetAssetMetadata` ABI provided by the Asset Library with the `_set_metadata()` function. Be sure to follow the [SRC-9](https://docs.fuel.network/docs/sway-standards/src-9-metadata-keys/) standard for your `key`. It is recommended that the [Ownership Library](../ownership/index.md) is used in conjunction with the `SetAssetMetadata` ABI to ensure only a single user has permissions to set an Asset's metadata.
+As described in the [SRC-7](https://docs.fuel.network/docs/sway-standards/src-7-asset-metadata/) standard, the metadata type is a simple enum of the following types:
+
+- `b256`
+- `Bytes`
+- `u64`
+- `String`
+
+To set some metadata of any of the above types for an Asset, you can use the `SetAssetMetadata` ABI provided by the Asset Library with the `_set_metadata()` function. Be sure to follow the [SRC-9](https://docs.fuel.network/docs/sway-standards/src-9-metadata-keys/) standard for your `key`. It is recommended that the [Ownership Library](../ownership/index.md) is used in conjunction with the `SetAssetMetadata` ABI to ensure only a single user has permissions to set an Asset's metadata.
 
 The `_set_metadata()` function follows the SRC-7 standard for logging and will emit the `SetMetadataEvent` when called.
 
 ```sway
 {{#include ../../../../examples/asset/setting_src7_attributes/src/main.sw:setting_src7_attributes}}
+```
+
+> **NOTE** The `_set_metadata()` function will set the metadata of an asset *unconditionally*. External checks should be applied to restrict the setting of metadata.
+
+To set the metadata of an Asset, using only one of the above types, you can define a custom ABI and use it as such:
+
+```sway
+{{#include ../../../../examples/asset/setting_src7_attributes/src/main.sw:setting_src7_attributes_custom_abi}}
 ```
 
 > **NOTE** The `_set_metadata()` function will set the metadata of an asset *unconditionally*. External checks should be applied to restrict the setting of metadata.
@@ -52,4 +67,26 @@ To use the `StorageMetadata` type, simply get the stored metadata with the assoc
 
 ```sway
 {{#include ../../../../examples/asset/basic_src7/src/main.sw:basic_src7}}
+```
+
+### Getting Metadata
+
+To get the metadata for an asset, apart from the above mentioned `_metadata()` convenience function, you can also use the `get()` method on the `StorageMetadata` type, which returns the `Metadata` type.
+
+```sway
+{{#include ../../../../examples/asset/metadata_docs/src/main.sw:get_metadata}}
+```
+
+This results an `Option` type as the metadata may not be set for the asset and key combination.
+
+If you know that the metadata is set, but you don't know the type, you can use a match statement to access the metadata.
+
+```sway
+{{#include ../../../../examples/asset/metadata_docs/src/main.sw:get_metadata_match}}
+```
+
+If you know that the metadata is set and you know the type, you can use the `as_*` methods to access the metadata. We also provide `is_*` methods to check if the metadata is of a specific type.
+
+```sway
+{{#include ../../../../examples/asset/metadata_docs/src/main.sw:get_metadata_as}}
 ```

--- a/docs/book/src/getting_started/index.md
+++ b/docs/book/src/getting_started/index.md
@@ -5,7 +5,7 @@
 To import any library, the following dependency should be added to the project's `Forc.toml` file under `[dependencies]`.
 
 ```sway
-sway_libs = { git = "https://github.com/FuelLabs/sway-libs", tag = "v0.24.1" }
+sway_libs = { git = "https://github.com/FuelLabs/sway-libs", tag = "v0.24.2" }
 ```
 
 For reference, here is a complete `Forc.toml` file:
@@ -18,7 +18,7 @@ license = "Apache-2.0"
 name = "MyProject"
 
 [dependencies]
-sway_libs = { git = "https://github.com/FuelLabs/sway-libs", tag = "v0.24.1" }
+sway_libs = { git = "https://github.com/FuelLabs/sway-libs", tag = "v0.24.2" }
 ```
 
 > **NOTE:** Be sure to set the tag to the latest release.
@@ -38,7 +38,7 @@ use sway_libs::ownership::only_owner;
 ```
 
 > **NOTE:**
-> All projects currently use `forc 0.63.3`, `fuels-rs v0.66.2` and `fuel-core 0.34.0`.
+> All projects currently use `forc 0.66.6`, `fuels-rs v0.66.6` and `fuel-core 0.40.0`.
 
 ## Using Sway Libs
 

--- a/docs/book/src/signed_integers/index.md
+++ b/docs/book/src/signed_integers/index.md
@@ -2,7 +2,7 @@
 
 The Signed Integers library provides a library to use signed numbers in Sway. It has 6 distinct types: `I8`, `I16`, `I32`, `I64`, `I128`, `I256`. These types are stack allocated.
 
-These types are stored as unsigned integers, therefore either `u64` or a number of them. Therefore the size can be known at compile time and the length is static.
+Internally the library uses the `u8`, `u16`, `u32`, `u64`, `U128`, `u256` types to represent the underlying values of the signed integers.
 
 For implementation details on the Signed Integers Library please see the [Sway Libs Docs](https://fuellabs.github.io/sway-libs/master/sway_libs/signed_integers/index.html).
 
@@ -24,12 +24,74 @@ In order to use any of the Signed Integer types, import them into your Sway proj
 
 ## Basic Functionality
 
-### Instantiating a New Fixed Point Number
+All the functionality is demonstrated with the `I8` type, but all of the same functionality is available for the other types as well.
+
+### Instantiating a Signed Integer
+
+#### Zero value
 
 Once imported, a `Signed Integer` type can be instantiated defining a new variable and calling the `new` function.
 
 ```sway
 {{#include ../../../../examples/signed_integers/src/main.sw:initialize}}
+```
+
+this newly initialized variable represents the value of `0`.
+
+The `new` function is functionally equivalent to the `zero` function.
+
+```sway
+{{#include ../../../../examples/signed_integers/src/main.sw:zero}}
+```
+
+#### Positive and Negative Values
+
+As the signed variants can only represent half as high a number as the unsigned variants (but with either a positive or negative sign), the `try_from` and `neg_try_from` functions will only work with half of the maximum value of the unsigned variant.
+
+You can use the `try_from` function to create a new positive `Signed Integer` from a its unsigned variant.
+
+```sway
+{{#include ../../../../examples/signed_integers/src/main.sw:positive_conversion}}
+```
+
+You can use the `neg_try_from` function to create a new negative `Signed Integer` from a its unsigned variant.
+
+```sway
+{{#include ../../../../examples/signed_integers/src/main.sw:negative_conversion}}
+```
+
+#### With underlying value
+
+As mentioned previously, the signed integers are internally represented by an unsigned integer, with its values divided into two halves, the bottom half of the values represent the negative values and the top half represent the positive values, and the middle value represents zero.
+
+Therefore, for the lowest value representable by a i8, `-128`, the underlying value would be `0`.
+
+```sway
+{{#include ../../../../examples/signed_integers/src/main.sw:neg_128_from_underlying}}
+```
+
+For the zero value, the underlying value would be `128`.
+
+```sway
+{{#include ../../../../examples/signed_integers/src/main.sw:zero_from_underlying}}
+```
+
+And for the highest value representable by a i8, `127`, the underlying value would be `255`.
+
+```sway
+{{#include ../../../../examples/signed_integers/src/main.sw:127_from_underlying}}
+```
+
+#### Minimum and Maximum Values
+
+To get the minimum and maximum values of a signed integer, use the `min` and `max` functions.
+
+```sway
+{{#include ../../../../examples/signed_integers/src/main.sw:min}}
+```
+
+```sway
+{{#include ../../../../examples/signed_integers/src/main.sw:max}}
 ```
 
 ### Basic Mathematical Functions
@@ -38,6 +100,14 @@ Basic arithmetic operations are working as usual.
 
 ```sway
 {{#include ../../../../examples/signed_integers/src/main.sw:mathematical_ops}}
+```
+
+#### Checking if a Signed Integer is Zero
+
+The library also provides a helper function to easily check if a `Signed Integer` is zero.
+
+```sway
+{{#include ../../../../examples/signed_integers/src/main.sw:is_zero}}
 ```
 
 ## Known Issues

--- a/docs/contributing-book/src/code/Forc.lock
+++ b/docs/contributing-book/src/code/Forc.lock
@@ -1,0 +1,23 @@
+[[package]]
+name = "bad_documentation"
+source = "member"
+dependencies = ["std"]
+
+[[package]]
+name = "connect_four"
+source = "member"
+dependencies = ["std"]
+
+[[package]]
+name = "core"
+source = "path+from-root-2E654A91A5A21ADE"
+
+[[package]]
+name = "std"
+source = "git+https://github.com/fuellabs/sway?tag=v0.66.6#986aee2c1e34c9cd958c81e7fd6b84638b26619b"
+dependencies = ["core"]
+
+[[package]]
+name = "style_guide"
+source = "member"
+dependencies = ["std"]

--- a/docs/contributing-book/src/code/connect_four/src/main.sw
+++ b/docs/contributing-book/src/code/connect_four/src/main.sw
@@ -1,7 +1,7 @@
 contract;
 
-mod data_structures;
-mod interface;
+pub mod data_structures;
+pub mod interface;
 
 use data_structures::{Game, Player};
 use interface::ConnectFour;

--- a/docs/contributing-book/src/code_docs/specification.md
+++ b/docs/contributing-book/src/code_docs/specification.md
@@ -2,7 +2,7 @@
 
 A specification is a document which outlines the requirements and design of the library. There are many ways to structure a specification and this number only grows when considering the industry and target audience.
 
-For simplicity, a specification can be broken into two levels of detail and the one you choose depends on your target audiance.
+For simplicity, a specification can be broken into two levels of detail and the one you choose depends on your target audience.
 
 ## Non-technical specification
 

--- a/examples/Forc.lock
+++ b/examples/Forc.lock
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "core"
-source = "path+from-root-7053AAA90CC5E690"
+source = "path+from-root-2E654A91A5A21ADE"
 
 [[package]]
 name = "merkle_examples"
@@ -146,7 +146,7 @@ dependencies = ["std"]
 
 [[package]]
 name = "std"
-source = "git+https://github.com/fuellabs/sway?tag=v0.66.2#31486c0b47669612acb7c64d66ecb50aea281282"
+source = "git+https://github.com/fuellabs/sway?tag=v0.66.6#986aee2c1e34c9cd958c81e7fd6b84638b26619b"
 dependencies = ["core"]
 
 [[package]]

--- a/examples/asset/metadata_docs/src/main.sw
+++ b/examples/asset/metadata_docs/src/main.sw
@@ -33,7 +33,52 @@ impl SRC7 for Contract {
 impl SetAssetMetadata for Contract {
     #[storage(read, write)]
     fn set_metadata(asset: AssetId, key: String, metadata: Metadata) {
+        // add your authentication logic here
+        // eg. only_owner()
         _set_metadata(storage.metadata, asset, key, metadata);
     }
 }
 // ANCHOR_END: src7_set_metadata
+
+#[storage(read)]
+fn get_metadata(asset: AssetId, key: String) {
+    // ANCHOR: get_metadata
+    use sway_libs::asset::metadata::*; // To access trait implementations you must import everything using the glob operator.
+    let metadata: Option<Metadata> = storage.metadata.get(asset, key);
+    // ANCHOR_END: get_metadata
+
+    // ANCHOR: get_metadata_match
+    match metadata.unwrap() {
+        Metadata::B256(b256) => {
+        // do something with b256
+},
+        Metadata::Bytes(bytes) => {
+        // do something with bytes
+},
+        Metadata::Int(int) => {
+        // do something with int
+},
+        Metadata::String(string) => {
+        // do something with string
+},
+    }
+    // ANCHOR_END: get_metadata_match
+
+    // ANCHOR: get_metadata_as
+    let metadata: Metadata = storage.metadata.get(asset, key).unwrap();
+
+    if metadata.is_b256() {
+        let b256: b256 = metadata.as_b256().unwrap();
+        // do something with b256
+    } else if metadata.is_bytes() {
+        let bytes: Bytes = metadata.as_bytes().unwrap();
+        // do something with bytes
+    } else if metadata.is_u64() {
+        let int: u64 = metadata.as_u64().unwrap();
+        // do something with int
+    } else if metadata.is_string() {
+        let string: String = metadata.as_string().unwrap();
+        // do something with string
+    }
+    // ANCHOR_END: get_metadata_as
+}

--- a/examples/asset/setting_src7_attributes/src/main.sw
+++ b/examples/asset/setting_src7_attributes/src/main.sw
@@ -1,6 +1,7 @@
 contract;
 
 use std::string::String;
+use std::bytes::Bytes;
 
 // ANCHOR: setting_src7_attributes
 use sway_libs::asset::metadata::*;
@@ -13,7 +14,45 @@ storage {
 impl SetAssetMetadata for Contract {
     #[storage(read, write)]
     fn set_metadata(asset: AssetId, key: String, metadata: Metadata) {
+        // add your authentication logic here
+        // eg. only_owner()
         _set_metadata(storage.metadata, asset, key, metadata);
     }
 }
 // ANCHOR_END: setting_src7_attributes
+
+// ANCHOR: setting_src7_attributes_custom_abi
+abi CustomSetAssetMetadata {
+    #[storage(read, write)]
+    fn custom_set_metadata(
+        asset: AssetId,
+        key: String,
+        bits256: b256,
+        bytes: Bytes,
+        int: u64,
+        string: String,
+    );
+}
+
+impl CustomSetAssetMetadata for Contract {
+    #[storage(read, write)]
+    fn custom_set_metadata(
+        asset: AssetId,
+        key: String,
+        bits256: b256,
+        bytes: Bytes,
+        int: u64,
+        string: String,
+    ) {
+        let b256_metadata = Metadata::B256(bits256);
+        let bytes_metadata = Metadata::Bytes(bytes);
+        let int_metadata = Metadata::Int(int);
+        let string_metadata = Metadata::String(string);
+
+        // your authentication logic here
+
+        // set whichever metadata you want
+        storage.metadata.insert(asset, key, string_metadata);
+    }
+}
+// ANCHOR_END: setting_src7_attributes_custom_abi

--- a/examples/ownership/src/lib.sw
+++ b/examples/ownership/src/lib.sw
@@ -1,0 +1,57 @@
+library;
+
+// ANCHOR: import
+use sway_libs::ownership::*;
+use standards::src5::*;
+// ANCHOR_END: import
+
+// ANCHOR: integrate_with_src5
+use sway_libs::ownership::_owner;
+use standards::src5::{SRC5, State};
+
+impl SRC5 for Contract {
+    #[storage(read)]
+    fn owner() -> State {
+        _owner()
+    }
+}
+// ANCHOR_END: integrate_with_src5
+
+// ANCHOR: initialize
+#[storage(read, write)]
+fn my_constructor(new_owner: Identity) {
+    initialize_ownership(new_owner);
+}
+// ANCHOR_END: initialize
+
+// ANCHOR: only_owner
+#[storage(read)]
+fn only_owner_may_call() {
+    only_owner();
+    // Only the contract's owner may reach this line.
+}
+// ANCHOR_END: only_owner
+
+// ANCHOR: state
+#[storage(read)]
+fn get_owner_state() {
+    let owner: State = _owner();
+}
+// ANCHOR_END: state
+
+// ANCHOR: transfer_ownership
+#[storage(read, write)]
+fn transfer_contract_ownership(new_owner: Identity) {
+    // The caller must be the current owner.
+    transfer_ownership(new_owner);
+}
+// ANCHOR: transfer_ownership
+
+// ANCHOR: renouncing_ownership
+#[storage(read, write)]
+fn renounce_contract_owner() {
+    // The caller must be the current owner.
+    renounce_ownership();
+    // Now no one owns the contract.
+}
+// ANCHOR: renouncing_ownership

--- a/examples/ownership/src/main.sw
+++ b/examples/ownership/src/main.sw
@@ -1,12 +1,13 @@
-library;
+// ANCHOR: example_contract
+contract;
 
-// ANCHOR: import
-use sway_libs::ownership::*;
-use standards::src5::*;
-// ANCHOR_END: import
-
-// ANCHOR: integrate_with_src5
-use sway_libs::ownership::_owner;
+use sway_libs::ownership::{
+    _owner,
+    initialize_ownership,
+    only_owner,
+    renounce_ownership,
+    transfer_ownership,
+};
 use standards::src5::{SRC5, State};
 
 impl SRC5 for Contract {
@@ -15,26 +16,49 @@ impl SRC5 for Contract {
         _owner()
     }
 }
-// ANCHOR_END: integrate_with_src5
 
-// ANCHOR: initialize
-#[storage(read, write)]
-fn my_constructor(new_owner: Identity) {
-    initialize_ownership(new_owner);
+abi MyContract {
+    #[storage(read, write)]
+    fn constructor(new_owner: Identity);
+    #[storage(read)]
+    fn restricted_action();
+    #[storage(read, write)]
+    fn change_owner(new_owner: Identity);
+    #[storage(read, write)]
+    fn revoke_ownership();
+    #[storage(read)]
+    fn get_current_owner() -> State;
 }
-// ANCHOR_END: initialize
 
-// ANCHOR: only_owner
-#[storage(read)]
-fn only_owner_may_call() {
-    only_owner();
-    // Only the contract's owner may reach this line.
-}
-// ANCHOR_END: only_owner
+impl MyContract for Contract {
+    #[storage(read, write)]
+    fn constructor(new_owner: Identity) {
+        initialize_ownership(new_owner);
+    }
 
-// ANCHOR: state
-#[storage(read)]
-fn get_owner_state() {
-    let owner: State = _owner();
+    // A function restricted to the owner
+    #[storage(read)]
+    fn restricted_action() {
+        only_owner();
+        // Protected action
+    }
+
+    // Transfer ownership
+    #[storage(read, write)]
+    fn change_owner(new_owner: Identity) {
+        transfer_ownership(new_owner);
+    }
+
+    // Renounce ownership
+    #[storage(read, write)]
+    fn revoke_ownership() {
+        renounce_ownership();
+    }
+
+    // Get current owner state
+    #[storage(read)]
+    fn get_current_owner() -> State {
+        _owner()
+    }
 }
-// ANCHOR_END: state
+// ANCHOR: example_contract

--- a/examples/signed_integers/src/main.sw
+++ b/examples/signed_integers/src/main.sw
@@ -12,6 +12,40 @@ fn initialize() {
     // ANCHOR: initialize
     let mut i8_value = I8::new();
     // ANCHOR_END: initialize
+
+    // ANCHOR: zero
+    let zero = I8::zero();
+    // ANCHOR_END: zero
+
+    // ANCHOR: zero_from_underlying
+    let zero = I8::from_uint(128u8);
+    // ANCHOR_END: zero_from_underlying
+
+    // ANCHOR: neg_128_from_underlying
+    let neg_128 = I8::from_uint(0u8);
+    // ANCHOR_END: neg_128_from_underlying
+
+    // ANCHOR: 127_from_underlying
+    let pos_127 = I8::from_uint(255u8);
+    // ANCHOR_END: 127_from_underlying
+
+    // ANCHOR: min
+    let min = I8::min();
+    // ANCHOR_END: min
+
+    // ANCHOR: max
+    let max = I8::max();
+    // ANCHOR_END: max
+}
+
+fn conversion() {
+    // ANCHOR: positive_conversion
+    let one = I8::try_from(1u8).unwrap();
+    // ANCHOR_END: positive_conversion
+
+    // ANCHOR: negative_conversion
+    let negative_one = I8::neg_try_from(1u8).unwrap();
+    // ANCHOR_END: negative_conversion
 }
 
 // ANCHOR: mathematical_ops
@@ -31,3 +65,10 @@ fn divide_signed_int(val1: I8, val2: I8) {
     let result: I8 = val1 / val2;
 }
 // ANCHOR_END: mathematical_ops
+
+// ANCHOR: is_zero
+fn is_zero() {
+    let i8 = I8::zero();
+    assert(i8.is_zero());
+}
+// ANCHOR_END: is_zero

--- a/libs/Forc.lock
+++ b/libs/Forc.lock
@@ -1,6 +1,6 @@
 [[package]]
 name = "core"
-source = "path+from-root-7053AAA90CC5E690"
+source = "path+from-root-2E654A91A5A21ADE"
 
 [[package]]
 name = "standards"
@@ -9,7 +9,7 @@ dependencies = ["std"]
 
 [[package]]
 name = "std"
-source = "git+https://github.com/fuellabs/sway?tag=v0.66.2#31486c0b47669612acb7c64d66ecb50aea281282"
+source = "git+https://github.com/fuellabs/sway?tag=v0.66.6#986aee2c1e34c9cd958c81e7fd6b84638b26619b"
 dependencies = ["core"]
 
 [[package]]

--- a/libs/src/admin.sw
+++ b/libs/src/admin.sw
@@ -5,7 +5,7 @@ pub mod errors;
 use ::admin::errors::AdminError;
 use ::ownership::{_owner, only_owner};
 use standards::src5::State;
-use std::{auth::msg_sender, hash::{Hash, sha256}, storage::storage_api::clear,};
+use std::{auth::msg_sender, hash::{Hash, sha256}, storage::storage_api::clear};
 
 // Sets a new administrator.
 ///

--- a/libs/src/bytecode/utils.sw
+++ b/libs/src/bytecode/utils.sw
@@ -1,6 +1,6 @@
 library;
 
-use std::{alloc::{alloc, alloc_bytes, realloc_bytes}, bytes::Bytes,};
+use std::{alloc::{alloc, alloc_bytes, realloc_bytes}, bytes::Bytes};
 
 /// Pre-defined number of bytes of a leaf in a bytecode merkle tree.
 const LEAF_SIZE = 16 * 1024;

--- a/libs/src/signed_integers/i128.sw
+++ b/libs/src/signed_integers/i128.sw
@@ -395,8 +395,8 @@ impl core::ops::Subtract for I128 {
 
 impl WrappingNeg for I128 {
     fn wrapping_neg(self) -> Self {
-        if self == self::min() {
-            return self::min()
+        if self == Self::min() {
+            return Self::min()
         }
         self * Self::neg_try_from(U128::from((0, 1))).unwrap()
     }

--- a/libs/src/signed_integers/i16.sw
+++ b/libs/src/signed_integers/i16.sw
@@ -383,8 +383,8 @@ impl core::ops::Subtract for I16 {
 
 impl WrappingNeg for I16 {
     fn wrapping_neg(self) -> Self {
-        if self == self::min() {
-            return self::min()
+        if self == Self::min() {
+            return Self::min()
         }
         self * Self::neg_try_from(1u16).unwrap()
     }

--- a/libs/src/signed_integers/i256.sw
+++ b/libs/src/signed_integers/i256.sw
@@ -374,8 +374,8 @@ impl core::ops::Subtract for I256 {
 
 impl WrappingNeg for I256 {
     fn wrapping_neg(self) -> Self {
-        if self == self::min() {
-            return self::min()
+        if self == Self::min() {
+            return Self::min()
         }
         self * Self::neg_try_from(0x0000000000000000000000000000000000000000000000000000000000000001u256).unwrap()
     }

--- a/libs/src/signed_integers/i32.sw
+++ b/libs/src/signed_integers/i32.sw
@@ -383,8 +383,8 @@ impl core::ops::Divide for I32 {
 
 impl WrappingNeg for I32 {
     fn wrapping_neg(self) -> Self {
-        if self == self::min() {
-            return self::min()
+        if self == Self::min() {
+            return Self::min()
         }
         self * Self::neg_try_from(1u32).unwrap()
     }

--- a/libs/src/signed_integers/i64.sw
+++ b/libs/src/signed_integers/i64.sw
@@ -384,8 +384,8 @@ impl core::ops::Divide for I64 {
 
 impl WrappingNeg for I64 {
     fn wrapping_neg(self) -> Self {
-        if self == self::min() {
-            return self::min()
+        if self == Self::min() {
+            return Self::min()
         }
         self * Self::neg_try_from(1).unwrap()
     }

--- a/libs/src/signed_integers/i8.sw
+++ b/libs/src/signed_integers/i8.sw
@@ -383,8 +383,8 @@ impl core::ops::Subtract for I8 {
 
 impl WrappingNeg for I8 {
     fn wrapping_neg(self) -> Self {
-        if self == self::min() {
-            return self::min()
+        if self == Self::min() {
+            return Self::min()
         }
         self * Self::neg_try_from(1u8).unwrap()
     }

--- a/tests/Forc.lock
+++ b/tests/Forc.lock
@@ -22,7 +22,7 @@ dependencies = ["std"]
 
 [[package]]
 name = "core"
-source = "path+from-root-7053AAA90CC5E690"
+source = "path+from-root-2E654A91A5A21ADE"
 
 [[package]]
 name = "i128_test"
@@ -244,7 +244,7 @@ dependencies = ["std"]
 
 [[package]]
 name = "std"
-source = "git+https://github.com/fuellabs/sway?tag=v0.66.2#31486c0b47669612acb7c64d66ecb50aea281282"
+source = "git+https://github.com/fuellabs/sway?tag=v0.66.6#986aee2c1e34c9cd958c81e7fd6b84638b26619b"
 dependencies = ["core"]
 
 [[package]]

--- a/tests/src/bytecode/test_artifacts/complex_contract/src/main.sw
+++ b/tests/src/bytecode/test_artifacts/complex_contract/src/main.sw
@@ -1,6 +1,6 @@
 contract;
 
-use std::{hash::*, math::*, storage::storage_vec::*,};
+use std::{hash::*, math::*, storage::storage_vec::*};
 
 struct SimpleStruct {
     x: u32,

--- a/tests/src/bytecode/tests/utils/mod.rs
+++ b/tests/src/bytecode/tests/utils/mod.rs
@@ -40,11 +40,32 @@ const DEFAULT_PREDICATE_BALANCE: u64 = 512;
 const HEX_STR_1: &str = "0xb4ca495f61ac3433e9a78cbf3adfb0e4486913bb548029cef99d1de2cf606d52";
 const HEX_STR_2: &str = "0x5d617010b482b54332741fab0dfd1b15dfad07e8895360af0fb9f3e3a04b0c74";
 const HEX_STR_3: &str = "0xfebf0fdda20de46a0f2261a69556b0f9fdeea85759af1edb322831cf7d0dc8d5";
-const SIMPLE_PREDICATE_OFFSET: u64 = 376;
-const SIMPLE_CONTRACT_OFFSET: u64 = 1384;
-const COMPLEX_CONTRACT_OFFSET_1: u64 = 22584;
-const COMPLEX_CONTRACT_OFFSET_2: u64 = 22544;
-const COMPLEX_CONTRACT_OFFSET_3: u64 = 22472;
+// For bytecode test failures, these offsets need to be updated with the new configurable values
+// in the .json files in `bytecode/test_artifacts/*/out/*-abi.json`.
+// For example: in `bytecode/test_artifacts/complex_contract/out/contract_contract-abi.json` we have the following:
+//  "configurables": [
+//   {
+//     "name": "VALUE",
+//     "concreteTypeId": "1506e6f44c1d6291cdf46395a8e573276a4fa79e8ace3fc891e092ef32d1b0a0",
+//     "offset": 20800
+//   },
+//   {
+//     "name": "STRUCT",
+//     "concreteTypeId": "75f7f7a06026cab5d7a70984d1fde56001e83505e3a091ff9722b92d7f56d8be",
+//     "offset": 20760
+//   },
+//   {
+//     "name": "ENUM",
+//     "concreteTypeId": "8dfea60c80d5eb43188e38922a715225450c499b19fd0dacc673c13ff708cdb2",
+//     "offset": 20688
+//   }
+// ]
+// You would use 20800, 20760, and 20688 for 1, 2, 3 respectively
+const SIMPLE_PREDICATE_OFFSET: u64 = 384;
+const SIMPLE_CONTRACT_OFFSET: u64 = 1280;
+const COMPLEX_CONTRACT_OFFSET_1: u64 = 20800;
+const COMPLEX_CONTRACT_OFFSET_2: u64 = 20760;
+const COMPLEX_CONTRACT_OFFSET_3: u64 = 20688;
 
 pub mod abi_calls {
 

--- a/tests/src/reentrancy/reentrancy_attacker_contract/src/main.sw
+++ b/tests/src/reentrancy/reentrancy_attacker_contract/src/main.sw
@@ -1,6 +1,6 @@
 contract;
 
-use std::{auth::*, call_frames::*,};
+use std::{auth::*, call_frames::*};
 
 use reentrancy_target_abi::Target;
 use reentrancy_attacker_abi::Attacker;


### PR DESCRIPTION
## [Version v0.24.2]

### Added v0.24.2

- [#318](https://github.com/FuelLabs/sway-libs/pull/318) Adds further documentation and examples for the `signed_integers` library.
- [#319](https://github.com/FuelLabs/sway-libs/pull/319) Adds further documentation and examples for the ownership library.
- [#322](https://github.com/FuelLabs/sway-libs/pull/320) Adds further documentation and examples for the asset metadata library.

### Changed v0.24.2

- [#323](https://github.com/FuelLabs/sway-libs/pull/323) Updates the repository to forc `v0.66.6`.
- [#324](https://github.com/FuelLabs/sway-libs/pull/324) Prepares for the `v0.24.2` release.

### Fixed v0.24.2

- None

### Breaking v0.24.2

- None