### PR TITLE
give each libs docs its own unique subdirectory

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -78,7 +78,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./libs/${{ matrix.project }}/out/doc
-          destination_dir: mastermaster/${{ matrix.project }}
+          destination_dir: master/${{ matrix.project }}
         if: github.ref == 'refs/heads/master'
 
       - name: Get tag

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -78,7 +78,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./libs/${{ matrix.project }}/out/doc
-          destination_dir: master
+          destination_dir: mastermaster/${{ matrix.project }}
         if: github.ref == 'refs/heads/master'
 
       - name: Get tag
@@ -92,5 +92,5 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./libs/${{ matrix.project }}/out/doc
-          destination_dir: ${{ steps.branch_name.outputs.BRANCH_NAME }}
+          destination_dir: ${{ steps.branch_name.outputs.BRANCH_NAME }}/${{ matrix.project }}
         if: startsWith(github.ref, 'refs/tags')

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -78,7 +78,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./libs/${{ matrix.project }}/out/doc
-          destination_dir: master/${{ matrix.project }}
+          destination_dir: master/sway_libs/${{ matrix.project }}
         if: github.ref == 'refs/heads/master'
 
       - name: Get tag
@@ -92,5 +92,5 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./libs/${{ matrix.project }}/out/doc
-          destination_dir: ${{ steps.branch_name.outputs.BRANCH_NAME }}/${{ matrix.project }}
+          destination_dir: ${{ steps.branch_name.outputs.BRANCH_NAME }}/sway_libs/${{ matrix.project }}
         if: startsWith(github.ref, 'refs/tags')


### PR DESCRIPTION
 Ensures that each job writes to a separate directory, and they will no longer conflict.

With these changes, documentation will be published to paths like:
* https://fuellabs.github.io/sway-libs/master/asset/
* https://fuellabs.github.io/sway-libs/master/big_int/
* etc.

## Checklist

- [ ] I have linked to any relevant issues.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [ ] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [ ] I have requested a review from the relevant team or maintainers.
- [ ] I have updated the changelog to reflect the changes on this PR.
