### PR TITLE
Add README.md files to Libraries

### DIFF
--- a/docs/book/src/merkle/index.md
+++ b/docs/book/src/merkle/index.md
@@ -94,7 +94,7 @@ fuel-merkle = { version = "0.56.0" }
 The following should be added to your Rust file to use the Fuel-Merkle crate.
 
 ```rust
-{{#include ../../../../examples/merkle_sparse/mod.rs:import}}
+{{#include ../../../../examples/merkle_binary/mod.rs:import}}
 ```
 
 #### Using Fuel-Merkle's Binary Tree
@@ -104,7 +104,7 @@ The following should be added to your Rust file to use the Fuel-Merkle crate.
 To create a merkle tree using Fuel-Merkle is as simple as pushing your leaves in increasing order.
 
 ```rust
-{{#include ../../../../examples/merkle_sparse/mod.rs:generating_a_tree}}
+{{#include ../../../../examples/merkle_binary/mod.rs:generating_a_tree}}
 ```
 
 ##### Generating And Verifying A Binary Proof
@@ -112,13 +112,13 @@ To create a merkle tree using Fuel-Merkle is as simple as pushing your leaves in
 To generate a proof for a specific leaf, you must have the index or key of the leaf. Simply call the prove function:
 
 ```rust
-{{#include ../../../../examples/merkle_sparse/mod.rs:generating_proof}}
+{{#include ../../../../examples/merkle_binary/mod.rs:generating_proof}}
 ```
 
 Once the proof has been generated, you may call the Sway Smart Contract's `verify_proof` function:
 
 ```rust
-{{#include ../../../../examples/merkle_sparse/mod.rs:verify_proof}}
+{{#include ../../../../examples/merkle_binary/mod.rs:verify_proof}}
 ```
 
 ## Using the Sparse Merkle Proof Library In Sway

--- a/libs/admin/README.md
+++ b/libs/admin/README.md
@@ -1,0 +1,111 @@
+# Admin Library
+
+The Admin library provides a way to block users without an "administrative status" from calling functions within a contract. The Admin Library differs from the [Ownership Library](https://docs.fuel.network/docs/sway-libs/ownership/) as multiple users may have administrative status. The Admin Library is often used when needing administrative calls on a contract that involve multiple users or a whitelist.
+
+This library extends the [Ownership Library]([../ownership/index.md](https://docs.fuel.network/docs/sway-libs/ownership/)). The Ownership library must be imported and used to enable the Admin library. Only the contract's owner may add and remove administrative users.
+
+For implementation details on the Admin Library please see the [Sway Libs Docs](https://fuellabs.github.io/sway-libs/master/sway_libs/admin/admin/).
+
+## Importing the Admin Library
+
+In order to use the Admin Library, the Admin and the Ownership Libraries must be added to your `Forc.toml` file and then imported into your Sway project.
+
+To add the Admin and the Ownership Libraries as dependencies to your `Forc.toml` file in your project, use the `forc add` command.
+
+```bash
+forc add admin@0.26.0
+forc add ownership@0.26.0
+```
+
+> **NOTE:** Be sure to set the version to the latest release.
+
+To import the Admin Library, be sure to include both the Admin and Ownership Libraries in your import statements.
+
+```sway
+use {admin::*, ownership::*};
+```
+
+## Integrating the Admin Library into the Ownership Library
+
+To use the Admin library, be sure to set a contract owner for your contract. The following demonstrates setting a contract owner using the [Ownership Library](https://docs.fuel.network/docs/sway-libs/ownership/).
+
+```sway
+use {admin::add_admin, ownership::initialize_ownership};
+
+#[storage(read, write)]
+fn my_constructor(new_owner: Identity) {
+    initialize_ownership(new_owner);
+}
+
+#[storage(read, write)]
+fn add_a_admin(new_admin: Identity) {
+    // Can only be called by contract's owner set in the constructor above.
+    add_admin(new_admin);
+}
+```
+
+## Basic Functionality
+
+### Adding an Admin
+
+To add a new admin to a contract, call the `add_admin()` function.
+
+```sway
+#[storage(read, write)]
+fn add_a_admin(new_admin: Identity) {
+    // Can only be called by contract's owner.
+    add_admin(new_admin);
+}
+```
+
+> **NOTE** Only the contract's owner may call this function. Please see the example above to set a contract owner.
+
+### Removing an Admin
+
+To remove an admin from a contract, call the `revoke_admin()` function.
+
+```sway
+#[storage(read, write)]
+fn remove_an_admin(old_admin: Identity) {
+    // Can only be called by contract's owner.
+    revoke_admin(old_admin);
+}
+```
+
+> **NOTE** Only the contract's owner may call this function. Please see the example above to set a contract owner.
+
+### Applying Restrictions
+
+To restrict a function to only an admin, call the `only_admin()` function.
+
+```sway
+#[storage(read)]
+fn only_owner_may_call() {
+    only_admin();
+    // Only an admin may reach this line.
+}
+```
+
+> **NOTE:** Admins and the contract's owner are independent of one another. `only_admin()` will revert if called by the contract's owner.
+
+To restrict a function to only an admin or the contract's owner, call the `only_owner_or_admin()` function.
+
+```sway
+#[storage(read)]
+fn both_owner_or_admin_may_call() {
+    only_owner_or_admin();
+    // Only an admin may reach this line.
+}
+```
+
+### Checking Admin Status
+
+To check the administrative privileges of a user, call the `is_admin()` function.
+
+```sway
+#[storage(read)]
+fn check_if_admin(admin: Identity) {
+    let status = is_admin(admin);
+    assert(status);
+}
+```

--- a/libs/admin/README.md
+++ b/libs/admin/README.md
@@ -2,7 +2,7 @@
 
 The Admin library provides a way to block users without an "administrative status" from calling functions within a contract. The Admin Library differs from the [Ownership Library](https://docs.fuel.network/docs/sway-libs/ownership/) as multiple users may have administrative status. The Admin Library is often used when needing administrative calls on a contract that involve multiple users or a whitelist.
 
-This library extends the [Ownership Library]([../ownership/index.md](https://docs.fuel.network/docs/sway-libs/ownership/)). The Ownership library must be imported and used to enable the Admin library. Only the contract's owner may add and remove administrative users.
+This library extends the [Ownership Library](https://docs.fuel.network/docs/sway-libs/ownership/). The Ownership library must be imported and used to enable the Admin library. Only the contract's owner may add and remove administrative users.
 
 For implementation details on the Admin Library please see the [Sway Libs Docs](https://fuellabs.github.io/sway-libs/master/sway_libs/admin/admin/).
 

--- a/libs/asset/README.md
+++ b/libs/asset/README.md
@@ -1,0 +1,17 @@
+# Asset Library
+
+The Asset Library provides basic helper functions for the [SRC-20; Native Asset Standard](https://docs.fuel.network/docs/sway-standards/src-20-native-asset/), [SRC-3; Mint and Burn Standard](https://docs.fuel.network/docs/sway-standards/src-3-minting-and-burning/), and the [SRC-7; Arbitrary Asset Metadata Standard](https://docs.fuel.network/docs/sway-standards/src-7-asset-metadata/). It is intended to make development of Native Assets using Sway quick and easy while following the standard's specifications.
+
+For implementation details on the Asset Library please see the [Sway Libs Docs](https://fuellabs.github.io/sway-libs/master/sway_libs/asset/asset/).
+
+## [SRC-20 Functionality](https://docs.fuel.network/docs/sway-libs/asset/base/)
+
+The Base or core of any Asset on the Fuel Network must follow the [SRC-20; Native Asset Standard](https://docs.fuel.network/docs/sway-standards/src-20-native-asset/). The Asset Library's [Base](https://docs.fuel.network/docs/sway-libs/asset/base/) section supports the [SRC-20](https://docs.fuel.network/docs/sway-standards/src-20-native-asset/)'s implementation.
+
+## [SRC-3 Functionality](https://docs.fuel.network/docs/sway-libs/asset/supply/)
+
+The [SRC-3; Mint and Burn Standard](https://docs.fuel.network/docs/sway-standards/src-3-minting-and-burning/) prescribes an ABI for how Native Assets on the Fuel Network are minted and burned. The Asset Library's [supply](https://docs.fuel.network/docs/sway-libs/asset/supply/) section supports the [SRC-3](https://docs.fuel.network/docs/sway-standards/src-3-minting-and-burning/)'s implementation.
+
+## [SRC-7 Functionality](https://docs.fuel.network/docs/sway-libs/asset/metadata/)
+
+The [SRC-7; Onchain Asset Metadata Standard](https://docs.fuel.network/docs/sway-standards/src-7-asset-metadata/) prescribes an ABI for stateful metadata associated with Native Assets on the Fuel Network. The Asset Library's [metadata](https://docs.fuel.network/docs/sway-libs/asset/metadata/) section supports the [SRC-7](https://docs.fuel.network/docs/sway-standards/src-7-asset-metadata/)'s implementation.

--- a/libs/big_int/README.md
+++ b/libs/big_int/README.md
@@ -1,0 +1,207 @@
+# Big Integers Library
+
+<!--Include BigInt when BigInt is available-->
+The Big Integers library provides a library to use extremely large numbers in Sway. It has 1 distinct types: `BigUint`. These types are heap allocated.
+
+Internally the library uses the `Vec<u64>` type to represent the underlying values of the big integers.
+
+For implementation details on the Big Integers Library please see the [Sway Libs Docs](https://fuellabs.github.io/sway-libs/master/sway_libs/big_int/big_int/).
+
+## Importing the Big Integers Library
+
+In order to use the Big Integers Library, the Big Integers Library must be added to your `Forc.toml` file and then imported into your Sway project.
+
+To add the Big Integers Library as a dependency to your `Forc.toml` file in your project, use the `forc add` command.
+
+```bash
+forc add big_int@0.26.0
+```
+
+> **NOTE:** Be sure to set the version to the latest release.
+
+To import the Big Integers Library to your Sway Smart Contract, add the following to your Sway file:
+
+```sway
+use big_int::*;
+```
+
+In order to use any of the Big Integer types, import them into your Sway project like so:
+
+```sway
+use big_int::BigUint;
+```
+
+## Basic Functionality
+
+<!--Uncomment when BigInt is available-->
+<!--All the functionality is demonstrated with the `BigUint` type, but all of the same functionality is available for the other types as well.-->
+
+### Minimum and Maximum Values
+
+For the `BigUint` type, the minimum value is zero. There is no maximum value and the `BigUint` will grow to accommodate as large of a number as needed.
+
+### Instantiating a Big Integer
+
+#### Zero value
+
+Once imported, a `Big Integer` type can be instantiated defining a new variable and calling the `new` function.
+
+```sway
+let mut big_int = BigUint::new();
+```
+
+this newly initialized variable represents the value of `0`.
+
+The `new` function is functionally equivalent to the `zero` function.
+
+```sway
+let zero = BigUint::zero();
+```
+
+<!--#### Positive and Negative Values
+
+As the signed variants can only represent half as high a number as the unsigned variants (but with either a positive or negative sign), the `try_from` and `neg_try_from` functions will only work with half of the maximum value of the unsigned variant.
+
+You can use the `try_from` function to create a new positive `Big Integer` from a its unsigned variant.
+
+```sway
+{{#include ../../../../examples/big_integers/src/main.sw:positive_conversion}}
+```
+
+You can use the `neg_try_from` function to create a new negative `Big Integer` from a its unsigned variant.
+
+```sway
+{{#include ../../../../examples/big_integers/src/main.sw:negative_conversion}}
+```
+-->
+
+### Basic Mathematical Functions
+
+Basic arithmetic operations are working as usual.
+
+```sway
+let big_uint_1 = BigUint::from(1u64);
+let big_uint_2 = BigUint::from(2u64);
+
+// Add
+let result: BigUint = big_uint_1 + big_uint_2;
+
+// Multiply
+let result: BigUint = big_uint_1 * big_uint_2;
+
+// Subtract
+let result: BigUint = big_uint_2 - big_uint_1;
+
+// Eq
+let result: bool = big_uint_1 == big_uint_2;
+
+// Ord
+let result: bool = big_uint_1 < big_uint_2;
+```
+
+#### Checking if a Big Integer is Zero
+
+The library also provides a helper function to easily check if a `Big Integer` is zero.
+
+```sway
+fn is_zero() {
+    let big_int = BigUint::zero();
+    assert(big_int.is_zero());
+}
+```
+
+### Type Conversions
+
+The Big Integers Library offers a number of different conversions between mathematical types. These include the following:
+
+- `u8`
+- `u16`
+- `u32`
+- `u64`
+- `U128`
+- `u256`
+- `Bytes`
+
+To convert any of the above type to a Big Integer, you may use the `From` implementation.
+
+```sway
+// u8
+let u8_big_int = BigUint::from(u8::max());
+
+// u16
+let u16_big_int = BigUint::from(u16::max());
+
+// u32
+let u32_big_int = BigUint::from(u32::max());
+
+// u64
+let u64_big_int = BigUint::from(u64::max());
+
+// U128
+let u128_big_int = BigUint::from(U128::max());
+
+// u256
+let u256_big_int = BigUint::from(u256::max());
+
+// Bytes
+let bytes_big_int = BigUint::from(Bytes::new());
+```
+
+To convert back to any of the above types, the `TryInto` implementation will be needed. If the Bit Integer does not fit into the conversion type, `None` will be returned.
+
+```sway
+let big_uint = BigUint::zero();
+
+// u8
+let u8_result: Option<u8> = <BigUint as TryInto<u8>>::try_into(big_uint);
+
+// u16
+let u16_result: Option<u16> = <BigUint as TryInto<u16>>::try_into(big_uint);
+
+// u32
+let u32_result: Option<u32> = <BigUint as TryInto<u32>>::try_into(big_uint);
+
+// u64
+let u64_result: Option<u64> = <BigUint as TryInto<u64>>::try_into(big_uint);
+
+// U128
+let u128_big_int: Option<U128> = <BigUint as TryInto<U128>>::try_into(big_uint);
+
+// u256
+let u256_big_int: Option<u256> = <BigUint as TryInto<u256>>::try_into(big_uint);
+```
+
+The only exception is the `Bytes` type, which uses `Into`.
+
+```sway
+// Bytes
+let bytes_big_int: Bytes = <BigUint as Into<Bytes>>::into(big_uint);
+```
+
+### Underlying Values
+
+As mentioned previously, the big integers are internally represented by a `Vec<u64>`. To introspect these underlying values you may either get a copy of the data, inspect individual elements, or get the length.
+
+To get a copy of the underlying data, you may call the `limbs()` function. Please note that modifying the copy will have no impact on the Big Integer.
+
+```sway
+let limbs: Vec<u64> = big_int.limbs();
+```
+
+To introspect an individual element, you may use the `get_limb()` function.
+
+```sway
+let limb: Option<u64> = big_int.get_limb(0);
+```
+
+To get the length of the underlying `Vec<u64>`, call the `number_of_limbs()` function.
+
+```sway
+let number_of_limbs: u64 = big_int.number_of_limbs();
+```
+
+And to check whether two Big Integers have the same number of limbs, you may use the `equal_limb_size()` function.
+
+```sway
+let result: bool = big_int_1.equal_limb_size(big_int_2);
+```

--- a/libs/bytecode/README.md
+++ b/libs/bytecode/README.md
@@ -1,0 +1,148 @@
+# Bytecode Library
+
+The Bytecode Library allows for on-chain verification and computation of bytecode roots for contracts and predicates.
+
+A bytecode root for a contract and predicate is the Merkle root of the [binary Merkle tree](https://github.com/FuelLabs/fuel-specs/blob/master/src/protocol/cryptographic-primitives.md#binary-merkle-tree) with each leaf being 16KiB of instructions. This library will compute any contract's or predicate's bytecode root/address allowing for the verification of deployed contracts and generation of predicate addresses on-chain.
+
+For implementation details on the Bytecode Library please see the [Sway Libs Docs](https://fuellabs.github.io/sway-libs/master/sway_libs/bytecode/bytecode/).
+
+## Importing the Bytecode Library
+
+In order to use the Bytecode Library, the Bytecode Library must be added to your `Forc.toml` file and then imported into your Sway project.
+
+To add the Bytecode Library as a dependency to your `Forc.toml` file in your project, use the `forc add` command.
+
+```bash
+forc add bytecode@0.26.0
+```
+
+> **NOTE:** Be sure to set the version to the latest release.
+
+To import the Bytecode Library to your Sway Smart Contract, add the following to your Sway file:
+
+```sway
+use bytecode::*;
+```
+
+## Using the Bytecode Library In Sway
+
+Once imported, using the Bytecode Library is as simple as calling the desired function. Here is a list of function definitions that you may use.
+
+- `compute_bytecode_root()`
+- `compute_predicate_address()`
+- `predicate_address_from_root()`
+- `swap_configurables()`
+- `verify_contract_bytecode()`
+- `verify_predicate_address()`
+
+## Known Issues
+
+Please note that if you are passing the bytecode from the SDK and are including configurable values, the `Vec<u8>` bytecode provided must be copied to be mutable. The following can be added to make your bytecode mutable:
+
+```sway
+fn make_mutable(not_mutable_bytecode: Vec<u8>) {
+    // Copy the bytecode to a newly allocated memory to avoid memory ownership error.
+    let mut bytecode_slice = raw_slice::from_parts::<u8>(
+        alloc_bytes(not_mutable_bytecode.len()),
+        not_mutable_bytecode
+            .len(),
+    );
+    not_mutable_bytecode
+        .ptr()
+        .copy_bytes_to(bytecode_slice.ptr(), not_mutable_bytecode.len());
+    let mut bytecode_vec = Vec::from(bytecode_slice);
+    // You may now use `bytecode_vec` in your computation and verification function calls
+}
+```
+
+## Basic Functionality
+
+The examples below are intended for internal contract calls. If you are passing bytecode from the SDK, please follow the steps listed above in known issues to avoid the memory ownership error.
+
+## Swapping Configurables
+
+Given some bytecode, you may swap the configurables of both Contracts and Predicates by calling the `swap_configurables()` function.
+
+```sway
+fn swap(
+    my_bytecode: Vec<u8>,
+    my_configurables: ContractConfigurables,
+) {
+    let mut my_bytecode = my_bytecode;
+    let resulting_bytecode: Vec<u8> = swap_configurables(my_bytecode, my_configurables);
+}
+```
+
+## Contracts
+
+### Computing the Bytecode Root
+
+To compute a contract's bytecode root you may call the `compute_bytecode_root()` function.
+
+```sway
+fn compute_bytecode(
+    my_bytecode: Vec<u8>,
+    my_configurables: Option<ContractConfigurables>,
+) {
+    let mut my_bytecode = my_bytecode;
+    let root: BytecodeRoot = compute_bytecode_root(my_bytecode, my_configurables);
+}
+```
+
+### Verifying a Contract's Bytecode Root
+
+To verify a contract's bytecode root you may call `verify_bytecode_root()` function.
+
+```sway
+fn verify_contract(
+    my_contract: ContractId,
+    my_bytecode: Vec<u8>,
+    my_configurables: Option<ContractConfigurables>,
+) {
+    let mut my_bytecode = my_bytecode;
+    verify_contract_bytecode(my_contract, my_bytecode, my_configurables);
+    // By reaching this line the contract has been verified to match the bytecode provided.
+}
+```
+
+## Predicates
+
+### Computing the Address from Bytecode
+
+To compute a predicate's address you may call the `compute_predicate_address()` function.
+
+```sway
+fn compute_predicate(
+    my_bytecode: Vec<u8>,
+    my_configurables: Option<ContractConfigurables>,
+) {
+    let mut my_bytecode = my_bytecode;
+    let address: Address = compute_predicate_address(my_bytecode, my_configurables);
+}
+```
+
+### Computing the Address from a Root
+
+If you have the root of a predicate, you may compute it's corresponding predicate address by calling the `predicate_address_from_root()` function.
+
+```sway
+fn predicate_address(my_root: BytecodeRoot) {
+    let address: Address = predicate_address_from_root(my_root);
+}
+```
+
+### Verifying the Address
+
+To verify a predicates's address you may call `verify_predicate_address()` function.
+
+```sway
+fn verify_predicate(
+    my_predicate: Address,
+    my_bytecode: Vec<u8>,
+    my_configurables: Option<ContractConfigurables>,
+) {
+    let mut my_bytecode = my_bytecode;
+    verify_predicate_address(my_predicate, my_bytecode, my_configurables);
+    // By reaching this line the predicate bytecode matches the address provided.
+}
+```

--- a/libs/merkle/README.md
+++ b/libs/merkle/README.md
@@ -1,0 +1,344 @@
+# Merkle Library
+
+Merkle trees allow for on-chain verification of off-chain data. With the merkle root posted on-chain, the generation of proofs off-chain can provide verifiably true data.
+
+The Merkle Library currently supports two different tree structures: Binary Trees and Sparse Trees. For information implementation specifications, please refer to the [Merkle Tree Specification](https://docs.fuel.network/docs/specs/protocol/cryptographic-primitives/#merkle-trees).
+
+For implementation details on the Merkle Library please see the [Sway Libs Docs](https://fuellabs.github.io/sway-libs/master/sway_libs/merkle/merkle/).
+
+## Importing the Merkle Library
+
+In order to use the Merkle Library, the Merkle Library must be added to your `Forc.toml` file and then imported into your Sway project.
+
+To add the Merkle Library as a dependency to your `Forc.toml` file in your project, use the `forc add` command.
+
+```bash
+forc add merkle@0.26.0
+```
+
+> **NOTE:** Be sure to set the version to the latest release.
+
+To import the Binary Merkle Library to your Sway Smart Contract, add the following to your Sway file:
+
+```sway
+use merkle::binary::{leaf_digest, process_proof, verify_proof};
+use merkle::common::{MerkleRoot, node_digest, ProofSet};
+```
+
+To import the Sparse Merkle Library to your Sway Smart Contract, add the following to your Sway file:
+
+```sway
+use merkle::sparse::*;
+use merkle::common::{MerkleRoot, ProofSet};
+```
+
+## Using the Binary Merkle Proof Library In Sway
+
+Once imported, using the Binary Merkle Proof library is as simple as calling the desired function. Here is a list of function definitions that you may use.
+
+- `leaf_digest()`
+- `node_digest()`
+- `process_proof()`
+- `verify_proof()`
+
+### Binary Sway Functionality
+
+#### Computing Leaves and Nodes of a Binary Tree
+
+The Binary Proof currently allows for you to compute leaves and nodes of a merkle tree given the appropriate hash digest.
+
+To compute a leaf use the `leaf_digest()` function:
+
+```sway
+fn compute_leaf(hashed_data: b256) {
+    let leaf: b256 = leaf_digest(hashed_data);
+}
+```
+
+To compute a node given two leaves, use the `node_digest()` function:
+
+```sway
+fn compute_node(leaf_a: b256, leaf_b: b256) {
+    let node: b256 = node_digest(leaf_a, leaf_b);
+}
+```
+
+> **NOTE** Order matters when computing a node.
+
+#### Computing the Merkle Root of a Binary Tree
+
+To compute a Merkle root given a proof, use the `process_proof()` function.
+
+```sway
+fn process(key: u64, leaf: b256, num_leaves: u64, proof: ProofSet) {
+    let merkle_root: MerkleRoot = process_proof(key, leaf, num_leaves, proof);
+}
+```
+
+#### Verifying the Proof of a Binary Tree
+
+To verify a proof against a merkle root, use the `verify_proof()` function.
+
+```sway
+fn verify(
+    merkle_root: MerkleRoot,
+    key: u64,
+    leaf: b256,
+    num_leaves: u64,
+    proof: ProofSet,
+) {
+    assert(verify_proof(key, leaf, merkle_root, num_leaves, proof));
+}
+```
+
+### Using the Binary Merkle Proof Library with Fuels-rs
+
+To generate a Binary Merkle Tree and corresponding proof for your Sway Smart Contract, use the [Fuel-Merkle](https://github.com/FuelLabs/fuel-vm/tree/master/fuel-merkle) crate.
+
+#### Importing Binary Into Your Project
+
+To import the Fuel-Merkle crate, the following should be added to the project's `Cargo.toml` file under `[dependencies]`:
+
+```sway
+fuel-merkle = { version = "0.56.0" }
+```
+
+> **NOTE** Make sure to use the latest version of the [fuel-merkle](https://crates.io/crates/fuel-merkle) crate.
+
+#### Importing Binary Into Your Rust File
+
+The following should be added to your Rust file to use the Fuel-Merkle crate.
+
+```rust
+use fuel_merkle::binary::in_memory::MerkleTree;
+```
+
+#### Using Fuel-Merkle's Binary Tree
+
+##### Generating A Binary Tree
+
+To create a merkle tree using Fuel-Merkle is as simple as pushing your leaves in increasing order.
+
+```rust
+// Create a new Merkle Tree and define leaves
+let mut tree = MerkleTree::new();
+let leaves = [b"A", b"B", b"C"].to_vec();
+
+// Hash the leaves and then push to the merkle tree
+for datum in &leaves {
+    let mut hasher = Sha256::new();
+    hasher.update(datum);
+    let hash = hasher.finalize();
+    tree.push(&hash);
+}
+```
+
+##### Generating And Verifying A Binary Proof
+
+To generate a proof for a specific leaf, you must have the index or key of the leaf. Simply call the prove function:
+
+```rust
+// Define the key or index of the leaf you want to prove and the number of leaves
+let key: u64 = 0;
+
+// Get the merkle root and proof set
+let (merkle_root, proof_set) = tree.prove(key).unwrap();
+
+// Convert the proof set from Vec<Bytes32> to Vec<Bits256>
+let mut bits256_proof: Vec<Bits256> = Vec::new();
+for itterator in proof_set {
+    bits256_proof.push(Bits256(itterator));
+}
+```
+
+Once the proof has been generated, you may call the Sway Smart Contract's `verify_proof` function:
+
+```rust
+// Create the merkle leaf
+let mut leaf_hasher = Sha256::new();
+leaf_hasher.update(leaves[key as usize]);
+let hashed_leaf_data = leaf_hasher.finalize();
+let merkle_leaf = leaf_sum(&hashed_leaf_data);
+
+// Get the number of leaves or data points
+let num_leaves: u64 = leaves.len() as u64;
+
+// Call the Sway contract to verify the generated merkle proof
+let result: bool = contract_instance
+    .methods()
+    .verify(
+        Bits256(merkle_root),
+        key,
+        Bits256(merkle_leaf),
+        num_leaves,
+        bits256_proof,
+    )
+    .call()
+    .await
+    .unwrap()
+    .value;
+assert!(result);
+```
+
+## Using the Sparse Merkle Proof Library In Sway
+
+Once imported, using the Sparse Merkle Proof library is as simple as calling the desired function on the `Proof` type. Here is a list of function definitions that you may use.
+
+- `root()`
+- `verify()`
+
+To explore additional utility and support functions available, please check out the [Sway Libs Docs](https://fuellabs.github.io/sway-libs/master/sway_libs/merkle/merkle/).
+
+### Sparse Sway Functionality
+
+#### Computing the Merkle Root of a Sparse Tree
+
+To compute a Sparse Merkle root given a proof, use the `root()` function. You must provide the appropriate `MerkleTreeKey` and leaf data. Please note that the leaf data should be `Some` if you are proving an inclusion proof, and `None` if your are proving an exclusion proof.
+
+```sway
+fn compute_root(key: MerkleTreeKey, leaf: Option<Bytes>, proof: Proof) {
+    let merkle_root: MerkleRoot = proof.root(key, leaf);
+}
+```
+
+#### Verifying the Proof of a Sparse Tree
+
+To verify a proof against a merkle root, use the `verify()` function. You must provide the appropriate `MerkleTreeKey`, `MerkleRoot`, and leaf data. Please note that the leaf data should be `Some` if you are proving an inclusion proof, and `None` if your are proving an exclusion proof.
+
+```sway
+fn verify_proof(
+    root: MerkleRoot,
+    key: MerkleTreeKey,
+    leaf: Option<Bytes>,
+    proof: Proof,
+) {
+    let result: bool = proof.verify(root, key, leaf);
+    assert(result);
+}
+```
+
+#### Verifying an Inclusion Proof with Hashed Data
+
+If you would like to verify an inclusion proof using only the SHA256 hash of the leaf data rather than the entire `Bytes`, you may do so as shown:
+
+```sway
+fn inclusion_proof_hash(key: MerkleTreeKey, leaf: b256, proof: Proof) {
+    assert(proof.is_inclusion());
+
+    // Compute the merkle root of an inclusion proof using the sha256 hash of the leaf
+    let root: MerkleRoot = proof.as_inclusion().unwrap().root_from_hash(key, leaf);
+
+    // Verifying an inclusion proof using the sha256 hash of the leaf
+    let result: bool = proof.as_inclusion().unwrap().verify_hash(root, key, leaf);
+    assert(result);
+}
+```
+
+### Using the Sparse Merkle Proof Library with Fuels-rs
+
+To generate a Sparse Merkle Tree and corresponding proof for your Sway Smart Contract, use the [Fuel-Merkle](https://github.com/FuelLabs/fuel-vm/tree/master/fuel-merkle) crate.
+
+#### Importing Sparse Tree Into Your Project
+
+To import the Fuel-Merkle crate, the following should be added to the project's `Cargo.toml` file under `[dependencies]`:
+
+```sway
+fuel-merkle = { version = "0.56.0" }
+```
+
+> **NOTE** Make sure to use the latest version of the [fuel-merkle](https://crates.io/crates/fuel-merkle) crate.
+
+#### Importing Sparse Tree Into Your Rust File
+
+The following should be added to your Rust file to use the Fuel-Merkle crate.
+
+```rust
+use fuel_merkle::sparse::in_memory::MerkleTree as SparseTree;
+use fuel_merkle::sparse::proof::ExclusionLeaf as FuelExclusionLeaf;
+use fuel_merkle::sparse::proof::Proof as FuelProof;
+use fuel_merkle::sparse::MerkleTreeKey as SparseTreeKey;
+use fuels::types::{Bits256, Bytes};
+```
+
+#### Using Fuel-Merkle's Sparse Tree
+
+##### Generating A Sparse Tree
+
+To create a merkle tree using Fuel-Merkle is as simple as pushing your leaves in increasing order.
+
+```rust
+// Create a new Merkle Tree and define leaves
+let mut tree = SparseTree::new();
+let leaves = ["A", "B", "C"].to_vec();
+let leaf_to_prove = "A";
+let key = SparseTreeKey::new(leaf_to_prove);
+
+// Hash the leaves and then push to the merkle tree
+for datum in &leaves {
+    let _ = tree.update(SparseTreeKey::new(datum), datum.as_bytes());
+}
+```
+
+##### Generating And Verifying A Sparse Proof
+
+To generate a proof for a specific leaf, you must have the index or key of the leaf. Simply call the prove function:
+
+```rust
+// Get the merkle root and proof set
+let root = tree.root();
+let fuel_proof: FuelProof = tree.generate_proof(&key).unwrap();
+
+// Convert the proof from a FuelProof to the Sway Proof
+let sway_proof: Proof = fuel_to_sway_sparse_proof(fuel_proof);
+```
+
+Once the proof has been generated, you may call the Sway Smart Contract's `verify_proof` function:
+
+```rust
+// Call the Sway contract to verify the generated merkle proof
+let result: bool = contract_instance
+    .methods()
+    .verify(
+        Bits256(root),
+        Bits256(*key),
+        Some(Bytes(leaves[0].into())),
+        sway_proof,
+    )
+    .call()
+    .await
+    .unwrap()
+    .value;
+
+assert!(result);
+```
+
+##### Converting from a Fuel Proof to a Sway Proof
+
+The Rust SDK does not currently support the `Proof` type in Sway and will conflict with the `Proof` type in fuel-merkle. Therefore, you MUST import the `Proof` type from fuel-merkle as `FuelProof`.
+
+To convert between the two types, you may use the following function:
+
+```rust
+pub fn fuel_to_sway_sparse_proof(fuel_proof: FuelProof) -> Proof {
+    let mut proof_bits: Vec<Bits256> = Vec::new();
+    for iterator in fuel_proof.proof_set().iter() {
+        proof_bits.push(Bits256(iterator.clone()));
+    }
+
+    match fuel_proof {
+        FuelProof::Exclusion(exlcusion_proof) => Proof::Exclusion(ExclusionProof {
+            proof_set: proof_bits,
+            leaf: match exlcusion_proof.leaf {
+                FuelExclusionLeaf::Leaf(leaf_data) => ExclusionLeaf::Leaf(ExclusionLeafData {
+                    leaf_key: Bits256(leaf_data.leaf_key),
+                    leaf_value: Bits256(leaf_data.leaf_value),
+                }),
+                FuelExclusionLeaf::Placeholder => ExclusionLeaf::Placeholder,
+            },
+        }),
+        FuelProof::Inclusion(_) => Proof::Inclusion(InclusionProof {
+            proof_set: proof_bits,
+        }),
+    }
+}
+```

--- a/libs/ownership/README.md
+++ b/libs/ownership/README.md
@@ -1,0 +1,225 @@
+# Ownership Library
+
+The **Ownership Library** provides a straightforward way to restrict specific calls in a Sway contract to a single _owner_. Its design follows the [SRC-5](https://docs.fuel.network/docs/sway-standards/src-5-ownership/) standard from [Sway Standards](https://docs.fuel.network/docs/sway-standards/) and offers a set of functions to initialize, verify, revoke, and transfer ownership.
+
+For implementation details, visit the [Sway Libs Docs](https://fuellabs.github.io/sway-libs/master/sway_libs/ownership/ownership/).
+
+## Importing the Ownership Library
+
+In order to use the Ownership Library, the Ownership Library and the [SRC-5](https://docs.fuel.network/docs/sway-standards/src-5-ownership/) Standard must be added to your `Forc.toml` file and then imported into your Sway project.
+
+To add the Ownership Library and the [SRC-5](https://docs.fuel.network/docs/sway-standards/src-5-ownership/) Standard as a dependency to your `Forc.toml` file in your project, use the `forc add` command.
+
+```bash
+forc add ownership@0.26.0
+forc add src5@0.8.0
+```
+
+> **NOTE:** Be sure to set the version to the latest release.
+
+To import the Ownership Library and [SRC-5](https://docs.fuel.network/docs/sway-standards/src-5-ownership/) Standard to your Sway Smart Contract, add the following to your Sway file:
+
+```sway
+use ownership::*;
+use src5::*;
+```
+
+## Integrating the Ownership Library into the SRC-5 Standard
+
+When integrating the Ownership Library with [SRC-5](https://docs.fuel.network/docs/sway-standards/src-5-ownership/), ensure that the `SRC5` trait from **Sway Standards** is implemented in your contract, as shown below. The `_owner()` function from this library is used to fulfill the SRC-5 requirement of exposing the ownership state.
+
+```sway
+use ownership::_owner;
+use src5::{SRC5, State};
+
+impl SRC5 for Contract {
+    #[storage(read)]
+    fn owner() -> State {
+        _owner()
+    }
+}
+```
+
+## Basic Usage
+
+### Setting a Contract Owner
+
+Establishes the initial ownership state by calling `initialize_ownership(new_owner)`. This can only be done once, typically in your contract's constructor.
+
+```sway
+#[storage(read, write)]
+fn my_constructor(new_owner: Identity) {
+    initialize_ownership(new_owner);
+}
+```
+
+Please note that the example above does not apply any restrictions on who may call the `initialize()` function. This leaves the opportunity for a bad actor to front-run your contract and claim ownership for themselves. To ensure the intended `Identity` is set as the contract owner upon contract deployment, use a `configurable` where the `INITIAL_OWNER` is the intended owner of the contract.
+
+```sway
+configurable {
+    INITAL_OWNER: Identity = Identity::Address(Address::zero()),
+}
+
+impl MyContract for Contract {
+    #[storage(read, write)]
+    fn initialize() {
+        initialize_ownership(INITAL_OWNER);
+    }
+}
+```
+
+### Applying Restrictions
+
+Protect functions so only the owner can call them by invoking `only_owner()` at the start of those functions.
+
+```sway
+#[storage(read)]
+fn only_owner_may_call() {
+    only_owner();
+    // Only the contract's owner may reach this line.
+}
+```
+
+### Checking the Ownership Status
+
+To retrieve the current ownership state, call `_owner()`.
+
+```sway
+#[storage(read)]
+fn get_owner_state() {
+    let owner: State = _owner();
+}
+```
+
+### Transferring Ownership
+
+To transfer ownership from the current owner to a new owner, call `transfer_ownership(new_owner)`.
+
+```sway
+#[storage(read, write)]
+fn transfer_contract_ownership(new_owner: Identity) {
+    // The caller must be the current owner.
+    transfer_ownership(new_owner);
+}
+```
+
+### Renouncing Ownership
+
+To revoke ownership entirely and disallow the assignment of a new owner, call `renounce_ownership()`.
+
+```sway
+#[storage(read, write)]
+fn renounce_contract_owner() {
+    // The caller must be the current owner.
+    renounce_ownership();
+    // Now no one owns the contract.
+}
+```
+
+## Events
+
+### `OwnershipRenounced`
+
+Emitted when ownership is revoked.
+
+- **Fields:**
+  - `previous_owner`: Identity of the owner prior to revocation.
+
+### `OwnershipSet`
+
+Emitted when initial ownership is set.
+
+- **Fields:**
+  - `new_owner`: Identity of the newly set owner.
+
+### `OwnershipTransferred`
+
+Emitted when ownership is transferred from one owner to another.
+
+- **Fields:**
+  - `new_owner`: Identity of the new owner.
+  - `previous_owner`: Identity of the prior owner.
+
+## Errors
+
+### `InitializationError`
+
+- **Variants:**
+  - `CannotReinitialized`: Thrown when attempting to initialize ownership if the owner is already set.
+
+### `AccessError`
+
+- **Variants:**
+  - `NotOwner`: Thrown when a function restricted to the owner is called by a non-owner.
+
+## Example Integration
+
+Below is a example illustrating how to use this library within a Sway contract:
+
+```sway
+contract;
+
+use ownership::{_owner, initialize_ownership, only_owner, renounce_ownership, transfer_ownership};
+use src5::{SRC5, State};
+
+configurable {
+    INITAL_OWNER: Identity = Identity::Address(Address::zero()),
+}
+
+impl SRC5 for Contract {
+    #[storage(read)]
+    fn owner() -> State {
+        _owner()
+    }
+}
+
+abi MyContract {
+    #[storage(read, write)]
+    fn initialize();
+    #[storage(read)]
+    fn restricted_action();
+    #[storage(read, write)]
+    fn change_owner(new_owner: Identity);
+    #[storage(read, write)]
+    fn revoke_ownership();
+    #[storage(read)]
+    fn get_current_owner() -> State;
+}
+
+impl MyContract for Contract {
+    #[storage(read, write)]
+    fn initialize() {
+        initialize_ownership(INITAL_OWNER);
+    }
+
+    // A function restricted to the owner
+    #[storage(read)]
+    fn restricted_action() {
+        only_owner();
+        // Protected action
+    }
+
+    // Transfer ownership
+    #[storage(read, write)]
+    fn change_owner(new_owner: Identity) {
+        transfer_ownership(new_owner);
+    }
+
+    // Renounce ownership
+    #[storage(read, write)]
+    fn revoke_ownership() {
+        renounce_ownership();
+    }
+
+    // Get current owner state
+    #[storage(read)]
+    fn get_current_owner() -> State {
+        _owner()
+    }
+}
+```
+
+1. **Initialization:** Call `constructor(new_owner)` once to set the initial owner.  
+2. **Restricted Calls:** Use `only_owner()` to guard any owner-specific functions.  
+3. **Ownership Checks:** Retrieve the current owner state via `_owner()`.  
+4. **Transfer or Renounce:** Use `transfer_ownership(new_owner)` or `renounce_ownership()` for ownership modifications.

--- a/libs/pausable/README.md
+++ b/libs/pausable/README.md
@@ -1,0 +1,125 @@
+# Pausable Library
+
+The Pausable library allows contracts to implement an emergency stop mechanism. This can be useful for scenarios such as having an emergency switch to freeze all transactions in the event of a large bug.
+
+It is highly encouraged to use the [Ownership Library](https://docs.fuel.network/docs/sway-libs/ownership/) in combination with the Pausable Library to ensure that only a single administrative user has the ability to pause your contract.
+
+For implementation details on the Pausable Library please see the [Sway Libs Docs](https://fuellabs.github.io/sway-libs/master/sway_libs/pausable/pausable/).
+
+## Importing the Pausable Library
+
+In order to use the Pausable library, the Pausable Library must be added to your `Forc.toml` file and then imported into your Sway project.
+
+To add the Pausable Library as a dependency to your `Forc.toml` file in your project, use the `forc add` command.
+
+```bash
+forc add pausable@0.26.0
+```
+
+> **NOTE:** Be sure to set the version to the latest release.
+
+To import the Pausable Library to your Sway Smart Contract, add the following to your Sway file:
+
+```sway
+use pausable::*;
+```
+
+## Basic Functionality
+
+### Implementing the `Pausable` abi
+
+The Pausable Library has two states:
+
+- `Paused`
+- `Unpaused`
+
+By default, your contract will start in the `Unpaused` state. To pause your contract, you may call the `_pause()` function. The example below provides a basic pausable contract using the Pausable Library's `Pausable` abi without any restrictions such as an administrator.
+
+```sway
+use pausable::{_is_paused, _pause, _unpause, Pausable};
+
+impl Pausable for Contract {
+    #[storage(write)]
+    fn pause() {
+        _pause();
+    }
+
+    #[storage(write)]
+    fn unpause() {
+        _unpause();
+    }
+
+    #[storage(read)]
+    fn is_paused() -> bool {
+        _is_paused()
+    }
+}
+```
+
+## Applying Paused Restrictions
+
+When developing a contract, you may want to lock functions down to a specific state. To do this, you may call either of the `require_paused()` or `require_not_paused()` functions. The example below shows these functions in use.
+
+```sway
+use pausable::require_paused;
+
+#[storage(read)]
+fn require_paused_state() {
+    require_paused();
+    // This comment will only ever be reached if the contract is in the paused state
+}
+```
+
+```sway
+use pausable::require_not_paused;
+
+#[storage(read)]
+fn require_not_paused_state() {
+    require_not_paused();
+    // This comment will only ever be reached if the contract is in the unpaused state
+}
+```
+
+## Using the Ownership Library with the Pausable Library
+
+It is highly recommended to integrate the [Ownership Library](https://docs.fuel.network/docs/sway-libs/ownership/) with the Pausable Library and apply restrictions the `pause()` and `unpause()` functions. This will ensure that only a single user may pause and unpause a contract in cause of emergency. Failure to apply this restriction will allow any user to obstruct a contract's functionality.
+
+The follow example implements the `Pausable` abi and applies restrictions to it's pause/unpause functions. The owner of the contract must be set in a constructor defined by `MyConstructor` in this example.
+
+```sway
+use pausable::{_is_paused, _pause, _unpause, Pausable};
+use ownership::{initialize_ownership, only_owner};
+
+abi MyConstructor {
+    #[storage(read, write)]
+    fn my_constructor(new_owner: Identity);
+}
+
+impl MyConstructor for Contract {
+    #[storage(read, write)]
+    fn my_constructor(new_owner: Identity) {
+        initialize_ownership(new_owner);
+    }
+}
+
+impl Pausable for Contract {
+    #[storage(write)]
+    fn pause() {
+        // Add the `only_owner()` check to ensure only the owner may unpause this contract.
+        only_owner();
+        _pause();
+    }
+
+    #[storage(write)]
+    fn unpause() {
+        // Add the `only_owner()` check to ensure only the owner may unpause this contract.
+        only_owner();
+        _unpause();
+    }
+
+    #[storage(read)]
+    fn is_paused() -> bool {
+        _is_paused()
+    }
+}
+```

--- a/libs/queue/README.md
+++ b/libs/queue/README.md
@@ -1,0 +1,72 @@
+# Queue Library
+
+A Queue is a linear structure which follows the First-In-First-Out (FIFO) principle. This means that the elements added first are the ones that get removed first.
+
+For implementation details on the Queue Library please see the [Sway Libs Docs](https://fuellabs.github.io/sway-libs/master/sway_libs/queue/queue/).
+
+## Importing the Queue Library
+
+In order to use the Queue Library, the Queue Library must be added to your `Forc.toml` file and then imported into your Sway project.
+
+To add the Queue Library as a dependency to your `Forc.toml` file in your project, use the `forc add` command.
+
+```bash
+forc add queue@0.26.0
+```
+
+> **NOTE:** Be sure to set the version to the latest release.
+
+To import the Queue Library to your Sway Smart Contract, add the following to your Sway file:
+
+```sway
+use queue::*;
+```
+
+## Basic Functionality
+
+### Instantiating a New Queue
+
+Once the `Queue` has been imported, you can create a new queue instance by calling the `new` function.
+
+```sway
+let mut queue = Queue::new();
+```
+
+## Enqueuing elements
+
+Adding elements to the `Queue` can be done using the `enqueue` function.
+
+```sway
+// Enqueue an element to the queue
+queue.enqueue(10u8);
+```
+
+### Dequeuing Elements
+
+To remove elements from the `Queue`, the `dequeue` function is used. This function follows the FIFO principle.
+
+```sway
+// Dequeue the first element and unwrap the value
+let first_item = queue.dequeue().unwrap();
+```
+
+### Fetching the Head Element
+
+To retrieve the element at the head of the `Queue` without removing it, you can use the `peek` function.
+
+```sway
+// Peek at the head of the queue
+let head_item = queue.peek();
+```
+
+### Checking the Queue's Length
+
+The `is_empty` and `len` functions can be used to check if the queue is empty and to get the number of elements in the queue respectively.
+
+```sway
+// Checks if queue is empty (returns True or False)
+let is_queue_empty = queue.is_empty();
+
+// Returns length of queue
+let queue_length = queue.len();
+```

--- a/libs/reentrancy/README.md
+++ b/libs/reentrancy/README.md
@@ -1,0 +1,70 @@
+# Reentrancy Guard Library
+
+The Reentrancy Guard Library provides an API to check for and disallow reentrancy on a contract. A reentrancy attack happens when a function is externally invoked during its execution, allowing it to be run multiple times in a single transaction.
+
+The reentrancy check is used to check if a contract ID has been called more than once in the current call stack.
+
+A reentrancy, or "recursive call" attack can cause some functions to behave in unexpected ways. This can be prevented by asserting a contract has not yet been called in the current transaction. An example can be found [here](https://swcregistry.io/docs/SWC-107).
+
+For implementation details on the Reentrancy Guard Library please see the [Sway Libs Docs](https://fuellabs.github.io/sway-libs/master/sway_libs/reentrancy/reentrancy/).
+
+## Importing the Reentrancy Guard Library
+
+In order to use the Reentrancy Guard library, the Reentrancy Guard Library must be added to your `Forc.toml` file and then imported into your Sway project.
+
+To add the Reentrancy Guard Library as a dependency to your `Forc.toml` file in your project, use the `forc add` command.
+
+```bash
+forc add reentrancy@0.26.0
+```
+
+> **NOTE:** Be sure to set the version to the latest release.
+
+To import the Reentrancy Guard Library to your Sway Smart Contract, add the following to your Sway file:
+
+```sway
+use reentrancy::*;
+```
+
+## Basic Functionality
+
+Once imported, using the Reentrancy Library can be done by calling one of the two functions:
+
+- `is_reentrant() -> bool`
+- `reentrancy_guard()`
+
+### Using the Reentrancy Guard
+
+Once imported, using the Reentrancy Guard Library can be used by calling the `reentrancy_guard()` in your Sway Smart Contract. The following shows a Sway Smart Contract that applies the Reentrancy Guard Library:
+
+```sway
+use reentrancy::reentrancy_guard;
+
+abi MyContract {
+    fn my_non_reentrant_function();
+}
+
+impl MyContract for Contract {
+    fn my_non_reentrant_function() {
+        reentrancy_guard();
+
+        // my code here
+    }
+}
+```
+
+### Checking Reentrancy Status
+
+To check if the current caller is a reentrant, you may call the `is_reentrant()` function.
+
+```sway
+use reentrancy::is_reentrant;
+
+fn check_if_reentrant() {
+    assert(!is_reentrant());
+}
+```
+
+## Cross Contract Reentrancy
+
+Cross-Contract Reentrancy is not possible on Fuel due to the use of Native Assets. As such, no contract calls are performed when assets are transferred. However standard security practices when relying on other contracts for state should still be applied, especially when making external calls.

--- a/libs/signed_int/README.md
+++ b/libs/signed_int/README.md
@@ -1,0 +1,140 @@
+# Signed Integers Library
+
+The Signed Integers library provides a library to use signed numbers in Sway. It has 6 distinct types: `I8`, `I16`, `I32`, `I64`, `I128`, `I256`. These types are stack allocated.
+
+Internally the library uses the `u8`, `u16`, `u32`, `u64`, `U128`, `u256` types to represent the underlying values of the signed integers.
+
+For implementation details on the Signed Integers Library please see the [Sway Libs Docs](https://fuellabs.github.io/sway-libs/master/sway_libs/signed_int/signed_int/).
+
+## Importing the Signed Integer Library
+
+In order to use the Signed Integers Library, the Signed Integers Library must be added to your `Forc.toml` file and then imported into your Sway project.
+
+To add the Signed Integers Library as a dependency to your `Forc.toml` file in your project, use the `forc add` command.
+
+```bash
+forc add signed_int@0.26.0
+```
+
+> **NOTE:** Be sure to set the version to the latest release.
+
+To import the Signed Integers Library to your Sway Smart Contract, add the following to your Sway file:
+
+```sway
+use signed_int::*;
+```
+
+In order to use any of the Signed Integer types, import them into your Sway project like so:
+
+```sway
+use signed_int::i8::I8;
+```
+
+## Basic Functionality
+
+All the functionality is demonstrated with the `I8` type, but all of the same functionality is available for the other types as well.
+
+### Instantiating a Signed Integer
+
+#### Zero value
+
+Once imported, a `Signed Integer` type can be instantiated defining a new variable and calling the `new` function.
+
+```sway
+let mut i8_value = I8::new();
+```
+
+this newly initialized variable represents the value of `0`.
+
+The `new` function is functionally equivalent to the `zero` function.
+
+```sway
+let zero = I8::zero();
+```
+
+#### Positive and Negative Values
+
+As the signed variants can only represent half as high a number as the unsigned variants (but with either a positive or negative sign), the `try_from` and `neg_try_from` functions will only work with half of the maximum value of the unsigned variant.
+
+You can use the `try_from` function to create a new positive `Signed Integer` from a its unsigned variant.
+
+```sway
+let one = I8::try_from(1u8).unwrap();
+```
+
+You can use the `neg_try_from` function to create a new negative `Signed Integer` from a its unsigned variant.
+
+```sway
+let negative_one = I8::neg_try_from(1u8).unwrap();
+```
+
+#### With underlying value
+
+As mentioned previously, the signed integers are internally represented by an unsigned integer, with its values divided into two halves, the bottom half of the values represent the negative values and the top half represent the positive values, and the middle value represents zero.
+
+Therefore, for the lowest value representable by a i8, `-128`, the underlying value would be `0`.
+
+```sway
+let neg_128 = I8::from_uint(0u8);
+```
+
+For the zero value, the underlying value would be `128`.
+
+```sway
+let zero = I8::from_uint(128u8);
+```
+
+And for the highest value representable by a i8, `127`, the underlying value would be `255`.
+
+```sway
+let pos_127 = I8::from_uint(255u8);
+```
+
+#### Minimum and Maximum Values
+
+To get the minimum and maximum values of a signed integer, use the `min` and `max` functions.
+
+```sway
+let min = I8::MIN;
+```
+
+```sway
+let max = I8::MAX;
+```
+
+### Basic Mathematical Functions
+
+Basic arithmetic operations are working as usual.
+
+```sway
+fn add_signed_int(val1: I8, val2: I8) {
+    let result: I8 = val1 + val2;
+}
+
+fn subtract_signed_int(val1: I8, val2: I8) {
+    let result: I8 = val1 - val2;
+}
+
+fn multiply_signed_int(val1: I8, val2: I8) {
+    let result: I8 = val1 * val2;
+}
+
+fn divide_signed_int(val1: I8, val2: I8) {
+    let result: I8 = val1 / val2;
+}
+```
+
+#### Checking if a Signed Integer is Zero
+
+The library also provides a helper function to easily check if a `Signed Integer` is zero.
+
+```sway
+fn is_zero() {
+    let i8 = I8::zero();
+    assert(i8.is_zero());
+}
+```
+
+## Known Issues
+
+The current implementation of `U128` will compile large bytecode sizes when performing mathematical computations. As a result, `I128` and `I256` inherit the same issue and could cause high transaction costs. This should be resolved with future optimizations of the Sway compiler.

--- a/libs/upgradability/README.md
+++ b/libs/upgradability/README.md
@@ -1,0 +1,128 @@
+# Upgradability Library
+
+The Upgradability Library provides functions that can be used to implement contract upgrades via simple upgradable proxies. The Upgradability Library implements the required and optional functionality from [SRC-14](https://docs.fuel.network/docs/sway-standards/src-14-simple-upgradeable-proxies/) as well as additional functionality for ownership of the proxy contract.
+
+For implementation details on the Upgradability Library please see the [Sway Libs Docs](https://fuellabs.github.io/sway-libs/master/sway_libs/upgradability/upgradability/).
+
+## Importing the Upgradability Library
+
+In order to use the Upgradability Library, the Upgradability Library and the [SRC-14](https://docs.fuel.network/docs/sway-standards/src-14-simple-upgradeable-proxies/) Standard must be added to your `Forc.toml` file and then imported into your Sway project.
+
+To add the Upgradability Library and the [SRC-14](https://docs.fuel.network/docs/sway-standards/src-14-simple-upgradeable-proxies/) Standard as a dependency to your `Forc.toml` file in your project, use the `forc add` command.
+
+```bash
+forc add upgradability@0.26.0
+forc add src14@0.8.0
+```
+
+> **NOTE:** Be sure to set the version to the latest release.
+
+To import the Upgradability Library and  Standard to your Sway Smart Contract, add the following to your Sway file:
+
+```sway
+use upgradability::*;
+use src14::*;
+use src5::*;
+```
+
+## Integrating the Upgradability Library into the SRC-14 Standard
+
+To implement the [SRC-14](https://docs.fuel.network/docs/sway-standards/src-14-simple-upgradeable-proxies/) standard with the Upgradability library, be sure to add the Sway Standards dependency to your contract. The following demonstrates the integration of the Ownership library with the SRC-14 standard.
+
+```sway
+use upgradability::{_proxy_owner, _proxy_target, _set_proxy_target};
+use src14::{SRC14, SRC14Extension};
+use src5::State;
+
+storage {
+    SRC14 {
+        /// The [ContractId] of the target contract.
+        ///
+        /// # Additional Information
+        ///
+        /// `target` is stored at sha256("storage_SRC14_0")
+        target in 0x7bb458adc1d118713319a5baa00a2d049dd64d2916477d2688d76970c898cd55: Option<ContractId> = None,
+        /// The [State] of the proxy owner.
+        ///
+        /// # Additional Information
+        ///
+        /// `proxy_owner` is stored at sha256("storage_SRC14_1")
+        proxy_owner in 0xbb79927b15d9259ea316f2ecb2297d6cc8851888a98278c0a2e03e1a091ea754: State = State::Uninitialized,
+    },
+}
+
+impl SRC14 for Contract {
+    #[storage(read, write)]
+    fn set_proxy_target(new_target: ContractId) {
+        _set_proxy_target(new_target);
+    }
+
+    #[storage(read)]
+    fn proxy_target() -> Option<ContractId> {
+        _proxy_target()
+    }
+}
+
+impl SRC14Extension for Contract {
+    #[storage(read)]
+    fn proxy_owner() -> State {
+        _proxy_owner()
+    }
+}
+```
+
+> **NOTE** An initialization method must be implemented to initialize the proxy target or proxy owner.
+
+## Basic Functionality
+
+### Setting and getting a Proxy Target
+
+Once imported, the Upgradability Library's functions will be available. Use them to change the proxy target for your contract by calling the `set_proxy_target()` function.
+
+```sway
+#[storage(read, write)]
+fn set_proxy_target(new_target: ContractId) {
+    _set_proxy_target(new_target);
+}
+```
+
+Use the `proxy_target()` method to get the current proxy target.
+
+```sway
+#[storage(read)]
+fn proxy_target() -> Option<ContractId> {
+    _proxy_target()
+}
+```
+
+### Setting and getting a Proxy Owner
+
+To change the proxy target for your contract use the `set_proxy_owner()` function.
+
+```sway
+#[storage(write)]
+fn set_proxy_owner(new_proxy_owner: State) {
+    _set_proxy_owner(new_proxy_owner);
+}
+```
+
+Use the `proxy_owner()` method to get the current proxy owner.
+
+```sway
+#[storage(read)]
+fn proxy_owner() -> State {
+    _proxy_owner()
+}
+```
+
+### Proxy access control
+
+To restrict a function to only be callable by the proxy's owner, call the `only_proxy_owner()` function.
+
+```sway
+#[storage(read)]
+fn only_proxy_owner_may_call() {
+    only_proxy_owner();
+    // Only the proxy's owner may reach this line.
+}
+```


### PR DESCRIPTION
## Type of change

<!--Delete points that do not apply-->

- Documentation


## Changes

The following changes have been made:

- Adds README.md files to all libraries to be integrated with forc.pub

## Notes

- When https://github.com/FuelLabs/sway/pull/7264 is resolved the README will link to the existing docs if `docs/book/`

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [x] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
- [x] I have updated the changelog to reflect the changes on this PR.
