### PR TITLE
Bump `forc` to 0.72.0 and `asset` to 0.27.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,9 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   REGISTRY: ghcr.io
-  RUST_VERSION: 1.90.0
-  FORC_VERSION: 0.70.2
-  CORE_VERSION: 0.47.1
+  RUST_VERSION: 1.93.0
+  FORC_VERSION: 0.72.0
+  CORE_VERSION: 0.48.2
 
 jobs:
   build-sway-lib:
@@ -41,15 +41,6 @@ jobs:
       steps:
         - name: Checkout repository
           uses: actions/checkout@v3
-
-        - name: Install Rust toolchain
-          uses: dtolnay/rust-toolchain@master
-          with:
-            toolchain: ${{ env.RUST_VERSION }}
-            components: rustfmt
-
-        - name: Init cache
-          uses: Swatinem/rust-cache@v2
 
         - name: Install Fuel toolchain
           uses: FuelLabs/action-fuel-toolchain@v0.6.0
@@ -93,7 +84,7 @@ jobs:
         - name: Build All Tests
           run: forc build --path tests --release --locked
           
-        - name: Cargo Test sway-lib
+        - name: Cargo Test sway-libs
           run: cargo test --manifest-path tests/Cargo.toml
 
   forc-inline-tests:
@@ -118,14 +109,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ env.RUST_VERSION }}
-
-      - name: Init cache
-        uses: Swatinem/rust-cache@v2
-
       - name: Install Fuel toolchain
         uses: FuelLabs/action-fuel-toolchain@v0.6.0
         with:
@@ -146,15 +129,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ env.RUST_VERSION }}
-          components: rustfmt
-
-      - name: Init cache
-        uses: Swatinem/rust-cache@v2
 
       - name: Install Fuel toolchain
         uses: FuelLabs/action-fuel-toolchain@v0.6.0
@@ -189,14 +163,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ env.RUST_VERSION }}
-
-      - name: Init cache
-        uses: Swatinem/rust-cache@v2
 
       - name: Install Fuel toolchain
         uses: FuelLabs/action-fuel-toolchain@v0.6.0

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -8,9 +8,8 @@ on:
       - v*
 
 env:
-  RUST_VERSION: 1.90.0
-  FORC_VERSION: 0.70.2
-  CORE_VERSION: 0.47.1
+  FORC_VERSION: 0.72.0
+  CORE_VERSION: 0.48.2
 
 jobs:
   deploy-contributing:
@@ -54,14 +53,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ env.RUST_VERSION }}
-
-      - name: Init cache
-        uses: Swatinem/rust-cache@v2
 
       - name: Install Fuel toolchain
         uses: FuelLabs/action-fuel-toolchain@v0.6.0

--- a/.github/workflows/publish-libs.yml
+++ b/.github/workflows/publish-libs.yml
@@ -11,11 +11,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
 
 env:
-  CARGO_TERM_COLOR: always
   REGISTRY: ghcr.io
-  RUST_VERSION: 1.90.0
-  FORC_VERSION: 0.70.2
-  CORE_VERSION: 0.47.1
+  FORC_VERSION: 0.72.0
+  CORE_VERSION: 0.48.2
 
 jobs:
   verify-branch:
@@ -87,17 +85,6 @@ jobs:
           else
             echo "changed=false" >> $GITHUB_OUTPUT
           fi
-
-      - name: Install Rust toolchain
-        if: steps.version-check.outputs.changed == 'true'
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ env.RUST_VERSION }}
-          components: rustfmt
-
-      - name: Init cache
-        if: steps.version-check.outputs.changed == 'true'
-        uses: Swatinem/rust-cache@v2
 
       - name: Install Fuel toolchain
         if: steps.version-check.outputs.changed == 'true'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,0 @@
-[package]
-name = "sway-libs"
-version = "0.25.2"
-edition = "2021"

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
     <a href="https://github.com/FuelLabs/sway-libs/actions/workflows/ci.yml" alt="CI">
         <img src="https://github.com/FuelLabs/sway-libs/actions/workflows/ci.yml/badge.svg" />
     </a>
-    <a href="https://crates.io/crates/forc/0.70.2" alt="forc">
-        <img src="https://img.shields.io/badge/forc-v0.70.2-orange" />
+    <a href="https://crates.io/crates/forc/0.72.0" alt="forc">
+        <img src="https://img.shields.io/badge/forc-v0.72.0-orange" />
     </a>
     <a href="./LICENSE" alt="forc">
         <img src="https://img.shields.io/github/license/FuelLabs/sway-libs" />
@@ -106,7 +106,7 @@ For more information about implementation please refer to the [Sway Libs Docs Hu
 
 ## Running Tests
 
-There are two sets of tests that should be run: inline tests and sdk-harness tests. Please make sure you are using `forc v0.70.2` and `fuel-core v0.47.1`. You can check what version you are using by running the `fuelup show` command.
+There are two sets of tests that should be run: inline tests and sdk-harness tests. Please make sure you are using `forc v0.72.0` and `fuel-core v0.48.2`. You can check what version you are using by running the `fuelup show` command.
 
 Make sure you are in the source directory of this repository `sway-libs/<you are here>`.
 
@@ -128,7 +128,7 @@ forc test --path tests --release --locked && cargo test --manifest-path tests/Ca
 Any instructions related to using a specific library should be found within the README.md of that library.
 
 > **NOTE:**
-> All projects currently use `forc v0.70.2`, `fuels-rs v0.70.0` and `fuel-core v0.47.1`.
+> All projects currently use `forc v0.72.0`, `fuels-rs v0.77.0` and `fuel-core v0.48.2`.
 
 ## Contributing
 

--- a/docs/book/src/getting_started/index.md
+++ b/docs/book/src/getting_started/index.md
@@ -32,7 +32,7 @@ use ownership::only_owner;
 ```
 
 > **NOTE:**
-> All projects currently use `forc v0.70.2`, `fuels-rs v0.70.0` and `fuel-core v0.47.1`.
+> All projects currently use `forc v0.72.0`, `fuels-rs v0.77.0` and `fuel-core v0.48.2`.
 
 ## Using Sway Libs
 

--- a/docs/contributing-book/src/pull-requests/commit.md
+++ b/docs/contributing-book/src/pull-requests/commit.md
@@ -42,7 +42,4 @@ The commit message should be a concise and accurate summary of the work done:
   - Fixed function
   - Fixed an assertion where a user is able to repeatedly call the `withdraw()` functions under an edge case which may lead to the contract being drained
 
-More information about commit messages may be found in:
-
-- The README from [joelparkerhenderson](https://github.com/joelparkerhenderson/git-commit-message/#git-commit-message)
-- The [Medium article](https://medium.com/swlh/writing-better-commit-messages-9b0b6ff60c67) by Apurva Jain
+More information about commit messages may be found in the README from [joelparkerhenderson](https://github.com/joelparkerhenderson/git-commit-message/#git-commit-message).

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -6,9 +6,9 @@ edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]
-fuel-merkle = { version = "0.56.0" }
+fuel-merkle = { version = "0.66.2" }
 sha2 = { version = "0.10" }
-fuels = { version = "0.70.0" }
+fuels = { version = "0.77.0" }
 tokio = { version = "1.12", features = ["rt", "macros"] }
 
 [[test]]

--- a/examples/Forc.lock
+++ b/examples/Forc.lock
@@ -182,8 +182,8 @@ dependencies = ["std"]
 
 [[package]]
 name = "std"
-version = "0.70.2"
-source = "registry+std?0.70.2#QmWuWwmjn2vVDup2672LpToek8N58PYGJt2eH55M7ZzY2Y!"
+version = "0.72.0"
+source = "registry+std?0.72.0#QmTnRFTVHzAWatvZXEPVnaiJrs81CZLkYbEovHzPTyNyis!"
 
 [[package]]
 name = "upgradability"

--- a/examples/asset/basic_src7/Forc.lock
+++ b/examples/asset/basic_src7/Forc.lock
@@ -2,7 +2,8 @@
 name = "asset"
 source = "path+from-root-7578654C0362FA69"
 dependencies = [
-    "standards git+https://github.com/FuelLabs/sway-standards?tag=v0.7.1#1b00ccc05af5886ae3abd07a9a0ce6122738fc48",
+    "src20",
+    "src7",
     "std",
 ]
 
@@ -11,31 +12,23 @@ name = "basic_src7"
 source = "member"
 dependencies = [
     "asset",
-    "standards git+https://github.com/FuelLabs/sway-standards?tag=v0.7.0#7d35df95e0b96dc8ad188ab169fbbeeac896aae8",
+    "src7",
     "std",
 ]
 
 [[package]]
-name = "standards"
-source = "git+https://github.com/FuelLabs/sway-standards?tag=v0.7.0#7d35df95e0b96dc8ad188ab169fbbeeac896aae8"
+name = "src20"
+version = "0.8.2"
+source = "registry+src20?0.8.2#QmUiXq3uPWaf6BxLeNdm8sHsjwbwQ5DRvBGLezv2k5EZ26!"
 dependencies = ["std"]
 
 [[package]]
-name = "standards"
-source = "git+https://github.com/FuelLabs/sway-standards?tag=v0.7.1#1b00ccc05af5886ae3abd07a9a0ce6122738fc48"
-dependencies = [
-    "std",
-    "sway_libs",
-]
+name = "src7"
+version = "0.8.3"
+source = "registry+src7?0.8.3#QmWv6hJb4CDkw7reaFrp59hkGBM48YiEjDYsNDYmBWJ7NC!"
+dependencies = ["std"]
 
 [[package]]
 name = "std"
-source = "git+https://github.com/fuellabs/sway?tag=v0.68.4#1fb61fdc42054109c54a57544b9aeb88afd3cae8"
-
-[[package]]
-name = "sway_libs"
-source = "git+https://github.com/FuelLabs/sway-libs?tag=v0.25.2#f43d8b4aacf60867989408991414958f8eab28c0"
-dependencies = [
-    "standards git+https://github.com/FuelLabs/sway-standards?tag=v0.7.0#7d35df95e0b96dc8ad188ab169fbbeeac896aae8",
-    "std",
-]
+version = "0.72.0"
+source = "registry+std?0.72.0#QmTnRFTVHzAWatvZXEPVnaiJrs81CZLkYbEovHzPTyNyis!"

--- a/examples/asset/basic_src7/Forc.toml
+++ b/examples/asset/basic_src7/Forc.toml
@@ -5,5 +5,5 @@ license = "Apache-2.0"
 name = "basic_src7"
 
 [dependencies]
-src7 = "0.8.2"
+src7 = "0.8.3"
 asset = { path = "../../../libs/asset" }

--- a/examples/asset/metadata_docs/Forc.toml
+++ b/examples/asset/metadata_docs/Forc.toml
@@ -5,5 +5,5 @@ license = "Apache-2.0"
 name = "metadata_docs"
 
 [dependencies]
-src7 = "0.8.2"
+src7 = "0.8.3"
 asset = { path = "../../../libs/asset" }

--- a/examples/asset/metadata_docs/src/main.sw
+++ b/examples/asset/metadata_docs/src/main.sw
@@ -49,18 +49,14 @@ fn get_metadata(asset: AssetId, key: String) {
 
     // ANCHOR: get_metadata_match
     match metadata.unwrap() {
-        Metadata::B256(b256) => {
-        // do something with b256
-},
-        Metadata::Bytes(bytes) => {
-        // do something with bytes
-},
-        Metadata::Int(int) => {
-        // do something with int
-},
-        Metadata::String(string) => {
-        // do something with string
-},
+        // Do something with `b256`.
+        Metadata::B256(b256) => {},
+        // Do something with `bytes`.
+        Metadata::Bytes(bytes) => {},
+        // Do something with `int`.
+        Metadata::Int(int) => {},
+        // Do something with `string`.
+        Metadata::String(string) => {},
     }
     // ANCHOR_END: get_metadata_match
 

--- a/examples/asset/setting_src7_attributes/Forc.toml
+++ b/examples/asset/setting_src7_attributes/Forc.toml
@@ -5,5 +5,5 @@ license = "Apache-2.0"
 name = "setting_src7_attributes"
 
 [dependencies]
-src7 = "0.8.2"
+src7 = "0.8.3"
 asset = { path = "../../../libs/asset" }

--- a/examples/merkle_binary/mod.rs
+++ b/examples/merkle_binary/mod.rs
@@ -12,7 +12,7 @@ abigen!(Contract(
     abi = "merkle_binary/out/release/merkle_binary_examples-abi.json"
 ));
 
-async fn get_contract_instance() -> (MerkleExample<WalletUnlocked>, WalletUnlocked) {
+async fn get_contract_instance() -> (MerkleExample<Wallet>, Wallet) {
     // Launch a local network and deploy the contract
     let mut wallets = launch_custom_provider_and_get_wallets(
         WalletsConfig::new(
@@ -34,7 +34,8 @@ async fn get_contract_instance() -> (MerkleExample<WalletUnlocked>, WalletUnlock
     .unwrap()
     .deploy(&wallet, TxPolicies::default())
     .await
-    .unwrap();
+    .unwrap()
+    .contract_id;
 
     let instance = MerkleExample::new(id, wallet.clone());
 

--- a/examples/merkle_sparse/mod.rs
+++ b/examples/merkle_sparse/mod.rs
@@ -14,7 +14,7 @@ abigen!(Contract(
     abi = "merkle_sparse/out/release/merkle_sparse_examples-abi.json"
 ));
 
-async fn get_contract_instance() -> (MerkleExample<WalletUnlocked>, WalletUnlocked) {
+async fn get_contract_instance() -> (MerkleExample<Wallet>, Wallet) {
     // Launch a local network and deploy the contract
     let mut wallets = launch_custom_provider_and_get_wallets(
         WalletsConfig::new(
@@ -36,7 +36,8 @@ async fn get_contract_instance() -> (MerkleExample<WalletUnlocked>, WalletUnlock
     .unwrap()
     .deploy(&wallet, TxPolicies::default())
     .await
-    .unwrap();
+    .unwrap()
+    .contract_id;
 
     let instance = MerkleExample::new(id, wallet.clone());
 

--- a/justfile
+++ b/justfile
@@ -1,0 +1,22 @@
+# lists the available recipes
+default:
+    @just --list --unsorted
+
+alias bl := build-libs
+# builds the libraries; additional arguments are forwarded to `forc build`, e.g.: `just bl --release`
+build-libs *args:
+    ./scripts/build-libs.sh {{ args }}
+
+alias be := build-examples
+# builds the examples; additional arguments are forwarded to `forc build`, e.g.: `just be --release`
+build-examples *args:
+    ./scripts/build-examples.sh {{ args }}
+
+alias bt := build-tests
+# builds the tests; additional arguments are forwarded to `forc build`, e.g.: `just bt --release`
+build-tests *args:
+    ./scripts/build-tests.sh {{ args }}
+
+alias ba := build-all
+# builds the libraries, the examples, and the tests; e.g.: `just ba --release`
+build-all *args: (build-libs args) (build-examples args) (build-tests args)

--- a/libs/admin/Forc.lock
+++ b/libs/admin/Forc.lock
@@ -24,5 +24,5 @@ dependencies = ["std"]
 
 [[package]]
 name = "std"
-version = "0.70.2"
-source = "registry+std?0.70.2#QmWuWwmjn2vVDup2672LpToek8N58PYGJt2eH55M7ZzY2Y!"
+version = "0.72.0"
+source = "registry+std?0.72.0#QmTnRFTVHzAWatvZXEPVnaiJrs81CZLkYbEovHzPTyNyis!"

--- a/libs/asset/Forc.lock
+++ b/libs/asset/Forc.lock
@@ -15,11 +15,11 @@ dependencies = ["std"]
 
 [[package]]
 name = "src7"
-version = "0.8.2"
-source = "registry+src7?0.8.2#QmXxuQD9GR4sa5kybYBFf2w2HmBzvUqGN5ypbTmT6gp1V5!"
+version = "0.8.3"
+source = "registry+src7?0.8.3#QmWv6hJb4CDkw7reaFrp59hkGBM48YiEjDYsNDYmBWJ7NC!"
 dependencies = ["std"]
 
 [[package]]
 name = "std"
-version = "0.70.2"
-source = "registry+std?0.70.2#QmWuWwmjn2vVDup2672LpToek8N58PYGJt2eH55M7ZzY2Y!"
+version = "0.72.0"
+source = "registry+std?0.72.0#QmTnRFTVHzAWatvZXEPVnaiJrs81CZLkYbEovHzPTyNyis!"

--- a/libs/asset/Forc.toml
+++ b/libs/asset/Forc.toml
@@ -3,7 +3,7 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 entry = "lib.sw"
 license = "Apache-2.0"
 name = "asset"
-version = "0.26.2"
+version = "0.27.0"
 description = "The Asset Library provides basic helper functions for the SRC-20, SRC-3, and the SRC-7 standards. It is intended to make development of Native Assets using Sway quick and easy while following the standard's specifications."
 homepage = "https://docs.fuel.network/docs/sway-libs/asset/"
 repository = "https://github.com/FuelLabs/sway-libs"
@@ -14,4 +14,4 @@ keywords = ["library"]
 
 [dependencies]
 src20 = "0.8.2"
-src7 = "0.8.2"
+src7 = "0.8.3"

--- a/libs/asset/src/base.sw
+++ b/libs/asset/src/base.sw
@@ -356,7 +356,7 @@ abi SetAssetAttributes {
     /// # Example
     ///
     /// ```sway
-    /// use standards::src20::SRC20;
+    /// use src20::SRC20;
     /// use asset::base::*;
     /// use std::string::String;
     ///
@@ -378,7 +378,7 @@ abi SetAssetAttributes {
     /// # Example
     ///
     /// ```sway
-    /// use standards::src20::SRC20;
+    /// use src20::SRC20;
     /// use asset::base::*;
     /// use std::string::String;
     ///
@@ -400,7 +400,7 @@ abi SetAssetAttributes {
     /// # Example
     ///
     /// ```sway
-    /// use standards::src20::SRC20;
+    /// use src20::SRC20;
     /// use asset::base::*;
     ///
     /// fn foo(contract_id: ContractId, asset: AssetId, decimals: u8) {

--- a/libs/asset/src/metadata.sw
+++ b/libs/asset/src/metadata.sw
@@ -10,8 +10,8 @@ use std::{
     },
     storage::{
         storage_api::{
-            read,
-            write,
+            read_quads,
+            write_quads,
         },
         storage_bytes::*,
         storage_string::*,
@@ -48,7 +48,7 @@ impl StorageKey<StorageMetadata> {
     /// # Example
     ///
     /// ```sway
-    /// use standards::src7::Metadata;
+    /// use src7::Metadata;
     /// use asset::metadata::*;
     /// use std::string::String;
     ///
@@ -66,26 +66,26 @@ impl StorageKey<StorageMetadata> {
 
         match metadata {
             Metadata::Int(data) => {
-                write(hashed_key, 0, data);
-                write(sha256((hashed_key, self.slot())), 0, 1);
+                write_quads(hashed_key, 0, data);
+                write_quads(sha256((hashed_key, self.slot())), 0, 1);
             },
             Metadata::B256(data) => {
-                write(hashed_key, 0, data);
-                write(sha256((hashed_key, self.slot())), 0, 2);
+                write_quads(hashed_key, 0, data);
+                write_quads(sha256((hashed_key, self.slot())), 0, 2);
             },
             Metadata::String(data) => {
                 require(!data.is_empty(), SetMetadataError::EmptyString);
 
                 let storage_string: StorageKey<StorageString> = StorageKey::new(hashed_key, 0, hashed_key);
                 storage_string.write_slice(data);
-                write(sha256((hashed_key, self.slot())), 0, 3);
+                write_quads(sha256((hashed_key, self.slot())), 0, 3);
             },
             Metadata::Bytes(data) => {
                 require(!data.is_empty(), SetMetadataError::EmptyBytes);
 
                 let storage_bytes: StorageKey<StorageBytes> = StorageKey::new(hashed_key, 0, hashed_key);
                 storage_bytes.write_slice(data);
-                write(sha256((hashed_key, self.slot())), 0, 4);
+                write_quads(sha256((hashed_key, self.slot())), 0, 4);
             },
         }
 
@@ -115,7 +115,7 @@ impl StorageKey<StorageMetadata> {
     /// # Example
     ///
     /// ```sway
-    /// use standards::src7::Metadata;
+    /// use src7::Metadata;
     /// use asset::metadata::*;
     /// use std::string::String;
     ///
@@ -132,12 +132,12 @@ impl StorageKey<StorageMetadata> {
     pub fn get(self, asset: AssetId, key: String) -> Option<Metadata> {
         let hashed_key = sha256((asset, key));
 
-        match read::<u64>(sha256((hashed_key, self.slot())), 0) {
+        match read_quads::<u64>(sha256((hashed_key, self.slot())), 0) {
             Some(1) => {
-                Some(Metadata::Int(read::<u64>(hashed_key, 0).unwrap()))
+                Some(Metadata::Int(read_quads::<u64>(hashed_key, 0).unwrap()))
             },
             Some(2) => {
-                Some(Metadata::B256(read::<b256>(hashed_key, 0).unwrap()))
+                Some(Metadata::B256(read_quads::<b256>(hashed_key, 0).unwrap()))
             },
             Some(3) => {
                 let storage_string: StorageKey<StorageString> = StorageKey::new(hashed_key, 0, hashed_key);
@@ -168,7 +168,7 @@ impl StorageKey<StorageMetadata> {
 /// # Example
 ///
 /// ```sway
-/// use standards::src7::Metadata;
+/// use src7::Metadata;
 /// use asset::metadata::*;
 /// use std::string::String;
 ///
@@ -206,7 +206,7 @@ pub fn _set_metadata(
 /// # Example
 ///
 /// ```sway
-/// use standards::src7::Metadata;
+/// use src7::Metadata;
 /// use asset::metadata::*;
 /// use std::string::String;
 ///
@@ -226,6 +226,7 @@ pub fn _metadata(
 ) -> Option<Metadata> {
     metadata_key.get(asset, key)
 }
+
 abi SetAssetMetadata {
     /// Stores metadata for a specific asset and key pair.
     ///
@@ -238,7 +239,7 @@ abi SetAssetMetadata {
     /// # Example
     ///
     /// ```sway
-    /// use standards::src7::{SRC7, Metadata};
+    /// use src7::{SRC7, Metadata};
     /// use asset::metadata::*;
     /// use std::string::String;
     ///
@@ -250,226 +251,4 @@ abi SetAssetMetadata {
     /// ```
     #[storage(read, write)]
     fn set_metadata(asset: AssetId, key: String, metadata: Metadata);
-}
-
-impl Metadata {
-    /// Returns the underlying metadata as a `String`.
-    ///
-    /// # Returns
-    ///
-    /// * [Option<String>] - `Some` if the underlying type is a `String`, otherwise `None`.
-    ///
-    /// # Examples
-    ///
-    /// ```sway
-    /// use std::string::String;
-    /// use asset::metadata::*;
-    /// use standards::src7::{SRC7, Metadata};
-    ///
-    /// fn foo(contract_id: ContractId, asset: AssetId, key: String) {
-    ///     let metadata_abi = abi(SRC7, contract_id);
-    ///     let metadata = metadata_abi.metadata(asset, key);
-    ///
-    ///     let string = metadata.unwrap().as_string();
-    ///     assert(string.len() != 0);
-    /// }
-    /// ```
-    pub fn as_string(self) -> Option<String> {
-        match self {
-            Self::String(data) => Option::Some(data),
-            _ => Option::None,
-        }
-    }
-
-    /// Returns whether the underlying metadata is a `String`.
-    ///
-    /// # Returns
-    ///
-    /// * [bool] - `true` if the metadata is a `String`, otherwise `false`.
-    ///
-    /// # Examples
-    ///
-    /// ```sway
-    /// use std::string::String;
-    /// use asset::metadata::*;
-    /// use standards::src7::{SRC7, Metadata};
-    ///
-    /// fn foo(contract_id: ContractId, asset: AssetId, key: String) {
-    ///     let metadata_abi = abi(SRC7, contract_id);
-    ///     let metadata = metadata_abi.metadata(asset, key);
-    ///
-    ///     assert(metadata.unwrap().is_string());
-    /// }
-    /// ```
-    pub fn is_string(self) -> bool {
-        match self {
-            Self::String(_) => true,
-            _ => false,
-        }
-    }
-
-    /// Returns the underlying metadata as a `u64`.
-    ///
-    /// # Returns
-    ///
-    /// * [Option<u64>] - `Some` if the underlying type is a `u64`, otherwise `None`.
-    ///
-    /// # Examples
-    ///
-    /// ```sway
-    /// use std::string::String;
-    /// use asset::metadata::*;
-    /// use standards::src7::{SRC7, Metadata};
-    ///
-    /// fn foo(contract_id: ContractId, asset: AssetId, key: String) {
-    ///     let metadata_abi = abi(SRC7, contract_id);
-    ///     let metadata = metadata_abi.metadata(asset, key);
-    ///
-    ///     let int = metadata.unwrap().as_u64();
-    ///     assert(int != 0);
-    /// }
-    /// ```
-    pub fn as_u64(self) -> Option<u64> {
-        match self {
-            Self::Int(data) => Option::Some(data),
-            _ => Option::None,
-        }
-    }
-
-    /// Returns whether the underlying metadata is a `u64`.
-    ///
-    /// # Returns
-    ///
-    /// * [bool] - `true` if the metadata is a `u64`, otherwise `false`.
-    ///
-    /// # Examples
-    ///
-    /// ```sway
-    /// use std::string::String;
-    /// use asset::metadata::*;
-    /// use standards::src7::{SRC7, Metadata};
-    ///
-    /// fn foo(contract_id: ContractId, asset: AssetId, key: String) {
-    ///     let metadata_abi = abi(SRC7, contract_id);
-    ///     let metadata = metadata_abi.metadata(asset, key);
-    ///
-    ///     assert(metadata.unwrap().is_u64());
-    /// }
-    /// ```
-    pub fn is_u64(self) -> bool {
-        match self {
-            Self::Int(_) => true,
-            _ => false,
-        }
-    }
-
-    /// Returns the underlying metadata as `Bytes`.
-    ///
-    /// # Returns
-    ///
-    /// * [Option<Bytes>] - `Some` if the underlying type is `Bytes`, otherwise `None`.
-    ///
-    /// # Examples
-    ///
-    /// ```sway
-    /// use std::{bytes::Bytes, string::String};
-    /// use asset::metadata::*;
-    /// use standards::src7::{SRC7, Metadata};
-    ///
-    /// fn foo(contract_id: ContractId, asset: AssetId, key: String) {
-    ///     let metadata_abi = abi(SRC7, contract_id);
-    ///     let metadata = metadata_abi.metadata(asset, key);
-    ///
-    ///     let bytes = metadata.unwrap().as_bytes();
-    ///     assert(bytes.len() != 0);
-    /// }
-    /// ```
-    pub fn as_bytes(self) -> Option<Bytes> {
-        match self {
-            Self::Bytes(data) => Option::Some(data),
-            _ => Option::None,
-        }
-    }
-
-    /// Returns whether the underlying metadata is `Bytes`.
-    ///
-    /// # Returns
-    ///
-    /// * [bool] - `true` if the metadata is `Bytes`, otherwise `false`.
-    ///
-    /// # Examples
-    ///
-    /// ```sway
-    /// use std::{bytes::Bytes, string::String};
-    /// use asset::metadata::*;
-    /// use standards::src7::{SRC7, Metadata};
-    ///
-    /// fn foo(contract_id: ContractId, asset: AssetId, key: String) {
-    ///     let metadata_abi = abi(SRC7, contract_id);
-    ///     let metadata = metadata_abi.metadata(asset, key);
-    ///
-    ///     assert(metadata.unwrap().is_bytes());
-    /// }
-    /// ```
-    pub fn is_bytes(self) -> bool {
-        match self {
-            Self::Bytes(_) => true,
-            _ => false,
-        }
-    }
-
-    /// Returns the underlying metadata as a `b256`.
-    ///
-    /// # Returns
-    ///
-    /// * [Option<u64>] - `Some` if the underlying type is a `b256`, otherwise `None`.
-    ///
-    /// # Examples
-    ///
-    /// ```sway
-    /// use std::string::String;
-    /// use asset::metadata::*;
-    /// use standards::src7::{SRC7, Metadata};
-    ///
-    /// fn foo(contract_id: ContractId, asset: AssetId, key: String) {
-    ///     let metadata_abi = abi(SRC7, contract_id);
-    ///     let metadata = metadata_abi.metadata(asset, key);
-    ///
-    ///     let val = metadata.unwrap().as_b256();
-    ///     assert(val != b256::zero());
-    /// }
-    /// ```
-    pub fn as_b256(self) -> Option<b256> {
-        match self {
-            Self::B256(data) => Option::Some(data),
-            _ => Option::None,
-        }
-    }
-
-    /// Returns whether the underlying metadata is a `b256`.
-    ///
-    /// # Returns
-    ///
-    /// * [bool] - `true` if the metadata is a `b256`, otherwise `false`.
-    ///
-    /// # Examples
-    ///
-    /// ```sway
-    /// use std::string::String;
-    /// use asset::metadata::*;
-    /// use standards::src7::{SRC7, Metadata};
-    ///
-    /// fn foo(contract_id: ContractId, asset: AssetId, key: String) {
-    ///     let metadata_abi = abi(SRC7, contract_id);
-    ///     let metadata = metadata_abi.metadata(asset, key);
-    ///
-    ///     assert(metadata.unwrap().is_b256());
-    /// }
-    /// ```
-    pub fn is_b256(self) -> bool {
-        match self {
-            Self::B256(_) => true,
-            _ => false,
-        }
-    }
 }

--- a/libs/big_int/Forc.lock
+++ b/libs/big_int/Forc.lock
@@ -5,5 +5,5 @@ dependencies = ["std"]
 
 [[package]]
 name = "std"
-version = "0.70.2"
-source = "registry+std?0.70.2#QmWuWwmjn2vVDup2672LpToek8N58PYGJt2eH55M7ZzY2Y!"
+version = "0.72.0"
+source = "registry+std?0.72.0#QmTnRFTVHzAWatvZXEPVnaiJrs81CZLkYbEovHzPTyNyis!"

--- a/libs/bytecode/Forc.lock
+++ b/libs/bytecode/Forc.lock
@@ -5,5 +5,5 @@ dependencies = ["std"]
 
 [[package]]
 name = "std"
-version = "0.70.2"
-source = "registry+std?0.70.2#QmWuWwmjn2vVDup2672LpToek8N58PYGJt2eH55M7ZzY2Y!"
+version = "0.72.0"
+source = "registry+std?0.72.0#QmTnRFTVHzAWatvZXEPVnaiJrs81CZLkYbEovHzPTyNyis!"

--- a/libs/merkle/Forc.lock
+++ b/libs/merkle/Forc.lock
@@ -5,5 +5,5 @@ dependencies = ["std"]
 
 [[package]]
 name = "std"
-version = "0.70.2"
-source = "registry+std?0.70.2#QmWuWwmjn2vVDup2672LpToek8N58PYGJt2eH55M7ZzY2Y!"
+version = "0.72.0"
+source = "registry+std?0.72.0#QmTnRFTVHzAWatvZXEPVnaiJrs81CZLkYbEovHzPTyNyis!"

--- a/libs/ownership/Forc.lock
+++ b/libs/ownership/Forc.lock
@@ -14,5 +14,5 @@ dependencies = ["std"]
 
 [[package]]
 name = "std"
-version = "0.70.2"
-source = "registry+std?0.70.2#QmWuWwmjn2vVDup2672LpToek8N58PYGJt2eH55M7ZzY2Y!"
+version = "0.72.0"
+source = "registry+std?0.72.0#QmTnRFTVHzAWatvZXEPVnaiJrs81CZLkYbEovHzPTyNyis!"

--- a/libs/pausable/Forc.lock
+++ b/libs/pausable/Forc.lock
@@ -5,5 +5,5 @@ dependencies = ["std"]
 
 [[package]]
 name = "std"
-version = "0.70.2"
-source = "registry+std?0.70.2#QmWuWwmjn2vVDup2672LpToek8N58PYGJt2eH55M7ZzY2Y!"
+version = "0.72.0"
+source = "registry+std?0.72.0#QmTnRFTVHzAWatvZXEPVnaiJrs81CZLkYbEovHzPTyNyis!"

--- a/libs/queue/Forc.lock
+++ b/libs/queue/Forc.lock
@@ -5,5 +5,5 @@ dependencies = ["std"]
 
 [[package]]
 name = "std"
-version = "0.70.2"
-source = "registry+std?0.70.2#QmWuWwmjn2vVDup2672LpToek8N58PYGJt2eH55M7ZzY2Y!"
+version = "0.72.0"
+source = "registry+std?0.72.0#QmTnRFTVHzAWatvZXEPVnaiJrs81CZLkYbEovHzPTyNyis!"

--- a/libs/reentrancy/Forc.lock
+++ b/libs/reentrancy/Forc.lock
@@ -5,5 +5,5 @@ dependencies = ["std"]
 
 [[package]]
 name = "std"
-version = "0.70.2"
-source = "registry+std?0.70.2#QmWuWwmjn2vVDup2672LpToek8N58PYGJt2eH55M7ZzY2Y!"
+version = "0.72.0"
+source = "registry+std?0.72.0#QmTnRFTVHzAWatvZXEPVnaiJrs81CZLkYbEovHzPTyNyis!"

--- a/libs/signed_int/Forc.lock
+++ b/libs/signed_int/Forc.lock
@@ -5,5 +5,5 @@ dependencies = ["std"]
 
 [[package]]
 name = "std"
-version = "0.70.2"
-source = "registry+std?0.70.2#QmWuWwmjn2vVDup2672LpToek8N58PYGJt2eH55M7ZzY2Y!"
+version = "0.72.0"
+source = "registry+std?0.72.0#QmTnRFTVHzAWatvZXEPVnaiJrs81CZLkYbEovHzPTyNyis!"

--- a/libs/upgradability/Forc.lock
+++ b/libs/upgradability/Forc.lock
@@ -15,8 +15,8 @@ dependencies = ["std"]
 
 [[package]]
 name = "std"
-version = "0.70.2"
-source = "registry+std?0.70.2#QmWuWwmjn2vVDup2672LpToek8N58PYGJt2eH55M7ZzY2Y!"
+version = "0.72.0"
+source = "registry+std?0.72.0#QmTnRFTVHzAWatvZXEPVnaiJrs81CZLkYbEovHzPTyNyis!"
 
 [[package]]
 name = "upgradability"

--- a/scripts/build-examples.sh
+++ b/scripts/build-examples.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+# Builds the examples located in the `./examples` folder. The examples are a
+# single workspace, so building it builds all of its member projects.
+#
+# Any arguments passed to this script are forwarded as-is to `forc build`, e.g.:
+#
+#     ./scripts/build-examples.sh --release --experimental dynamic_storage
+#
+# See `build.sh` for the full behavior.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec "${SCRIPT_DIR}/build.sh" examples example "$@"

--- a/scripts/build-libs.sh
+++ b/scripts/build-libs.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# Builds all the libraries located in the `./libs` folder, in parallel.
+#
+# Any arguments passed to this script are forwarded as-is to `forc build`, e.g.:
+#
+#     ./scripts/build-libs.sh --release --experimental dynamic_storage
+#
+# See `build.sh` for the full behavior.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec "${SCRIPT_DIR}/build.sh" libs library "$@"

--- a/scripts/build-tests.sh
+++ b/scripts/build-tests.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+# Builds the tests located in the `./tests` folder. The tests are a single
+# workspace, so building it builds all of its member projects.
+#
+# Any arguments passed to this script are forwarded as-is to `forc build`, e.g.:
+#
+#     ./scripts/build-tests.sh --release --experimental dynamic_storage
+#
+# See `build.sh` for the full behavior.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec "${SCRIPT_DIR}/build.sh" tests test "$@"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,199 @@
+#!/usr/bin/env bash
+
+# Shared implementation behind `build-<artifacts>.sh` scripts.
+#
+# Usage: build.sh <subdir> <label> [extra `forc build` args]
+#
+#   <subdir>  Directory under the repository root to build (e.g. `libs`,
+#             `examples`, `tests`).
+#   <label>   Singular noun used in the printed messages (e.g. `library`).
+#
+# If `<subdir>` itself contains a Forc.toml it is built as a single unit. This
+# covers the case where `<subdir>` is a workspace (e.g. `examples`), in which
+# case the whole workspace (all its member projects) is built at once.
+#
+# Otherwise, every immediate subdirectory of `<subdir>` that contains a
+# Forc.toml is built, in parallel (e.g. each library under `libs`).
+#
+# Any further arguments are forwarded as-is to `forc build`, e.g.:
+#
+#     build.sh libs library --release --experimental dynamic_storage
+#
+# Each project is built concurrently and only a concise per-project result is
+# printed live (green check mark on success, red cross mark on failure). The
+# full output of any failing build is printed at the end, before the final
+# statistics.
+#
+# The script continues even when individual builds fail, and exits with a
+# non-zero code at the end if any build failed.
+#
+# Concurrency defaults to half of the available CPU cores (at least 1) and can
+# be overridden via the PARALLEL_JOBS environment variable.
+
+set -u
+
+if [[ $# -lt 2 ]]; then
+    echo "ERROR: usage: build.sh <subdir> <label> [extra forc build args]" >&2
+    exit 2
+fi
+
+# The expected `forc` version. If the installed `forc` differs, a warning is
+# printed before and after building all the projects.
+FORC_VERSION="0.72.0"
+
+SUBDIR="$1"
+LABEL="$2"
+shift 2
+
+# Resolve paths relative to the repository root, regardless of the current
+# working directory from which the script is called.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+TARGET_DIR="${REPO_ROOT}/${SUBDIR}"
+
+# The additional arguments forwarded to `forc build`.
+FORC_BUILD_ARGS=("$@")
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+check_forc_version() {
+    local installed
+    installed="$(forc --version 2>/dev/null | awk '{print $NF}')"
+
+    if [[ "${installed}" != "${FORC_VERSION}" ]]; then
+        echo "WARNING: Expected forc version ${FORC_VERSION}, but found '${installed}'."
+        echo "         The ${LABEL}s are tested with forc ${FORC_VERSION}. Builds might behave unexpectedly."
+        echo
+    fi
+}
+
+if ! command -v forc >/dev/null 2>&1; then
+    echo "ERROR: 'forc' was not found in PATH. Please install forc ${FORC_VERSION}."
+    exit 1
+fi
+
+check_forc_version
+
+# Collect the projects to build. If `<subdir>` is itself a project or workspace
+# (i.e. it has a Forc.toml), build it as a single unit. Otherwise, build every
+# immediate subdirectory that contains a Forc.toml. The glob expands in sorted
+# order, which makes the final pass/fail reporting deterministic regardless of
+# build finish order.
+project_names=()
+project_dirs=()
+if [[ -f "${TARGET_DIR}/Forc.toml" ]]; then
+    project_names+=("$(basename "${TARGET_DIR}")")
+    project_dirs+=("${TARGET_DIR}/")
+else
+    for project_dir in "${TARGET_DIR}"/*/; do
+        [[ -f "${project_dir}Forc.toml" ]] || continue
+        project_names+=("$(basename "${project_dir}")")
+        project_dirs+=("${project_dir}")
+    done
+fi
+
+# Default concurrency to half of the available cores (at least 1) to leave
+# headroom on the machine. Can be overridden via the PARALLEL_JOBS env var.
+# `nproc` is Linux; `sysctl -n hw.ncpu` is the macOS equivalent.
+cores="$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4)"
+PARALLEL_JOBS="${PARALLEL_JOBS:-$(( cores / 2 ))}"
+(( PARALLEL_JOBS < 1 )) && PARALLEL_JOBS=1
+
+# `wait -n` (wait for any single job to finish) requires Bash >= 4.3.
+# macOS ships Bash 3.2, so fall back to polling there.
+if (( BASH_VERSINFO[0] > 4 || (BASH_VERSINFO[0] == 4 && BASH_VERSINFO[1] >= 3) )); then
+    HAVE_WAIT_N=true
+else
+    HAVE_WAIT_N=false
+fi
+
+wait_for_slot() {
+    if [[ "${HAVE_WAIT_N}" == true ]]; then
+        wait -n 2>/dev/null || true
+    else
+        sleep 0.2
+    fi
+}
+
+logs_dir="$(mktemp -d)"
+trap 'rm -rf "${logs_dir}"' EXIT
+
+build_one() {
+    local project_name="$1"
+    local project_dir="$2"
+    local log_file="${logs_dir}/${project_name}.log"
+
+    if forc build --path "${project_dir}" "${FORC_BUILD_ARGS[@]}" > "${log_file}" 2>&1; then
+        printf '%b %s\n' "${GREEN}✓${NC}" "${project_name}"
+        echo "pass" > "${logs_dir}/${project_name}.status"
+    else
+        printf '%b %s\n' "${RED}✗${NC}" "${project_name}"
+        echo "fail" > "${logs_dir}/${project_name}.status"
+    fi
+}
+
+echo "Building ${#project_names[@]} ${LABEL}(s) in parallel (up to ${PARALLEL_JOBS} at a time)..."
+echo
+
+start_time=${SECONDS}
+
+for i in "${!project_names[@]}"; do
+    # Throttle: wait for a free slot before launching the next build.
+    # Note: `jobs` reads Bash's job table, which is maintained even in
+    # non-interactive shells where job control (monitor mode) is off, as is the
+    # case when these scripts run under `just`. So `jobs -rp` reliably counts
+    # the running background builds here and the limit is enforced; this does
+    # not depend on monitor mode (`set -m`) being enabled.
+    while (( $(jobs -rp | wc -l) >= PARALLEL_JOBS )); do
+        wait_for_slot
+    done
+    build_one "${project_names[$i]}" "${project_dirs[$i]}" &
+done
+
+# Wait for all remaining builds to finish.
+wait
+
+elapsed=$(( SECONDS - start_time ))
+
+# Build pass/fail lists in the stable (sorted) project order.
+succeeded=()
+failed=()
+for project_name in "${project_names[@]}"; do
+    if [[ "$(cat "${logs_dir}/${project_name}.status" 2>/dev/null)" == "pass" ]]; then
+        succeeded+=("${project_name}")
+    else
+        failed+=("${project_name}")
+    fi
+done
+
+# Print the full output of any failing build to aid debugging.
+if [[ ${#failed[@]} -gt 0 ]]; then
+    echo
+    echo "================================================"
+    echo "Output of failing builds:"
+    echo "================================================"
+    for project_name in "${failed[@]}"; do
+        echo
+        echo "==> ${project_name}"
+        cat "${logs_dir}/${project_name}.log" 2>/dev/null
+    done
+fi
+
+echo
+
+check_forc_version
+
+echo "Total build time: $(( elapsed / 60 ))m $(( elapsed % 60 ))s."
+
+if [[ ${#failed[@]} -eq 0 ]]; then
+    echo "SUCCESS: Built ${#succeeded[@]} ${LABEL}(s)."
+    exit 0
+else
+    echo "FAILURE: ${#failed[@]} of ${#project_names[@]} ${LABEL}(s) failed to build:"
+    for project_name in "${failed[@]}"; do
+        echo "  - ${project_name}"
+    done
+    exit 1
+fi

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -125,7 +125,10 @@ build_one() {
     local project_dir="$2"
     local log_file="${logs_dir}/${project_name}.log"
 
-    if forc build --path "${project_dir}" "${FORC_BUILD_ARGS[@]}" > "${log_file}" 2>&1; then
+    # `${arr[@]+"${arr[@]}"}` guards against `set -u` aborting on an empty
+    # array: on Bash 3.2 (stock macOS) expanding an empty array with `[@]` is
+    # treated as an unbound variable and would abort the build.
+    if forc build --path "${project_dir}" ${FORC_BUILD_ARGS[@]+"${FORC_BUILD_ARGS[@]}"} > "${log_file}" 2>&1; then
         printf '%b %s\n' "${GREEN}✓${NC}" "${project_name}"
         echo "pass" > "${logs_dir}/${project_name}.status"
     else

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -6,15 +6,15 @@ edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]
-fuel-merkle = { version = "0.56.0" }
-fuels = { version = "0.70.0" }
+fuel-merkle = { version = "0.66.2" }
+fuels = { version = "0.77.0" }
 sha2 = { version = "0.10" }
 tokio = { version = "1.12", features = ["rt", "macros"] }
 rand = { version = "0.8.5", default-features = false, features = [
     "std_rng",
     "getrandom",
 ] }
-fuel-tx = { version = "0.56.0" }
+fuel-tx = { version = "0.66.2" }
 
 [[test]]
 harness = true

--- a/tests/Forc.lock
+++ b/tests/Forc.lock
@@ -294,14 +294,14 @@ dependencies = ["std"]
 
 [[package]]
 name = "src7"
-version = "0.8.2"
-source = "registry+src7?0.8.2#QmXxuQD9GR4sa5kybYBFf2w2HmBzvUqGN5ypbTmT6gp1V5!"
+version = "0.8.3"
+source = "registry+src7?0.8.3#QmWv6hJb4CDkw7reaFrp59hkGBM48YiEjDYsNDYmBWJ7NC!"
 dependencies = ["std"]
 
 [[package]]
 name = "std"
-version = "0.70.2"
-source = "registry+std?0.70.2#QmWuWwmjn2vVDup2672LpToek8N58PYGJt2eH55M7ZzY2Y!"
+version = "0.72.0"
+source = "registry+std?0.72.0#QmTnRFTVHzAWatvZXEPVnaiJrs81CZLkYbEovHzPTyNyis!"
 
 [[package]]
 name = "upgradability"

--- a/tests/src/admin/tests/functions/add_admin.rs
+++ b/tests/src/admin/tests/functions/add_admin.rs
@@ -2,6 +2,7 @@ use crate::admin::tests::utils::{
     abi_calls::{add_admin, is_admin, set_ownership},
     test_helpers::setup,
 };
+use fuels::accounts::ViewOnlyAccount;
 use fuels::types::Identity;
 
 mod success {

--- a/tests/src/admin/tests/functions/is_admin.rs
+++ b/tests/src/admin/tests/functions/is_admin.rs
@@ -2,6 +2,7 @@ use crate::admin::tests::utils::{
     abi_calls::{add_admin, is_admin, set_ownership},
     test_helpers::setup,
 };
+use fuels::accounts::ViewOnlyAccount;
 use fuels::types::Identity;
 
 mod success {

--- a/tests/src/admin/tests/functions/only_admin.rs
+++ b/tests/src/admin/tests/functions/only_admin.rs
@@ -2,6 +2,7 @@ use crate::admin::tests::utils::{
     abi_calls::{add_admin, only_admin, set_ownership},
     test_helpers::setup,
 };
+use fuels::accounts::ViewOnlyAccount;
 use fuels::types::Identity;
 
 mod success {

--- a/tests/src/admin/tests/functions/only_owner_or_admin.rs
+++ b/tests/src/admin/tests/functions/only_owner_or_admin.rs
@@ -2,6 +2,7 @@ use crate::admin::tests::utils::{
     abi_calls::{add_admin, only_owner_or_admin, set_ownership},
     test_helpers::setup,
 };
+use fuels::accounts::ViewOnlyAccount;
 use fuels::types::Identity;
 
 mod success {

--- a/tests/src/admin/tests/functions/remove_admin.rs
+++ b/tests/src/admin/tests/functions/remove_admin.rs
@@ -2,6 +2,7 @@ use crate::admin::tests::utils::{
     abi_calls::{add_admin, is_admin, remove_admin, set_ownership},
     test_helpers::setup,
 };
+use fuels::accounts::ViewOnlyAccount;
 use fuels::types::Identity;
 
 mod success {

--- a/tests/src/admin/tests/utils/mod.rs
+++ b/tests/src/admin/tests/utils/mod.rs
@@ -1,7 +1,7 @@
 use fuels::{
     prelude::{
         abigen, launch_custom_provider_and_get_wallets, Contract, LoadConfiguration,
-        StorageConfiguration, TxPolicies, WalletUnlocked, WalletsConfig,
+        StorageConfiguration, TxPolicies, Wallet, WalletsConfig,
     },
     programs::responses::CallResponse,
     types::Identity,
@@ -14,18 +14,15 @@ abigen!(Contract(
 ));
 
 pub struct Metadata {
-    pub contract: AdminLib<WalletUnlocked>,
-    pub wallet: WalletUnlocked,
+    pub contract: AdminLib<Wallet>,
+    pub wallet: Wallet,
 }
 
 pub mod abi_calls {
 
     use super::*;
 
-    pub async fn add_admin(
-        contract: &AdminLib<WalletUnlocked>,
-        new_admin: Identity,
-    ) -> CallResponse<()> {
+    pub async fn add_admin(contract: &AdminLib<Wallet>, new_admin: Identity) -> CallResponse<()> {
         contract
             .methods()
             .add_admin(new_admin)
@@ -35,7 +32,7 @@ pub mod abi_calls {
     }
 
     pub async fn remove_admin(
-        contract: &AdminLib<WalletUnlocked>,
+        contract: &AdminLib<Wallet>,
         old_admin: Identity,
     ) -> CallResponse<()> {
         contract
@@ -46,7 +43,7 @@ pub mod abi_calls {
             .unwrap()
     }
 
-    pub async fn is_admin(contract: &AdminLib<WalletUnlocked>, admin: Identity) -> bool {
+    pub async fn is_admin(contract: &AdminLib<Wallet>, admin: Identity) -> bool {
         contract
             .methods()
             .is_admin(admin)
@@ -56,11 +53,11 @@ pub mod abi_calls {
             .value
     }
 
-    pub async fn only_admin(contract: &AdminLib<WalletUnlocked>) -> CallResponse<()> {
+    pub async fn only_admin(contract: &AdminLib<Wallet>) -> CallResponse<()> {
         contract.methods().only_admin().call().await.unwrap()
     }
 
-    pub async fn only_owner_or_admin(contract: &AdminLib<WalletUnlocked>) -> CallResponse<()> {
+    pub async fn only_owner_or_admin(contract: &AdminLib<Wallet>) -> CallResponse<()> {
         contract
             .methods()
             .only_owner_or_admin()
@@ -70,7 +67,7 @@ pub mod abi_calls {
     }
 
     pub async fn set_ownership(
-        contract: &AdminLib<WalletUnlocked>,
+        contract: &AdminLib<Wallet>,
         new_owner: Identity,
     ) -> CallResponse<()> {
         contract
@@ -112,7 +109,8 @@ pub mod test_helpers {
             .unwrap()
             .deploy(&wallet1, TxPolicies::default())
             .await
-            .unwrap();
+            .unwrap()
+            .contract_id;
 
         let deploy_wallet = Metadata {
             contract: AdminLib::new(id.clone(), wallet1.clone()),

--- a/tests/src/bytecode/test_artifacts/complex_contract/src/main.sw
+++ b/tests/src/bytecode/test_artifacts/complex_contract/src/main.sw
@@ -106,7 +106,7 @@ impl ComplexContract for Contract {
 
     #[storage(write)]
     fn clear() {
-        storage.my_vec.clear();
+        let _ = storage.my_vec.clear();
     }
 
     #[storage(read, write)]

--- a/tests/src/bytecode/tests/utils/mod.rs
+++ b/tests/src/bytecode/tests/utils/mod.rs
@@ -61,18 +61,18 @@ const HEX_STR_3: &str = "0xfebf0fdda20de46a0f2261a69556b0f9fdeea85759af1edb32283
 //   }
 // ]
 // You would use 20800, 20760, and 20688 for 1, 2, 3 respectively
-const SIMPLE_PREDICATE_OFFSET: u64 = 288;
-const SIMPLE_CONTRACT_OFFSET: u64 = 536;
-const COMPLEX_CONTRACT_OFFSET_1: u64 = 12720;
-const COMPLEX_CONTRACT_OFFSET_2: u64 = 12680;
-const COMPLEX_CONTRACT_OFFSET_3: u64 = 12608;
+const SIMPLE_PREDICATE_OFFSET: u64 = 176;
+const SIMPLE_CONTRACT_OFFSET: u64 = 280;
+const COMPLEX_CONTRACT_OFFSET_1: u64 = 8056;
+const COMPLEX_CONTRACT_OFFSET_2: u64 = 8016;
+const COMPLEX_CONTRACT_OFFSET_3: u64 = 7944;
 
 pub mod abi_calls {
 
     use super::*;
 
     pub async fn predicate_address_from_root(
-        contract: &BytecodeTestContract<WalletUnlocked>,
+        contract: &BytecodeTestContract<Wallet>,
         bytecode_root: Bits256,
     ) -> Address {
         contract
@@ -85,7 +85,7 @@ pub mod abi_calls {
     }
 
     pub async fn compute_predicate_address(
-        contract: &BytecodeTestContract<WalletUnlocked>,
+        contract: &BytecodeTestContract<Wallet>,
         bytecode: Vec<u8>,
         configurables: Option<Vec<(u64, Vec<u8>)>>,
     ) -> Address {
@@ -99,7 +99,7 @@ pub mod abi_calls {
     }
 
     pub async fn compute_bytecode_root(
-        contract: &BytecodeTestContract<WalletUnlocked>,
+        contract: &BytecodeTestContract<Wallet>,
         bytecode: Vec<u8>,
         configurables: Option<Vec<(u64, Vec<u8>)>>,
     ) -> Bits256 {
@@ -118,7 +118,7 @@ pub mod abi_calls {
     }
 
     pub async fn return_configurables(
-        contract: &ComplexContract<WalletUnlocked>,
+        contract: &ComplexContract<Wallet>,
     ) -> (u64, SimpleStruct, SimpleEnum) {
         contract
             .methods()
@@ -130,7 +130,7 @@ pub mod abi_calls {
     }
 
     pub async fn swap_configurables(
-        contract: &BytecodeTestContract<WalletUnlocked>,
+        contract: &BytecodeTestContract<Wallet>,
         bytecode: Vec<u8>,
         configurables: Vec<(u64, Vec<u8>)>,
     ) -> Vec<u8> {
@@ -152,7 +152,7 @@ pub mod abi_calls {
             .value
     }
 
-    pub async fn test_function(contract: &SimpleContract<WalletUnlocked>) -> u64 {
+    pub async fn test_function(contract: &SimpleContract<Wallet>) -> u64 {
         contract
             .methods()
             .test_function()
@@ -163,11 +163,11 @@ pub mod abi_calls {
     }
 
     pub async fn verify_simple_contract_bytecode(
-        contract: &BytecodeTestContract<WalletUnlocked>,
+        contract: &BytecodeTestContract<Wallet>,
         bytecode: Vec<u8>,
         configurables: Option<Vec<(u64, Vec<u8>)>>,
         contract_id: ContractId,
-        simple_contract_instance: SimpleContract<WalletUnlocked>,
+        simple_contract_instance: SimpleContract<Wallet>,
     ) -> CallResponse<()> {
         contract
             .methods()
@@ -179,11 +179,11 @@ pub mod abi_calls {
     }
 
     pub async fn verify_complex_contract_bytecode(
-        contract: &BytecodeTestContract<WalletUnlocked>,
+        contract: &BytecodeTestContract<Wallet>,
         bytecode: Vec<u8>,
         configurables: Option<Vec<(u64, Vec<u8>)>>,
         contract_id: ContractId,
-        complex_contract_instance: ComplexContract<WalletUnlocked>,
+        complex_contract_instance: ComplexContract<Wallet>,
     ) -> CallResponse<()> {
         contract
             .clone()
@@ -200,7 +200,7 @@ pub mod abi_calls {
     }
 
     pub async fn verify_predicate_address(
-        contract: &BytecodeTestContract<WalletUnlocked>,
+        contract: &BytecodeTestContract<Wallet>,
         bytecode: Vec<u8>,
         configurables: Option<Vec<(u64, Vec<u8>)>>,
         predicate_id: Address,
@@ -245,8 +245,7 @@ pub mod test_helpers {
     }
 
     /// Helper function to deploy the simple contract
-    pub async fn test_contract_instance() -> (BytecodeTestContract<WalletUnlocked>, WalletUnlocked)
-    {
+    pub async fn test_contract_instance() -> (BytecodeTestContract<Wallet>, Wallet) {
         // Launch a local network and deploy the contract
         let mut wallets = launch_custom_provider_and_get_wallets(
             WalletsConfig::new(
@@ -268,7 +267,8 @@ pub mod test_helpers {
         .unwrap()
         .deploy(&wallet, TxPolicies::default())
         .await
-        .unwrap();
+        .unwrap()
+        .contract_id;
 
         let instance = BytecodeTestContract::new(id.clone(), wallet.clone());
 
@@ -277,28 +277,30 @@ pub mod test_helpers {
 
     /// Helper function to deploy the simple contract from bytecode
     pub async fn deploy_simple_contract_from_bytecode(
-        wallet: WalletUnlocked,
+        wallet: Wallet,
         bytecode: Vec<u8>,
-    ) -> SimpleContract<WalletUnlocked> {
+    ) -> SimpleContract<Wallet> {
         let rng = &mut StdRng::seed_from_u64(2322u64);
         let salt: [u8; 32] = rng.gen();
         let storage_vec = Vec::<StorageSlot>::new();
         let result_id = Contract::regular(bytecode, salt.into(), storage_vec)
             .deploy(&wallet, TxPolicies::default())
             .await
-            .unwrap();
+            .unwrap()
+            .contract_id;
         SimpleContract::new(result_id.clone(), wallet.clone())
     }
 
     /// Helper function to deploy the simple contract from file
     pub async fn deploy_simple_contract_from_file(
-        wallet: WalletUnlocked,
-    ) -> (SimpleContract<WalletUnlocked>, ContractId) {
+        wallet: Wallet,
+    ) -> (SimpleContract<Wallet>, ContractId) {
         let id = Contract::load_from(SIMPLE_CONTRACT_BYTECODE_PATH, LoadConfiguration::default())
             .unwrap()
             .deploy(&wallet, TxPolicies::default())
             .await
-            .unwrap();
+            .unwrap()
+            .contract_id;
 
         let instance = SimpleContract::new(id.clone(), wallet.clone());
 
@@ -307,9 +309,9 @@ pub mod test_helpers {
 
     /// Helper function to deploy the simple contract from file
     pub async fn deploy_simple_contract_with_configurables_from_file(
-        wallet: WalletUnlocked,
+        wallet: Wallet,
         config_value: u64,
-    ) -> (SimpleContract<WalletUnlocked>, ContractId) {
+    ) -> (SimpleContract<Wallet>, ContractId) {
         let configurables = SimpleContractConfigurables::default()
             .with_VALUE(config_value)
             .unwrap();
@@ -321,7 +323,8 @@ pub mod test_helpers {
         .unwrap()
         .deploy(&wallet, TxPolicies::default())
         .await
-        .unwrap();
+        .unwrap()
+        .contract_id;
 
         let instance = SimpleContract::new(id.clone(), wallet.clone());
 
@@ -362,28 +365,30 @@ pub mod test_helpers {
 
     /// Helper function to deploy the simple contract from bytecode
     pub async fn deploy_complex_contract_from_bytecode(
-        wallet: WalletUnlocked,
+        wallet: Wallet,
         bytecode: Vec<u8>,
-    ) -> ComplexContract<WalletUnlocked> {
+    ) -> ComplexContract<Wallet> {
         let rng = &mut StdRng::seed_from_u64(2323u64);
         let salt: [u8; 32] = rng.gen();
         let storage_vec = Vec::<StorageSlot>::new();
         let result_id = Contract::regular(bytecode, salt.into(), storage_vec)
             .deploy(&wallet, TxPolicies::default())
             .await
-            .unwrap();
+            .unwrap()
+            .contract_id;
         ComplexContract::new(result_id.clone(), wallet.clone())
     }
 
     /// Helper function to deploy the simple contract from file
     pub async fn deploy_complex_contract_from_file(
-        wallet: WalletUnlocked,
-    ) -> (ComplexContract<WalletUnlocked>, ContractId) {
+        wallet: Wallet,
+    ) -> (ComplexContract<Wallet>, ContractId) {
         let id = Contract::load_from(COMPLEX_CONTRACT_BYTECODE_PATH, LoadConfiguration::default())
             .unwrap()
             .deploy(&wallet, TxPolicies::default())
             .await
-            .unwrap();
+            .unwrap()
+            .contract_id;
 
         let instance = ComplexContract::new(id.clone(), wallet.clone());
 
@@ -392,11 +397,11 @@ pub mod test_helpers {
 
     /// Helper function to deploy the simple contract from file
     pub async fn deploy_complex_contract_with_configurables_from_file(
-        wallet: WalletUnlocked,
+        wallet: Wallet,
         config_value: u64,
         config_struct: SimpleStruct,
         config_enum: SimpleEnum,
-    ) -> (ComplexContract<WalletUnlocked>, ContractId) {
+    ) -> (ComplexContract<Wallet>, ContractId) {
         let configurables = ComplexContractConfigurables::new(EncoderConfig {
             max_tokens: 10_000_000,
             ..Default::default()
@@ -415,7 +420,8 @@ pub mod test_helpers {
         .unwrap()
         .deploy(&wallet, TxPolicies::default())
         .await
-        .unwrap();
+        .unwrap()
+        .contract_id;
 
         let instance = ComplexContract::new(id.clone(), wallet.clone());
 
@@ -462,7 +468,7 @@ pub mod test_helpers {
     }
 
     pub async fn setup_predicate_from_bytecode(
-        wallet: WalletUnlocked,
+        wallet: Wallet,
         bytecode: Vec<u8>,
         config_value: u64,
     ) -> Predicate {
@@ -481,7 +487,6 @@ pub mod test_helpers {
                 DEFAULT_PREDICATE_BALANCE,
                 *wallet
                     .provider()
-                    .unwrap()
                     .consensus_parameters()
                     .await
                     .unwrap()
@@ -495,7 +500,6 @@ pub mod test_helpers {
             .get_asset_balance(
                 &wallet
                     .provider()
-                    .unwrap()
                     .consensus_parameters()
                     .await
                     .unwrap()
@@ -503,12 +507,12 @@ pub mod test_helpers {
             )
             .await
             .unwrap();
-        assert_eq!(predicate_balance, DEFAULT_PREDICATE_BALANCE);
+        assert_eq!(predicate_balance, DEFAULT_PREDICATE_BALANCE as u128);
 
         result_instance
     }
 
-    pub async fn setup_predicate_from_file(wallet: WalletUnlocked) -> Predicate {
+    pub async fn setup_predicate_from_file(wallet: Wallet) -> Predicate {
         let provider = wallet.try_provider().unwrap();
         let result_instance = Predicate::load_from(PREDICATE_BYTECODE_PATH)
             .unwrap()
@@ -521,7 +525,6 @@ pub mod test_helpers {
                 DEFAULT_PREDICATE_BALANCE,
                 *wallet
                     .provider()
-                    .unwrap()
                     .consensus_parameters()
                     .await
                     .unwrap()
@@ -535,7 +538,6 @@ pub mod test_helpers {
             .get_asset_balance(
                 &wallet
                     .provider()
-                    .unwrap()
                     .consensus_parameters()
                     .await
                     .unwrap()
@@ -543,13 +545,13 @@ pub mod test_helpers {
             )
             .await
             .unwrap();
-        assert_eq!(predicate_balance, DEFAULT_PREDICATE_BALANCE);
+        assert_eq!(predicate_balance, DEFAULT_PREDICATE_BALANCE as u128);
 
         result_instance
     }
 
     pub async fn setup_predicate_from_file_with_configurable(
-        wallet: WalletUnlocked,
+        wallet: Wallet,
         config_value: u64,
     ) -> Predicate {
         let provider = wallet.try_provider().unwrap();
@@ -572,7 +574,6 @@ pub mod test_helpers {
                 DEFAULT_PREDICATE_BALANCE,
                 *wallet
                     .provider()
-                    .unwrap()
                     .consensus_parameters()
                     .await
                     .unwrap()
@@ -586,7 +587,6 @@ pub mod test_helpers {
             .get_asset_balance(
                 &wallet
                     .provider()
-                    .unwrap()
                     .consensus_parameters()
                     .await
                     .unwrap()
@@ -594,12 +594,12 @@ pub mod test_helpers {
             )
             .await
             .unwrap();
-        assert_eq!(predicate_balance, DEFAULT_PREDICATE_BALANCE);
+        assert_eq!(predicate_balance, DEFAULT_PREDICATE_BALANCE as u128);
 
         result_instance
     }
 
-    pub async fn simple_predicate_bytecode_root_from_file(wallet: WalletUnlocked) -> Bits256 {
+    pub async fn simple_predicate_bytecode_root_from_file(wallet: Wallet) -> Bits256 {
         let predicate_bytecode = predicate_bytecode();
 
         let provider: &Provider = wallet.try_provider().unwrap();
@@ -610,7 +610,7 @@ pub mod test_helpers {
     }
 
     pub async fn simple_predicate_bytecode_root_with_configurables_from_file(
-        wallet: WalletUnlocked,
+        wallet: Wallet,
         config_value: u64,
     ) -> Bits256 {
         let predicate_bytecode = predicate_bytecode();
@@ -630,14 +630,13 @@ pub mod test_helpers {
         Bits256(*fuel_tx::Contract::root_from_code(result_instance.code()))
     }
 
-    pub async fn spend_predicate(predicate_instance: Predicate, wallet: WalletUnlocked) {
+    pub async fn spend_predicate(predicate_instance: Predicate, wallet: Wallet) {
         predicate_instance
             .transfer(
                 wallet.address(),
                 1,
                 *wallet
                     .provider()
-                    .unwrap()
                     .consensus_parameters()
                     .await
                     .unwrap()
@@ -648,23 +647,10 @@ pub mod test_helpers {
             .unwrap();
     }
 
-    /// Helper function to generate the configurable changes needed. Hardcoded for now
+    /// Helper function to generate the configurable changes needed.
+    /// The `offset` is read from the `configurables` section of the contract's
+    /// `*-abi.json` (see the `*_OFFSET` constants at the top of this module).
     pub fn build_simple_configurables(offset: u64, config_value: u8) -> Vec<(u64, Vec<u8>)> {
-        // Build the configurable changes from the abi.json
-        // This is hardcoded for now. From the json below we know it's at offset 68 for simple_contract
-
-        // "configurables": [
-        // {
-        //     "name": "VALUE",
-        //     "configurableType": {
-        //       "name": "",
-        //       "type": 0,
-        //       "typeArguments": null
-        //     },
-        //     "offset": 68
-        //   }
-        // ]
-
         let mut my_configurables: Vec<(u64, Vec<u8>)> = Vec::new();
         let mut data: Vec<u8> = Vec::new();
 

--- a/tests/src/merkle_proof/tests/utils/mod.rs
+++ b/tests/src/merkle_proof/tests/utils/mod.rs
@@ -6,8 +6,7 @@ use fuel_merkle::sparse::MerkleTreeKey as SparseTreeKey;
 use fuel_tx::Bytes32;
 use fuels::{
     prelude::{
-        abigen, launch_provider_and_get_wallet, Contract, LoadConfiguration, TxPolicies,
-        WalletUnlocked,
+        abigen, launch_provider_and_get_wallet, Contract, LoadConfiguration, TxPolicies, Wallet,
     },
     types::{Bits256, Bytes},
 };
@@ -26,7 +25,7 @@ pub mod abi_calls {
     use super::*;
 
     pub async fn binary_leaf_digest(
-        contract: &TestMerkleProofLib<WalletUnlocked>,
+        contract: &TestMerkleProofLib<Wallet>,
         data: Bits256,
     ) -> Bits256 {
         contract
@@ -39,7 +38,7 @@ pub mod abi_calls {
     }
 
     pub async fn node_digest(
-        contract: &TestMerkleProofLib<WalletUnlocked>,
+        contract: &TestMerkleProofLib<Wallet>,
         left: Bits256,
         right: Bits256,
     ) -> Bits256 {
@@ -53,7 +52,7 @@ pub mod abi_calls {
     }
 
     pub async fn binary_process_proof(
-        contract: &TestMerkleProofLib<WalletUnlocked>,
+        contract: &TestMerkleProofLib<Wallet>,
         key: u64,
         leaf: Bits256,
         num_leaves: u64,
@@ -69,7 +68,7 @@ pub mod abi_calls {
     }
 
     pub async fn binary_verify_proof(
-        contract: &TestMerkleProofLib<WalletUnlocked>,
+        contract: &TestMerkleProofLib<Wallet>,
         key: u64,
         leaf: Bits256,
         root: Bits256,
@@ -86,7 +85,7 @@ pub mod abi_calls {
     }
 
     pub async fn sparse_root(
-        contract: &TestMerkleProofLib<WalletUnlocked>,
+        contract: &TestMerkleProofLib<Wallet>,
         key: Bits256,
         leaf: Option<Bytes>,
         proof: Proof,
@@ -101,7 +100,7 @@ pub mod abi_calls {
     }
 
     pub async fn sparse_root_hash(
-        contract: &TestMerkleProofLib<WalletUnlocked>,
+        contract: &TestMerkleProofLib<Wallet>,
         key: Bits256,
         leaf: Bits256,
         proof: Proof,
@@ -116,7 +115,7 @@ pub mod abi_calls {
     }
 
     pub async fn sparse_verify(
-        contract: &TestMerkleProofLib<WalletUnlocked>,
+        contract: &TestMerkleProofLib<Wallet>,
         key: Bits256,
         leaf: Option<Bytes>,
         root: Bits256,
@@ -132,7 +131,7 @@ pub mod abi_calls {
     }
 
     pub async fn sparse_verify_hash(
-        contract: &TestMerkleProofLib<WalletUnlocked>,
+        contract: &TestMerkleProofLib<Wallet>,
         key: Bits256,
         leaf: Bits256,
         root: Bits256,
@@ -148,7 +147,7 @@ pub mod abi_calls {
     }
 
     pub async fn sparse_leaf_digest(
-        contract: &TestMerkleProofLib<WalletUnlocked>,
+        contract: &TestMerkleProofLib<Wallet>,
         key: Bits256,
         data: Bits256,
     ) -> Bits256 {
@@ -359,7 +358,7 @@ pub mod test_helpers {
         return_vec
     }
 
-    pub async fn merkle_proof_instance() -> TestMerkleProofLib<WalletUnlocked> {
+    pub async fn merkle_proof_instance() -> TestMerkleProofLib<Wallet> {
         let wallet = launch_provider_and_get_wallet().await.unwrap();
 
         let contract_id = Contract::load_from(
@@ -369,7 +368,8 @@ pub mod test_helpers {
         .unwrap()
         .deploy(&wallet, TxPolicies::default())
         .await
-        .unwrap();
+        .unwrap()
+        .contract_id;
 
         let instance = TestMerkleProofLib::new(contract_id.clone(), wallet.clone());
 

--- a/tests/src/native_asset/Forc.toml
+++ b/tests/src/native_asset/Forc.toml
@@ -6,6 +6,6 @@ name = "native_asset_lib"
 
 [dependencies]
 src20 = "0.8.2"
-src7 = "0.8.2"
+src7 = "0.8.3"
 src3 = "0.8.2"
 asset = { path = "../../../libs/asset" }

--- a/tests/src/native_asset/src/main.sw
+++ b/tests/src/native_asset/src/main.sw
@@ -62,7 +62,7 @@ impl SRC20 for Contract {
 impl SRC3 for Contract {
     #[storage(read, write)]
     fn mint(recipient: Identity, sub_id: Option<SubId>, amount: u64) {
-        _mint(
+        let _ = _mint(
             storage
                 .total_assets,
             storage

--- a/tests/src/native_asset/tests/functions/burn.rs
+++ b/tests/src/native_asset/tests/functions/burn.rs
@@ -2,6 +2,7 @@ use crate::native_asset::tests::utils::{
     interface::{burn, mint, total_assets, total_supply},
     setup::{defaults, get_wallet_balance, setup, TotalSupplyEvent},
 };
+use fuels::accounts::ViewOnlyAccount;
 use fuels::types::Identity;
 
 mod success {

--- a/tests/src/native_asset/tests/functions/mint.rs
+++ b/tests/src/native_asset/tests/functions/mint.rs
@@ -2,6 +2,7 @@ use crate::native_asset::tests::utils::{
     interface::{mint, total_assets, total_supply},
     setup::{defaults, get_asset_id, get_wallet_balance, setup, TotalSupplyEvent},
 };
+use fuels::accounts::ViewOnlyAccount;
 use fuels::types::{Bytes32, Identity};
 
 mod success {

--- a/tests/src/native_asset/tests/functions/set_decimals.rs
+++ b/tests/src/native_asset/tests/functions/set_decimals.rs
@@ -2,6 +2,7 @@ use crate::native_asset::tests::utils::{
     interface::{decimals, set_decimals},
     setup::{defaults, get_asset_id, setup, SetDecimalsEvent},
 };
+use fuels::accounts::ViewOnlyAccount;
 use fuels::types::{Bytes32, Identity};
 
 mod success {

--- a/tests/src/native_asset/tests/functions/set_metadata.rs
+++ b/tests/src/native_asset/tests/functions/set_metadata.rs
@@ -2,6 +2,7 @@ use crate::native_asset::tests::utils::{
     interface::{metadata, set_metadata},
     setup::{defaults, get_asset_id, setup, Metadata, SetMetadataEvent},
 };
+use fuels::accounts::ViewOnlyAccount;
 use fuels::types::{Bits256, Bytes, Bytes32, Identity};
 
 mod success {

--- a/tests/src/native_asset/tests/functions/set_name.rs
+++ b/tests/src/native_asset/tests/functions/set_name.rs
@@ -2,6 +2,7 @@ use crate::native_asset::tests::utils::{
     interface::{name, set_name},
     setup::{defaults, get_asset_id, setup, SetNameEvent},
 };
+use fuels::accounts::ViewOnlyAccount;
 use fuels::types::{Bytes32, Identity};
 
 mod success {

--- a/tests/src/native_asset/tests/functions/set_symbol.rs
+++ b/tests/src/native_asset/tests/functions/set_symbol.rs
@@ -2,6 +2,7 @@ use crate::native_asset::tests::utils::{
     interface::{set_symbol, symbol},
     setup::{defaults, get_asset_id, setup, SetSymbolEvent},
 };
+use fuels::accounts::ViewOnlyAccount;
 use fuels::types::{Bytes32, Identity};
 
 mod success {

--- a/tests/src/native_asset/tests/utils/interface.rs
+++ b/tests/src/native_asset/tests/utils/interface.rs
@@ -1,11 +1,11 @@
 use crate::native_asset::tests::utils::setup::{AssetLib, Metadata};
 use fuels::{
-    prelude::{AssetId, CallParameters, TxPolicies, WalletUnlocked},
+    prelude::{AssetId, CallParameters, TxPolicies, Wallet},
     programs::responses::CallResponse,
     types::{transaction_builders::VariableOutputPolicy, Bits256, Identity},
 };
 
-pub(crate) async fn total_assets(contract: &AssetLib<WalletUnlocked>) -> u64 {
+pub(crate) async fn total_assets(contract: &AssetLib<Wallet>) -> u64 {
     contract
         .methods()
         .total_assets()
@@ -15,10 +15,7 @@ pub(crate) async fn total_assets(contract: &AssetLib<WalletUnlocked>) -> u64 {
         .value
 }
 
-pub(crate) async fn total_supply(
-    contract: &AssetLib<WalletUnlocked>,
-    asset: AssetId,
-) -> Option<u64> {
+pub(crate) async fn total_supply(contract: &AssetLib<Wallet>, asset: AssetId) -> Option<u64> {
     contract
         .methods()
         .total_supply(asset)
@@ -28,15 +25,15 @@ pub(crate) async fn total_supply(
         .value
 }
 
-pub(crate) async fn name(contract: &AssetLib<WalletUnlocked>, asset: AssetId) -> Option<String> {
+pub(crate) async fn name(contract: &AssetLib<Wallet>, asset: AssetId) -> Option<String> {
     contract.methods().name(asset).call().await.unwrap().value
 }
 
-pub(crate) async fn symbol(contract: &AssetLib<WalletUnlocked>, asset: AssetId) -> Option<String> {
+pub(crate) async fn symbol(contract: &AssetLib<Wallet>, asset: AssetId) -> Option<String> {
     contract.methods().symbol(asset).call().await.unwrap().value
 }
 
-pub(crate) async fn decimals(contract: &AssetLib<WalletUnlocked>, asset: AssetId) -> Option<u8> {
+pub(crate) async fn decimals(contract: &AssetLib<Wallet>, asset: AssetId) -> Option<u8> {
     contract
         .methods()
         .decimals(asset)
@@ -47,7 +44,7 @@ pub(crate) async fn decimals(contract: &AssetLib<WalletUnlocked>, asset: AssetId
 }
 
 pub(crate) async fn mint(
-    contract: &AssetLib<WalletUnlocked>,
+    contract: &AssetLib<Wallet>,
     recipient: Identity,
     sub_id: Option<Bits256>,
     amount: u64,
@@ -62,7 +59,7 @@ pub(crate) async fn mint(
 }
 
 pub(crate) async fn burn(
-    contract: &AssetLib<WalletUnlocked>,
+    contract: &AssetLib<Wallet>,
     asset_id: AssetId,
     sub_id: Bits256,
     amount: u64,
@@ -81,7 +78,7 @@ pub(crate) async fn burn(
 }
 
 pub(crate) async fn set_name(
-    contract: &AssetLib<WalletUnlocked>,
+    contract: &AssetLib<Wallet>,
     asset: AssetId,
     name: Option<String>,
 ) -> CallResponse<()> {
@@ -94,7 +91,7 @@ pub(crate) async fn set_name(
 }
 
 pub(crate) async fn set_symbol(
-    contract: &AssetLib<WalletUnlocked>,
+    contract: &AssetLib<Wallet>,
     asset: AssetId,
     symbol: Option<String>,
 ) -> CallResponse<()> {
@@ -107,7 +104,7 @@ pub(crate) async fn set_symbol(
 }
 
 pub(crate) async fn set_decimals(
-    contract: &AssetLib<WalletUnlocked>,
+    contract: &AssetLib<Wallet>,
     asset: AssetId,
     decimals: u8,
 ) -> CallResponse<()> {
@@ -120,7 +117,7 @@ pub(crate) async fn set_decimals(
 }
 
 pub(crate) async fn metadata(
-    contract: &AssetLib<WalletUnlocked>,
+    contract: &AssetLib<Wallet>,
     asset: AssetId,
     key: String,
 ) -> Option<Metadata> {
@@ -134,7 +131,7 @@ pub(crate) async fn metadata(
 }
 
 pub(crate) async fn set_metadata(
-    contract: &AssetLib<WalletUnlocked>,
+    contract: &AssetLib<Wallet>,
     asset: AssetId,
     key: String,
     metadata: Option<Metadata>,

--- a/tests/src/native_asset/tests/utils/setup.rs
+++ b/tests/src/native_asset/tests/utils/setup.rs
@@ -2,7 +2,7 @@ use fuels::{
     accounts::ViewOnlyAccount,
     prelude::{
         abigen, launch_custom_provider_and_get_wallets, AssetConfig, Contract, ContractId,
-        LoadConfiguration, TxPolicies, WalletUnlocked, WalletsConfig,
+        LoadConfiguration, TxPolicies, Wallet, WalletsConfig,
     },
     types::{Address, AssetId, Bits256, Bytes32, Identity},
 };
@@ -18,8 +18,8 @@ const NATIVE_ASSET_TEST_CONTRACT_BINARY_PATH: &str =
 
 pub(crate) fn defaults(
     contract_id: ContractId,
-    wallet_1: WalletUnlocked,
-    wallet_2: WalletUnlocked,
+    wallet_1: Wallet,
+    wallet_2: Wallet,
 ) -> (AssetId, AssetId, Bits256, Bits256, Identity, Identity) {
     let sub_id_1 = Bytes32::from([1u8; 32]);
     let sub_id_2 = Bytes32::from([2u8; 32]);
@@ -40,11 +40,11 @@ pub(crate) fn defaults(
 }
 
 pub(crate) async fn setup() -> (
-    WalletUnlocked,
-    WalletUnlocked,
+    Wallet,
+    Wallet,
     ContractId,
-    AssetLib<WalletUnlocked>,
-    AssetLib<WalletUnlocked>,
+    AssetLib<Wallet>,
+    AssetLib<Wallet>,
 ) {
     let number_of_coins = 1;
     let coin_amount = 100_000_000;
@@ -72,7 +72,8 @@ pub(crate) async fn setup() -> (
     .unwrap()
     .deploy(&wallet1, TxPolicies::default())
     .await
-    .unwrap();
+    .unwrap()
+    .contract_id;
 
     let instance_1 = AssetLib::new(id.clone(), wallet1.clone());
     let instance_2 = AssetLib::new(id.clone(), wallet2.clone());
@@ -87,6 +88,6 @@ pub(crate) fn get_asset_id(sub_id: Bytes32, contract: ContractId) -> AssetId {
     AssetId::new(*Bytes32::from(<[u8; 32]>::from(hasher.finalize())))
 }
 
-pub(crate) async fn get_wallet_balance(wallet: &WalletUnlocked, asset: &AssetId) -> u64 {
-    wallet.get_asset_balance(asset).await.unwrap()
+pub(crate) async fn get_wallet_balance(wallet: &Wallet, asset: &AssetId) -> u64 {
+    wallet.get_asset_balance(asset).await.unwrap() as u64
 }

--- a/tests/src/ownership/tests/functions/only_owner.rs
+++ b/tests/src/ownership/tests/functions/only_owner.rs
@@ -2,6 +2,7 @@ use crate::ownership::tests::utils::{
     abi_calls::{only_owner, set_ownership, transfer_ownership},
     test_helpers::setup,
 };
+use fuels::accounts::ViewOnlyAccount;
 use fuels::types::Identity;
 
 mod success {

--- a/tests/src/ownership/tests/functions/owner.rs
+++ b/tests/src/ownership/tests/functions/owner.rs
@@ -3,6 +3,7 @@ use crate::ownership::tests::utils::{
     test_helpers::setup,
     State,
 };
+use fuels::accounts::ViewOnlyAccount;
 use fuels::types::Identity;
 
 mod success {

--- a/tests/src/ownership/tests/functions/renounce_ownership.rs
+++ b/tests/src/ownership/tests/functions/renounce_ownership.rs
@@ -3,6 +3,7 @@ use crate::ownership::tests::utils::{
     test_helpers::setup,
     State,
 };
+use fuels::accounts::ViewOnlyAccount;
 use fuels::types::Identity;
 
 mod success {

--- a/tests/src/ownership/tests/functions/set_ownership.rs
+++ b/tests/src/ownership/tests/functions/set_ownership.rs
@@ -3,6 +3,7 @@ use crate::ownership::tests::utils::{
     test_helpers::setup,
     State,
 };
+use fuels::accounts::ViewOnlyAccount;
 use fuels::types::Identity;
 
 mod success {

--- a/tests/src/ownership/tests/functions/transfer_ownership.rs
+++ b/tests/src/ownership/tests/functions/transfer_ownership.rs
@@ -3,6 +3,7 @@ use crate::ownership::tests::utils::{
     test_helpers::setup,
     State,
 };
+use fuels::accounts::ViewOnlyAccount;
 use fuels::types::Identity;
 
 mod success {

--- a/tests/src/ownership/tests/utils/mod.rs
+++ b/tests/src/ownership/tests/utils/mod.rs
@@ -1,7 +1,7 @@
 use fuels::{
     prelude::{
         abigen, launch_custom_provider_and_get_wallets, Contract, LoadConfiguration,
-        StorageConfiguration, TxPolicies, WalletUnlocked, WalletsConfig,
+        StorageConfiguration, TxPolicies, Wallet, WalletsConfig,
     },
     programs::responses::CallResponse,
     types::Identity,
@@ -14,23 +14,23 @@ abigen!(Contract(
 ));
 
 pub struct Metadata {
-    pub contract: OwnershipLib<WalletUnlocked>,
-    pub wallet: WalletUnlocked,
+    pub contract: OwnershipLib<Wallet>,
+    pub wallet: Wallet,
 }
 
 pub mod abi_calls {
 
     use super::*;
 
-    pub async fn only_owner(contract: &OwnershipLib<WalletUnlocked>) -> CallResponse<()> {
+    pub async fn only_owner(contract: &OwnershipLib<Wallet>) -> CallResponse<()> {
         contract.methods().only_owner().call().await.unwrap()
     }
 
-    pub async fn owner(contract: &OwnershipLib<WalletUnlocked>) -> State {
+    pub async fn owner(contract: &OwnershipLib<Wallet>) -> State {
         contract.methods().owner().call().await.unwrap().value
     }
 
-    pub async fn renounce_ownership(contract: &OwnershipLib<WalletUnlocked>) -> CallResponse<()> {
+    pub async fn renounce_ownership(contract: &OwnershipLib<Wallet>) -> CallResponse<()> {
         contract
             .methods()
             .renounce_ownership()
@@ -40,7 +40,7 @@ pub mod abi_calls {
     }
 
     pub async fn set_ownership(
-        contract: &OwnershipLib<WalletUnlocked>,
+        contract: &OwnershipLib<Wallet>,
         new_owner: Identity,
     ) -> CallResponse<()> {
         contract
@@ -52,7 +52,7 @@ pub mod abi_calls {
     }
 
     pub async fn transfer_ownership(
-        contract: &OwnershipLib<WalletUnlocked>,
+        contract: &OwnershipLib<Wallet>,
         new_owner: Identity,
     ) -> CallResponse<()> {
         contract
@@ -97,7 +97,8 @@ pub mod test_helpers {
         .unwrap()
         .deploy(&wallet1, TxPolicies::default())
         .await
-        .unwrap();
+        .unwrap()
+        .contract_id;
 
         let deploy_wallet = Metadata {
             contract: OwnershipLib::new(id.clone(), wallet1.clone()),

--- a/tests/src/reentrancy/mod.rs
+++ b/tests/src/reentrancy/mod.rs
@@ -1,7 +1,8 @@
 use fuels::{
+    accounts::ViewOnlyAccount,
     prelude::{
         abigen, launch_provider_and_get_wallet, Contract, LoadConfiguration, StorageConfiguration,
-        TxPolicies, WalletUnlocked,
+        TxPolicies, Wallet,
     },
     types::ContractId,
 };
@@ -27,9 +28,7 @@ const REENTRANCY_PROXY_BIN: &str =
     "src/reentrancy/reentrancy_proxy_contract/out/release/reentrancy_proxy_contract.bin";
 const REENTRANCY_PROXY_STORAGE: &str = "src/reentrancy/reentrancy_proxy_contract/out/release/reentrancy_proxy_contract-storage_slots.json";
 
-pub async fn get_attacker_instance(
-    wallet: WalletUnlocked,
-) -> (AttackerContract<WalletUnlocked>, ContractId) {
+pub async fn get_attacker_instance(wallet: Wallet) -> (AttackerContract<Wallet>, ContractId) {
     let storage_configuration =
         StorageConfiguration::default().add_slot_overrides_from_file(REENTRANCY_ATTACKER_STORAGE);
     let id = Contract::load_from(
@@ -39,7 +38,8 @@ pub async fn get_attacker_instance(
     .unwrap()
     .deploy(&wallet, TxPolicies::default())
     .await
-    .unwrap();
+    .unwrap()
+    .contract_id;
 
     let instance = AttackerContract::new(id.clone(), wallet);
 
@@ -47,9 +47,9 @@ pub async fn get_attacker_instance(
 }
 
 pub async fn get_target_instance(
-    wallet: WalletUnlocked,
+    wallet: Wallet,
     attack_contract_id: ContractId,
-) -> (TargetContract<WalletUnlocked>, ContractId) {
+) -> (TargetContract<Wallet>, ContractId) {
     let storage_configuration =
         StorageConfiguration::default().add_slot_overrides_from_file(REENTRANCY_TARGET_STORAGE);
     let id = Contract::load_from(
@@ -59,7 +59,8 @@ pub async fn get_target_instance(
     .unwrap()
     .deploy(&wallet, TxPolicies::default())
     .await
-    .unwrap();
+    .unwrap()
+    .contract_id;
 
     let instance = TargetContract::new(id.clone(), wallet);
 
@@ -74,9 +75,9 @@ pub async fn get_target_instance(
 }
 
 pub async fn get_proxy_instance(
-    wallet: WalletUnlocked,
+    wallet: Wallet,
     target_contract: ContractId,
-) -> (ProxyContract<WalletUnlocked>, ContractId) {
+) -> (ProxyContract<Wallet>, ContractId) {
     let configurables = ProxyContractConfigurables::default()
         .with_INITIAL_TARGET(Some(target_contract))
         .unwrap()
@@ -95,7 +96,8 @@ pub async fn get_proxy_instance(
     .unwrap()
     .deploy(&wallet, TxPolicies::default())
     .await
-    .unwrap();
+    .unwrap()
+    .contract_id;
 
     let instance = ProxyContract::new(id.clone(), wallet);
 
@@ -104,14 +106,13 @@ pub async fn get_proxy_instance(
     (instance, id.into())
 }
 
-pub async fn get_attack_helper_id(
-    wallet: WalletUnlocked,
-) -> (AttackHelperContract<WalletUnlocked>, ContractId) {
+pub async fn get_attack_helper_id(wallet: Wallet) -> (AttackHelperContract<Wallet>, ContractId) {
     let id = Contract::load_from(REENTRANCY_ATTACK_HELPER_BIN, LoadConfiguration::default())
         .unwrap()
         .deploy(&wallet, TxPolicies::default())
         .await
-        .unwrap();
+        .unwrap()
+        .contract_id;
 
     let instance = AttackHelperContract::new(id.clone(), wallet);
 

--- a/tests/src/upgradability/tests/functions/only_proxy_owner.rs
+++ b/tests/src/upgradability/tests/functions/only_proxy_owner.rs
@@ -3,6 +3,7 @@ use crate::upgradability::tests::utils::{
     test_helpers::setup,
     State,
 };
+use fuels::accounts::ViewOnlyAccount;
 
 mod success {
 

--- a/tests/src/upgradability/tests/functions/proxy_owner.rs
+++ b/tests/src/upgradability/tests/functions/proxy_owner.rs
@@ -5,6 +5,7 @@ mod success {
         test_helpers::setup,
         State,
     };
+    use fuels::accounts::ViewOnlyAccount;
 
     #[tokio::test]
     async fn returns_initialized_owner() {

--- a/tests/src/upgradability/tests/functions/set_proxy_owner.rs
+++ b/tests/src/upgradability/tests/functions/set_proxy_owner.rs
@@ -3,6 +3,7 @@ use crate::upgradability::tests::utils::{
     test_helpers::setup,
     State,
 };
+use fuels::accounts::ViewOnlyAccount;
 
 mod success {
 

--- a/tests/src/upgradability/tests/utils/mod.rs
+++ b/tests/src/upgradability/tests/utils/mod.rs
@@ -1,7 +1,8 @@
 use fuels::{
+    accounts::ViewOnlyAccount,
     prelude::{
         abigen, launch_custom_provider_and_get_wallets, Contract, ContractId, LoadConfiguration,
-        StorageConfiguration, TxPolicies, WalletUnlocked, WalletsConfig,
+        StorageConfiguration, TxPolicies, Wallet, WalletsConfig,
     },
     programs::responses::CallResponse,
 };
@@ -13,8 +14,8 @@ abigen!(Contract(
 ));
 
 pub struct Metadata {
-    pub contract: UpgradabilityLib<WalletUnlocked>,
-    pub wallet: WalletUnlocked,
+    pub contract: UpgradabilityLib<Wallet>,
+    pub wallet: Wallet,
 }
 
 pub mod abi_calls {
@@ -22,7 +23,7 @@ pub mod abi_calls {
     use super::*;
 
     pub async fn set_proxy_target(
-        contract: &UpgradabilityLib<WalletUnlocked>,
+        contract: &UpgradabilityLib<Wallet>,
         new_target: ContractId,
     ) -> CallResponse<()> {
         contract
@@ -34,21 +35,21 @@ pub mod abi_calls {
     }
 
     pub async fn proxy_target(
-        contract: &UpgradabilityLib<WalletUnlocked>,
+        contract: &UpgradabilityLib<Wallet>,
     ) -> CallResponse<Option<ContractId>> {
         contract.methods().proxy_target().call().await.unwrap()
     }
 
-    pub async fn proxy_owner(contract: &UpgradabilityLib<WalletUnlocked>) -> CallResponse<State> {
+    pub async fn proxy_owner(contract: &UpgradabilityLib<Wallet>) -> CallResponse<State> {
         contract.methods().proxy_owner().call().await.unwrap()
     }
 
-    pub async fn only_proxy_owner(contract: &UpgradabilityLib<WalletUnlocked>) -> CallResponse<()> {
+    pub async fn only_proxy_owner(contract: &UpgradabilityLib<Wallet>) -> CallResponse<()> {
         contract.methods().only_proxy_owner().call().await.unwrap()
     }
 
     pub async fn set_proxy_owner(
-        contract: &UpgradabilityLib<WalletUnlocked>,
+        contract: &UpgradabilityLib<Wallet>,
         new_proxy_owner: State,
     ) -> CallResponse<()> {
         contract
@@ -59,7 +60,7 @@ pub mod abi_calls {
             .unwrap()
     }
 
-    pub async fn initialize_proxy(contract: &UpgradabilityLib<WalletUnlocked>) -> CallResponse<()> {
+    pub async fn initialize_proxy(contract: &UpgradabilityLib<Wallet>) -> CallResponse<()> {
         contract.methods().initialize_proxy().call().await.unwrap()
     }
 }
@@ -112,7 +113,8 @@ pub mod test_helpers {
         .unwrap()
         .deploy(&wallet1, TxPolicies::default())
         .await
-        .unwrap();
+        .unwrap()
+        .contract_id;
 
         let deploy_wallet = Metadata {
             contract: UpgradabilityLib::new(id.clone(), wallet1.clone()),


### PR DESCRIPTION
## Changes

- Bump `forc` to 0.72.0, Rust to 1.93.0, `fuels` to 0.77.0, and `fuel-core` to 0.48.2.
- Bump `asset` to 0.27.0. The `impl Metadata` is removed (moved to `sway-standards`) which makes it a breaking change. Having `impl Metadata` in the `sway-libs` violates coherence rules.
- Removes unnecessary installation of Rust toolchain from CI.
- Adds `justfile` and build scripts for convenient local building of artifacts.  

## Checklist

- [ ] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
- [ ] I have updated the changelog to reflect the changes on this PR.