### PR TITLE
Prepare for v0.25.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,24 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Some breaking change here.
 - Some breaking change here.
 
+## [Version 0.25.2]
+
+### Added
+
+- None
+
+### Changed
+
+- None
+
+### Fixed v0.25.2
+
+- [#342](https://github.com/FuelLabs/sway-libs/pull/342) Puts module comment on top of file since module comments after the file type are no longer allowed.
+
+### Breaking
+
+- None
+
 ## [Version 0.25.1]
 
 ### Added v0.25.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,19 +29,19 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Version 0.25.2]
 
-### Added
+### Added v0.25.2
 
 - None
 
-### Changed
+### Changed v0.25.2
 
-- None
+- [#343](https://github.com/FuelLabs/sway-libs/pull/343) Prepares for the `v0.25.2` release.
 
 ### Fixed v0.25.2
 
 - [#342](https://github.com/FuelLabs/sway-libs/pull/342) Puts module comment on top of file since module comments after the file type are no longer allowed.
 
-### Breaking
+### Breaking v0.25.2
 
 - None
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed v0.25.2
 
+- [#341](https://github.com/FuelLabs/sway-libs/pull/341) Fixes anchors in examples for docs.
 - [#342](https://github.com/FuelLabs/sway-libs/pull/342) Puts module comment on top of file since module comments after the file type are no longer allowed.
 
 ### Breaking v0.25.2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,4 @@
 [package]
 name = "sway-libs"
-version = "0.25.1"
+version = "0.25.2"
 edition = "2021"

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ For implementation details on the libraries please see the [Sway Libs Docs](http
 To import a library, the following dependency should be added to the project's `Forc.toml` file under `[dependencies]`.
 
 ```rust
-sway_libs = { git = "https://github.com/FuelLabs/sway-libs", tag = "v0.25.1" }
+sway_libs = { git = "https://github.com/FuelLabs/sway-libs", tag = "v0.25.2" }
 ```
 
 > **NOTE:**

--- a/docs/book/src/getting_started/index.md
+++ b/docs/book/src/getting_started/index.md
@@ -5,7 +5,7 @@
 To import any library, the following dependency should be added to the project's `Forc.toml` file under `[dependencies]`.
 
 ```sway
-sway_libs = { git = "https://github.com/FuelLabs/sway-libs", tag = "v0.25.1" }
+sway_libs = { git = "https://github.com/FuelLabs/sway-libs", tag = "v0.25.2" }
 ```
 
 For reference, here is a complete `Forc.toml` file:
@@ -18,7 +18,7 @@ license = "Apache-2.0"
 name = "MyProject"
 
 [dependencies]
-sway_libs = { git = "https://github.com/FuelLabs/sway-libs", tag = "v0.25.1" }
+sway_libs = { git = "https://github.com/FuelLabs/sway-libs", tag = "v0.25.2" }
 ```
 
 > **NOTE:** Be sure to set the tag to the latest release.


### PR DESCRIPTION
## Type of change

<!--Delete points that do not apply-->

- Release

## Changes

The following changes have been made:

- Updates the repo in preparation for the v0.25.2 release

## Notes

- Fixes a critical issue that makes sway-libs compatible with forc `v0.68.x`

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [x] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
- [x] I have updated the changelog to reflect the changes on this PR.
