### PR TITLE
Add missing breaking change docs for PR #312 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ use sway_libs::merkle::binary::{leaf_digest};
 - [#312](https://github.com/FuelLabs/sway-libs/pull/312) Breaks functionality of `I8`, `I16`, `I32`, `I64`, `I128`, and `I256`'s `::min()` and `::max()` functions. These functions are now used for comparison for two values of the type and return the higher or lower value respectively. To obtain the minimum and maximum values you must now use the `::MIN` and `::MAX` assosciated constants.
 
 Before:
+
 ```sway
 fn foo() -> I8 {
     let minimum_i8 = I8::min();
@@ -64,6 +65,7 @@ fn foo() -> I8 {
 ```
 
 After:
+
 ```sway
 fn foo() -> I8 {
     let minimum_i8 = I8::MIN;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,24 @@ use sway_libs::merkle::common::{LEAF, NODE, node_digest};
 use sway_libs::merkle::binary::{leaf_digest};
 ```
 
+- [#312](https://github.com/FuelLabs/sway-libs/pull/312) Breaks functionality of `I8`, `I16`, `I32`, `I64`, `I128`, and `I256`'s `::min()` and `::max()` functions. These functions are now used for comparison for two values of the type and return the higher or lower value respectively. To obtain the minimum and maximum values you must now use the `::MIN` and `::MAX` assosciated constants.
+
+Before:
+```sway
+fn foo() -> I8 {
+    let minimum_i8 = I8::min();
+    let maximum_i8 = I8::max();
+}
+```
+
+After:
+```sway
+fn foo() -> I8 {
+    let minimum_i8 = I8::MIN;
+    let maximum_i8 = I8::MAX;
+}
+```
+
 ## [Version v0.24.2]
 
 ### Added v0.24.2


### PR DESCRIPTION
## Type of change
- Documentation

## Changes

The following changes have been made:

- Adds breaking change warning and example fix for the TotalOrd implementation pr #312 


## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
- [x] I have updated the changelog to reflect the changes on this PR.
