### PR TITLE
Add example on using a `configurable` to prevent front-running ownership

### DIFF
--- a/docs/book/src/ownership/index.md
+++ b/docs/book/src/ownership/index.md
@@ -37,6 +37,12 @@ Establishes the initial ownership state by calling `initialize_ownership(new_own
 {{#include ../../../../examples/ownership/src/lib.sw:initialize}}
 ```
 
+Please note that the example above does not apply any restrictions on who may call the `initialize()` function. This leaves the opportunity for a bad actor to front-run your contract and claim ownership for themselves. To ensure the intended `Identity` is set as the contract owner upon contract deployment, use a `configurable` where the `INITIAL_OWNER` is the intended owner of the contract.
+
+```sway
+{{#include ../../../../examples/ownership_configurable/src/main.sw:ownership_configurable}}
+```
+
 ### Applying Restrictions
 
 Protect functions so only the owner can call them by invoking `only_owner()` at the start of those functions.

--- a/examples/Forc.lock
+++ b/examples/Forc.lock
@@ -85,6 +85,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ownership_configurable_examples"
+source = "member"
+dependencies = [
+    "standards",
+    "std",
+    "sway_libs",
+]
+
+[[package]]
 name = "ownership_examples"
 source = "member"
 dependencies = [
@@ -158,7 +167,7 @@ dependencies = ["std"]
 
 [[package]]
 name = "std"
-source = "git+https://github.com/fuellabs/sway?tag=v0.67.0#d821dcb0c7edb1d6e2a772f5a1ccefe38902eaec"
+source = "git+https://github.com/fuellabs/sway?tag=v0.68.2#05480bb07ed7b62e4123a2696ba22bce57ffb049"
 
 [[package]]
 name = "supply_docs"

--- a/examples/Forc.toml
+++ b/examples/Forc.toml
@@ -13,6 +13,7 @@ members = [
   "./merkle_binary",
   "./merkle_sparse",
   "./ownership",
+  "./ownership_configurable",
   "./pausable/pausable",
   "./pausable/pausable_with_ownership",
   "./queue",

--- a/examples/ownership/src/main.sw
+++ b/examples/ownership/src/main.sw
@@ -10,6 +10,10 @@ use sway_libs::ownership::{
 };
 use standards::src5::{SRC5, State};
 
+configurable {
+    INITAL_OWNER: Identity = Identity::Address(Address::zero()),
+}
+
 impl SRC5 for Contract {
     #[storage(read)]
     fn owner() -> State {
@@ -19,7 +23,7 @@ impl SRC5 for Contract {
 
 abi MyContract {
     #[storage(read, write)]
-    fn constructor(new_owner: Identity);
+    fn initialize();
     #[storage(read)]
     fn restricted_action();
     #[storage(read, write)]
@@ -32,8 +36,8 @@ abi MyContract {
 
 impl MyContract for Contract {
     #[storage(read, write)]
-    fn constructor(new_owner: Identity) {
-        initialize_ownership(new_owner);
+    fn initialize() {
+        initialize_ownership(INITAL_OWNER);
     }
 
     // A function restricted to the owner

--- a/examples/ownership_configurable/Forc.toml
+++ b/examples/ownership_configurable/Forc.toml
@@ -1,0 +1,9 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "ownership_configurable_examples"
+
+[dependencies]
+standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.7.0" }
+sway_libs = { path = "../../libs" }

--- a/examples/ownership_configurable/src/main.sw
+++ b/examples/ownership_configurable/src/main.sw
@@ -1,0 +1,36 @@
+// ANCHOR: example_contract
+contract;
+
+use sway_libs::ownership::{
+    _owner,
+    initialize_ownership,
+    only_owner,
+    renounce_ownership,
+    transfer_ownership,
+};
+use standards::src5::{SRC5, State};
+
+impl SRC5 for Contract {
+    #[storage(read)]
+    fn owner() -> State {
+        _owner()
+    }
+}
+
+abi MyContract {
+    #[storage(read, write)]
+    fn initialize();
+}
+
+// ANCHOR: ownership_configurable
+configurable {
+    INITAL_OWNER: Identity = Identity::Address(Address::zero()),
+}
+
+impl MyContract for Contract {
+    #[storage(read, write)]
+    fn initialize() {
+        initialize_ownership(INITAL_OWNER);
+    }
+}
+// ANCHOR_END: ownership_configurable


### PR DESCRIPTION
## Type of change

<!--Delete points that do not apply-->

- Improvement (refactoring, restructuring repository, cleaning tech debt, ...)
- Documentation

## Changes

The following changes have been made:

- Adds comments on the possibility for ownership to be front-run and how to prevent it.
- Adds example of using a configurable in ownership.
- Updates the full example to use the configurable.

## Notes

- This came up when reviewing a recent project and they did not know about this use case.

## Related Issues

<!--Delete everything after the "#" symbol and replace it with a number. No spaces between hash and number-->

Closes #346 

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
- [ ] I have updated the changelog to reflect the changes on this PR.
